### PR TITLE
fix: enable card movement in pipeline

### DIFF
--- a/frontend/src/pages/Pipeline.tsx
+++ b/frontend/src/pages/Pipeline.tsx
@@ -379,6 +379,7 @@ export default function Pipeline() {
                     draggable
                     onDragStart={(e) => handleDragStart(e, opportunity.id)}
                     onDragEnd={handleDragEnd}
+                    onDragOver={handleDragOver}
                     onClick={() => {
                       if (isDragging.current) return;
                       navigate(`/pipeline/oportunidade/${opportunity.id}`);

--- a/src/pages/Pipeline.tsx
+++ b/src/pages/Pipeline.tsx
@@ -334,6 +334,7 @@ export default function Pipeline() {
                     draggable
                     onDragStart={(e) => handleDragStart(e, opportunity.id)}
                     onDragEnd={handleDragEnd}
+                    onDragOver={handleDragOver}
                     onClick={() => {
                       if (isDragging.current) return;
                       navigate(`/pipeline/oportunidade/${opportunity.id}`);


### PR DESCRIPTION
## Summary
- allow dropping cards onto other cards in pipeline boards

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5d4a5dc708326984076b3c0bb172c