### PR TITLE
feat: add company creation screen

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ import Empresas from "./pages/configuracoes/Empresas";
 import Planos from "./pages/configuracoes/Planos";
 import Usuarios from "./pages/configuracoes/usuarios/Usuarios";
 import NovoUsuario from "./pages/configuracoes/usuarios/NovoUsuario";
+import NovaEmpresa from "./pages/configuracoes/NovaEmpresa";
 import PerfilUsuario from "./pages/configuracoes/usuarios/PerfilUsuario";
 import EditarPerfil from "./pages/configuracoes/usuarios/EditarPerfil";
 import AlterarSenha from "./pages/configuracoes/usuarios/AlterarSenha";
@@ -102,6 +103,7 @@ const App = () => (
             />
             <Route path="/configuracoes/usuarios" element={<Usuarios />} />
             <Route path="/configuracoes/empresas" element={<Empresas />} />
+            <Route path="/configuracoes/empresas/nova" element={<NovaEmpresa />} />
             <Route path="/configuracoes/planos" element={<Planos />} />
             <Route path="/configuracoes/usuarios/novo" element={<NovoUsuario />} />
             <Route path="/configuracoes/usuarios/:id" element={<PerfilUsuario />} />

--- a/frontend/src/pages/configuracoes/Empresas.tsx
+++ b/frontend/src/pages/configuracoes/Empresas.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { Plus, Pencil, Trash2, Check, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Link } from "react-router-dom";
 import {
   Table,
   TableBody,
@@ -49,13 +50,6 @@ const mapApiEmpresaToEmpresa = (e: ApiEmpresa): Empresa => ({
 
 export default function Empresas() {
   const [empresas, setEmpresas] = useState<Empresa[]>([]);
-  const [newEmpresa, setNewEmpresa] = useState({
-    nome: "",
-    cnpj: "",
-    responsavel: "",
-    telefone: "",
-    plano: "",
-  });
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editingEmpresa, setEditingEmpresa] = useState({
     nome: "",
@@ -92,19 +86,6 @@ export default function Empresas() {
     fetchEmpresas();
   }, []);
 
-  const addEmpresa = () => {
-    if (
-      !newEmpresa.nome.trim() ||
-      !newEmpresa.cnpj.trim() ||
-      !newEmpresa.responsavel.trim() ||
-      !newEmpresa.telefone.trim() ||
-      !newEmpresa.plano.trim()
-    )
-      return;
-    setEmpresas([...empresas, { id: Date.now(), ...newEmpresa }]);
-    setNewEmpresa({ nome: "", cnpj: "", responsavel: "", telefone: "", plano: "" });
-  };
-
   const startEdit = (empresa: Empresa) => {
     setEditingId(empresa.id);
     setEditingEmpresa({
@@ -134,45 +115,15 @@ export default function Empresas() {
 
   return (
     <div className="p-6 space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold text-foreground">Empresas</h1>
-        <p className="text-muted-foreground">Gerencie as empresas do sistema</p>
-      </div>
-
-      <div className="flex flex-col sm:flex-row gap-2">
-        <Input
-          placeholder="Nome da empresa"
-          value={newEmpresa.nome}
-          onChange={(e) => setNewEmpresa({ ...newEmpresa, nome: e.target.value })}
-          className="max-w-sm"
-        />
-        <Input
-          placeholder="CNPJ"
-          value={newEmpresa.cnpj}
-          onChange={(e) => setNewEmpresa({ ...newEmpresa, cnpj: e.target.value })}
-          className="max-w-sm"
-        />
-        <Input
-          placeholder="Responsável"
-          value={newEmpresa.responsavel}
-          onChange={(e) => setNewEmpresa({ ...newEmpresa, responsavel: e.target.value })}
-          className="max-w-sm"
-        />
-        <Input
-          placeholder="Telefone"
-          value={newEmpresa.telefone}
-          onChange={(e) => setNewEmpresa({ ...newEmpresa, telefone: e.target.value })}
-          className="max-w-sm"
-        />
-        <Input
-          placeholder="Plano"
-          value={newEmpresa.plano}
-          onChange={(e) => setNewEmpresa({ ...newEmpresa, plano: e.target.value })}
-          className="max-w-sm"
-        />
-        <Button onClick={addEmpresa}>
-          <Plus className="mr-2 h-4 w-4" />
-          Adicionar
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-foreground">Empresas</h1>
+          <p className="text-muted-foreground">Gerencie as empresas do sistema</p>
+        </div>
+        <Button asChild>
+          <Link to="/configuracoes/empresas/nova">
+            <Plus className="mr-2 h-4 w-4" /> Nova Empresa
+          </Link>
         </Button>
       </div>
 

--- a/frontend/src/pages/configuracoes/NovaEmpresa.tsx
+++ b/frontend/src/pages/configuracoes/NovaEmpresa.tsx
@@ -1,0 +1,187 @@
+import { useNavigate } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { toast } from "@/components/ui/use-toast";
+
+const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3000";
+
+function joinUrl(base: string, path = "") {
+  const b = base.replace(/\/+$/, "");
+  const p = path ? (path.startsWith("/") ? path : `/${path}`) : "";
+  return `${b}${p}`;
+}
+
+const formSchema = z.object({
+  name: z.string().min(1, "Nome é obrigatório"),
+  cnpj: z.string().min(1, "CNPJ é obrigatório"),
+  phone: z.string().min(1, "Telefone é obrigatório"),
+  email: z.string().email("Email inválido"),
+  plan: z.string().min(1, "Plano é obrigatório"),
+  manager: z.string().min(1, "Responsável é obrigatório"),
+});
+
+export default function NovaEmpresa() {
+  const navigate = useNavigate();
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: "",
+      cnpj: "",
+      phone: "",
+      email: "",
+      plan: "",
+      manager: "",
+    },
+  });
+
+  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+    try {
+      const url = joinUrl(apiUrl, "/api/empresas");
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          nome_empresa: values.name,
+          cnpj: values.cnpj,
+          telefone: values.phone,
+          email: values.email,
+          plano: values.plan,
+          responsavel: values.manager,
+          ativo: true,
+        }),
+      });
+      if (!response.ok) {
+        throw new Error("Failed to create company");
+      }
+      toast({ title: "Empresa cadastrada com sucesso" });
+      navigate("/configuracoes/empresas");
+    } catch (error) {
+      console.error("Erro ao criar empresa:", error);
+      toast({ title: "Erro ao criar empresa", variant: "destructive" });
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-foreground">Nova Empresa</h1>
+          <p className="text-muted-foreground">Cadastre uma nova empresa</p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Informações</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nome</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Nome da empresa" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="cnpj"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>CNPJ</FormLabel>
+                    <FormControl>
+                      <Input placeholder="CNPJ" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="phone"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Telefone</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Telefone" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input type="email" placeholder="email@exemplo.com" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="plan"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Plano</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Plano" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="manager"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Responsável</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Responsável" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="flex justify-end">
+                <Button type="submit">Salvar</Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import Empresas from "./pages/configuracoes/Empresas";
 import Planos from "./pages/configuracoes/Planos";
 import Usuarios from "./pages/configuracoes/usuarios/Usuarios";
 import NovoUsuario from "./pages/configuracoes/usuarios/NovoUsuario";
+import NovaEmpresa from "./pages/configuracoes/NovaEmpresa";
 import PerfilUsuario from "./pages/configuracoes/usuarios/PerfilUsuario";
 import EditarPerfil from "./pages/configuracoes/usuarios/EditarPerfil";
 import AlterarSenha from "./pages/configuracoes/usuarios/AlterarSenha";
@@ -102,6 +103,7 @@ const App = () => (
             />
             <Route path="/configuracoes/usuarios" element={<Usuarios />} />
             <Route path="/configuracoes/empresas" element={<Empresas />} />
+            <Route path="/configuracoes/empresas/nova" element={<NovaEmpresa />} />
             <Route path="/configuracoes/planos" element={<Planos />} />
             <Route path="/configuracoes/usuarios/novo" element={<NovoUsuario />} />
             <Route path="/configuracoes/usuarios/:id" element={<PerfilUsuario />} />

--- a/src/pages/configuracoes/Empresas.tsx
+++ b/src/pages/configuracoes/Empresas.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { Plus, Pencil, Trash2, Check, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Link } from "react-router-dom";
 import {
   Table,
   TableBody,
@@ -49,13 +50,6 @@ const mapApiEmpresaToEmpresa = (e: ApiEmpresa): Empresa => ({
 
 export default function Empresas() {
   const [empresas, setEmpresas] = useState<Empresa[]>([]);
-  const [newEmpresa, setNewEmpresa] = useState({
-    nome: "",
-    cnpj: "",
-    responsavel: "",
-    telefone: "",
-    plano: "",
-  });
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editingEmpresa, setEditingEmpresa] = useState({
     nome: "",
@@ -92,19 +86,6 @@ export default function Empresas() {
     fetchEmpresas();
   }, []);
 
-  const addEmpresa = () => {
-    if (
-      !newEmpresa.nome.trim() ||
-      !newEmpresa.cnpj.trim() ||
-      !newEmpresa.responsavel.trim() ||
-      !newEmpresa.telefone.trim() ||
-      !newEmpresa.plano.trim()
-    )
-      return;
-    setEmpresas([...empresas, { id: Date.now(), ...newEmpresa }]);
-    setNewEmpresa({ nome: "", cnpj: "", responsavel: "", telefone: "", plano: "" });
-  };
-
   const startEdit = (empresa: Empresa) => {
     setEditingId(empresa.id);
     setEditingEmpresa({
@@ -134,45 +115,15 @@ export default function Empresas() {
 
   return (
     <div className="p-6 space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold text-foreground">Empresas</h1>
-        <p className="text-muted-foreground">Gerencie as empresas do sistema</p>
-      </div>
-
-      <div className="flex flex-col sm:flex-row gap-2">
-        <Input
-          placeholder="Nome da empresa"
-          value={newEmpresa.nome}
-          onChange={(e) => setNewEmpresa({ ...newEmpresa, nome: e.target.value })}
-          className="max-w-sm"
-        />
-        <Input
-          placeholder="CNPJ"
-          value={newEmpresa.cnpj}
-          onChange={(e) => setNewEmpresa({ ...newEmpresa, cnpj: e.target.value })}
-          className="max-w-sm"
-        />
-        <Input
-          placeholder="Responsável"
-          value={newEmpresa.responsavel}
-          onChange={(e) => setNewEmpresa({ ...newEmpresa, responsavel: e.target.value })}
-          className="max-w-sm"
-        />
-        <Input
-          placeholder="Telefone"
-          value={newEmpresa.telefone}
-          onChange={(e) => setNewEmpresa({ ...newEmpresa, telefone: e.target.value })}
-          className="max-w-sm"
-        />
-        <Input
-          placeholder="Plano"
-          value={newEmpresa.plano}
-          onChange={(e) => setNewEmpresa({ ...newEmpresa, plano: e.target.value })}
-          className="max-w-sm"
-        />
-        <Button onClick={addEmpresa}>
-          <Plus className="mr-2 h-4 w-4" />
-          Adicionar
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-foreground">Empresas</h1>
+          <p className="text-muted-foreground">Gerencie as empresas do sistema</p>
+        </div>
+        <Button asChild>
+          <Link to="/configuracoes/empresas/nova">
+            <Plus className="mr-2 h-4 w-4" /> Nova Empresa
+          </Link>
         </Button>
       </div>
 

--- a/src/pages/configuracoes/NovaEmpresa.tsx
+++ b/src/pages/configuracoes/NovaEmpresa.tsx
@@ -1,0 +1,187 @@
+import { useNavigate } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { toast } from "@/components/ui/use-toast";
+
+const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3000";
+
+function joinUrl(base: string, path = "") {
+  const b = base.replace(/\/+$/, "");
+  const p = path ? (path.startsWith("/") ? path : `/${path}`) : "";
+  return `${b}${p}`;
+}
+
+const formSchema = z.object({
+  name: z.string().min(1, "Nome é obrigatório"),
+  cnpj: z.string().min(1, "CNPJ é obrigatório"),
+  phone: z.string().min(1, "Telefone é obrigatório"),
+  email: z.string().email("Email inválido"),
+  plan: z.string().min(1, "Plano é obrigatório"),
+  manager: z.string().min(1, "Responsável é obrigatório"),
+});
+
+export default function NovaEmpresa() {
+  const navigate = useNavigate();
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: "",
+      cnpj: "",
+      phone: "",
+      email: "",
+      plan: "",
+      manager: "",
+    },
+  });
+
+  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+    try {
+      const url = joinUrl(apiUrl, "/api/empresas");
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          nome_empresa: values.name,
+          cnpj: values.cnpj,
+          telefone: values.phone,
+          email: values.email,
+          plano: values.plan,
+          responsavel: values.manager,
+          ativo: true,
+        }),
+      });
+      if (!response.ok) {
+        throw new Error("Failed to create company");
+      }
+      toast({ title: "Empresa cadastrada com sucesso" });
+      navigate("/configuracoes/empresas");
+    } catch (error) {
+      console.error("Erro ao criar empresa:", error);
+      toast({ title: "Erro ao criar empresa", variant: "destructive" });
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-foreground">Nova Empresa</h1>
+          <p className="text-muted-foreground">Cadastre uma nova empresa</p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Informações</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nome</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Nome da empresa" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="cnpj"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>CNPJ</FormLabel>
+                    <FormControl>
+                      <Input placeholder="CNPJ" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="phone"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Telefone</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Telefone" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input type="email" placeholder="email@exemplo.com" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="plan"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Plano</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Plano" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="manager"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Responsável</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Responsável" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="flex justify-end">
+                <Button type="submit">Salvar</Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add dedicated company registration form
- link company list to new registration view and route

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5db0170fc83268a6b2b3a158863a7