### PR TITLE
Handle Google token refresh via CORS-friendly endpoint

### DIFF
--- a/frontend/src/lib/googleAuth.ts
+++ b/frontend/src/lib/googleAuth.ts
@@ -1,0 +1,24 @@
+export async function refreshGoogleToken(refreshToken: string) {
+  if (!refreshToken) return null;
+
+  const params = new URLSearchParams({
+    client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID || '',
+    client_secret: import.meta.env.VITE_GOOGLE_CLIENT_SECRET || '',
+    refresh_token: refreshToken,
+    grant_type: 'refresh_token',
+  });
+
+  const res = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params.toString(),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to refresh token: ${res.status}`);
+  }
+
+  return res.json();
+}

--- a/frontend/src/pages/Pipeline.tsx
+++ b/frontend/src/pages/Pipeline.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { refreshGoogleToken } from "@/lib/googleAuth";
 
 interface Opportunity {
   id: number;
@@ -261,6 +262,15 @@ export default function Pipeline() {
     const id = Number(event.dataTransfer.getData("text/plain"));
 
     try {
+      const storedRefresh = localStorage.getItem('google_refresh_token');
+      if (storedRefresh) {
+        try {
+          await refreshGoogleToken(storedRefresh);
+        } catch (err) {
+          console.error('Erro ao renovar token do Google', err);
+        }
+      }
+
       const res = await fetch(`${apiUrl}/api/oportunidades/${id}/etapa`, {
         method: "PATCH",
         headers: {


### PR DESCRIPTION
## Summary
- refresh Google OAuth tokens using `https://oauth2.googleapis.com/token`
- call token refresh before updating opportunity stage

## Testing
- `cd frontend && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c5d79b30e88326bf7f3be0399b5326