### PR TITLE
feat: add user lookup by id

### DIFF
--- a/backend/src/controllers/usuarioController.ts
+++ b/backend/src/controllers/usuarioController.ts
@@ -12,6 +12,23 @@ export const listUsuarios = async (_req: Request, res: Response) => {
   }
 };
 
+export const getUsuarioById = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  try {
+    const result = await pool.query(
+      'SELECT id, nome_completo, cpf, email, perfil, empresa, escritorio, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao  FROM public."vw.usuarios" WHERE id = $1',
+      [id]
+    );
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: 'Usuário não encontrado' });
+    }
+    res.json(result.rows[0]);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
 export const createUsuario = async (req: Request, res: Response) => {
   const {
     nome_completo,

--- a/backend/src/routes/usuarioRoutes.ts
+++ b/backend/src/routes/usuarioRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import {
   listUsuarios,
+  getUsuarioById,
   createUsuario,
   updateUsuario,
   deleteUsuario,
@@ -67,6 +68,30 @@ const router = Router();
  *                 $ref: '#/components/schemas/Usuario'
  */
 router.get('/usuarios', listUsuarios);
+
+/**
+ * @swagger
+ * /api/usuarios/{id}:
+ *   get:
+ *     summary: Obtém um usuário pelo ID
+ *     tags: [Usuarios]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *     responses:
+ *       200:
+ *         description: Dados do usuário
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Usuario'
+ *       404:
+ *         description: Usuário não encontrado
+ */
+router.get('/usuarios/:id', getUsuarioById);
 
 /**
  * @swagger


### PR DESCRIPTION
## Summary
- add controller to fetch user details by id
- expose GET /api/usuarios/{id} with swagger docs

## Testing
- `node node_modules/tsx/dist/cli.cjs --test tests/templateService.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5cfa7e0248326b9eeae07357d8321