### PR TITLE
feat: add pipeline menu selection page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -72,8 +72,8 @@ const App = () => (
               element={<ContratoPreview />}
             />
             <Route path="/clientes/:id" element={<VisualizarCliente />} />
-            <Route path="/pipeline" element={<Pipeline />} />
-            <Route path="/pipeline/:fluxoId" element={<PipelineMenu />} />
+            <Route path="/pipeline" element={<PipelineMenu />} />
+            <Route path="/pipeline/:fluxoId" element={<Pipeline />} />
             <Route path="/pipeline/nova-oportunidade" element={<NovaOportunidade />} />
             <Route path="/pipeline/oportunidade/:id" element={<VisualizarOportunidade />} />
             <Route path="/agenda" element={<Agenda />} />

--- a/frontend/src/pages/PipelineMenu.tsx
+++ b/frontend/src/pages/PipelineMenu.tsx
@@ -1,3 +1,81 @@
-import Pipeline from "./Pipeline";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Plus } from "lucide-react";
 
-export default Pipeline;
+interface MenuItem {
+  id: string;
+  name: string;
+}
+
+export default function PipelineMenu() {
+  const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3000";
+  const [menus, setMenus] = useState<MenuItem[]>([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchMenus = async () => {
+      try {
+        const res = await fetch(`${apiUrl}/api/fluxos-trabalho/menus`, {
+          headers: { Accept: "application/json" },
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+        const data = await res.json();
+        type MenuApiItem = { id: number | string; nome?: string };
+        const parsed: MenuApiItem[] = Array.isArray(data)
+          ? data
+          : Array.isArray(data?.rows)
+          ? data.rows
+          : Array.isArray(data?.data?.rows)
+          ? data.data.rows
+          : Array.isArray(data?.data)
+          ? data.data
+          : [];
+        setMenus(parsed.map((i) => ({ id: String(i.id), name: i.nome ?? "" })));
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    fetchMenus();
+  }, [apiUrl]);
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-foreground">Pipelines</h1>
+          <p className="text-muted-foreground">Selecione um pipeline para visualizar</p>
+        </div>
+        <Button
+          className="bg-primary hover:bg-primary-hover"
+          onClick={() => navigate("/configuracoes/parametros/fluxo-de-trabalho")}
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          Novo Pipeline
+        </Button>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {menus.map((menu) => (
+          <Card
+            key={menu.id}
+            className="cursor-pointer hover:shadow-md transition-shadow"
+            onClick={() => navigate(`/pipeline/${menu.id}`)}
+          >
+            <CardHeader>
+              <CardTitle>{menu.name}</CardTitle>
+            </CardHeader>
+          </Card>
+        ))}
+        {menus.length === 0 && (
+          <Card>
+            <CardContent className="p-6 text-center text-muted-foreground">
+              Nenhum pipeline encontrado
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,8 +72,8 @@ const App = () => (
               element={<ContratoPreview />}
             />
             <Route path="/clientes/:id" element={<VisualizarCliente />} />
-            <Route path="/pipeline" element={<Pipeline />} />
-            <Route path="/pipeline/:fluxoId" element={<PipelineMenu />} />
+            <Route path="/pipeline" element={<PipelineMenu />} />
+            <Route path="/pipeline/:fluxoId" element={<Pipeline />} />
             <Route path="/pipeline/nova-oportunidade" element={<NovaOportunidade />} />
             <Route path="/pipeline/oportunidade/:id" element={<VisualizarOportunidade />} />
             <Route path="/agenda" element={<Agenda />} />

--- a/src/pages/PipelineMenu.tsx
+++ b/src/pages/PipelineMenu.tsx
@@ -1,3 +1,81 @@
-import Pipeline from "./Pipeline";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Plus } from "lucide-react";
 
-export default Pipeline;
+interface MenuItem {
+  id: string;
+  name: string;
+}
+
+export default function PipelineMenu() {
+  const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3000";
+  const [menus, setMenus] = useState<MenuItem[]>([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchMenus = async () => {
+      try {
+        const res = await fetch(`${apiUrl}/api/fluxos-trabalho/menus`, {
+          headers: { Accept: "application/json" },
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+        const data = await res.json();
+        type MenuApiItem = { id: number | string; nome?: string };
+        const parsed: MenuApiItem[] = Array.isArray(data)
+          ? data
+          : Array.isArray(data?.rows)
+          ? data.rows
+          : Array.isArray(data?.data?.rows)
+          ? data.data.rows
+          : Array.isArray(data?.data)
+          ? data.data
+          : [];
+        setMenus(parsed.map((i) => ({ id: String(i.id), name: i.nome ?? "" })));
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    fetchMenus();
+  }, [apiUrl]);
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-foreground">Pipelines</h1>
+          <p className="text-muted-foreground">Selecione um pipeline para visualizar</p>
+        </div>
+        <Button
+          className="bg-primary hover:bg-primary-hover"
+          onClick={() => navigate("/configuracoes/parametros/fluxo-de-trabalho")}
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          Novo Pipeline
+        </Button>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {menus.map((menu) => (
+          <Card
+            key={menu.id}
+            className="cursor-pointer hover:shadow-md transition-shadow"
+            onClick={() => navigate(`/pipeline/${menu.id}`)}
+          >
+            <CardHeader>
+              <CardTitle>{menu.name}</CardTitle>
+            </CardHeader>
+          </Card>
+        ))}
+        {menus.length === 0 && (
+          <Card>
+            <CardContent className="p-6 text-center text-muted-foreground">
+              Nenhum pipeline encontrado
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- implement dedicated pipeline menu page listing available pipelines and allowing navigation to each board
- adjust routes so /pipeline shows the new menu and /pipeline/:fluxoId opens the selected pipeline

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5daa9d4e883269432d126245409c1