### PR TITLE
Show envolvidos on opportunity detail

### DIFF
--- a/frontend/src/pages/VisualizarOportunidade.tsx
+++ b/frontend/src/pages/VisualizarOportunidade.tsx
@@ -173,11 +173,6 @@ export default function VisualizarOportunidade() {
       fields: ["solicitante_nome", "solicitante_cpf_cnpj", "solicitante_email", "solicitante_telefone", "cliente_tipo"],
     },
     {
-      key: "envolvidos",
-      label: "Dados dos Envolvidos",
-      fields: ["autor", "reu", "terceiro_interessado", "responsible", "area"],
-    },
-    {
       key: "detalhes",
       label: "Detalhes",
       fields: ["detalhes"],
@@ -394,6 +389,41 @@ export default function VisualizarOportunidade() {
                   </section>
                 );
               })}
+
+              {Array.isArray(opportunity.envolvidos) && opportunity.envolvidos.length > 0 && (
+                <section
+                  key="envolvidos"
+                  aria-labelledby="heading-envolvidos"
+                  className="p-4"
+                >
+                  <h2 id="heading-envolvidos" className="text-lg font-semibold mb-3">
+                    Envolvidos
+                  </h2>
+                  <div className="space-y-4">
+                    {opportunity.envolvidos.map((env, idx) => (
+                      <div key={idx} className="border rounded p-4">
+                        {env.relacao && (
+                          <p className="font-medium mb-2">
+                            {String(env.relacao)}
+                          </p>
+                        )}
+                        <ul className="text-sm space-y-1">
+                          {env.nome && <li>Nome: {String(env.nome)}</li>}
+                          {env.cpf_cnpj && (
+                            <li>CPF/CNPJ: {String(env.cpf_cnpj)}</li>
+                          )}
+                          {env.telefone && (
+                            <li>Telefone: {String(env.telefone)}</li>
+                          )}
+                          {env.endereco && (
+                            <li>Endereço: {String(env.endereco)}</li>
+                          )}
+                        </ul>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
 
               {/* Metadados extras: campos que não estão nas seções acima */}
               <section aria-labelledby="heading-extras" className="p-4">

--- a/src/pages/VisualizarOportunidade.tsx
+++ b/src/pages/VisualizarOportunidade.tsx
@@ -121,19 +121,56 @@ export default function VisualizarOportunidade() {
           <ScrollArea className="max-h-[70vh]">
             <Table>
               <TableBody>
-                {Object.entries(opportunity).map(([key, value]) => (
-                  <TableRow key={key}>
-                    <TableCell className="font-medium w-[40%]">
-                      {formatLabel(key)}
-                    </TableCell>
-                    <TableCell>{renderValue(value)}</TableCell>
-                  </TableRow>
-                ))}
+                {Object.entries(opportunity)
+                  .filter(([key]) => key !== "envolvidos")
+                  .map(([key, value]) => (
+                    <TableRow key={key}>
+                      <TableCell className="font-medium w-[40%]">
+                        {formatLabel(key)}
+                      </TableCell>
+                      <TableCell>{renderValue(value)}</TableCell>
+                    </TableRow>
+                  ))}
               </TableBody>
             </Table>
           </ScrollArea>
         </CardContent>
       </Card>
+
+      {Array.isArray(opportunity.envolvidos) && opportunity.envolvidos.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Envolvidos</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableBody>
+                {opportunity.envolvidos.map((env, idx) => (
+                  <TableRow key={idx}>
+                    <TableCell className="font-medium w-[40%]">
+                      {formatLabel(env.relacao as string)}
+                    </TableCell>
+                    <TableCell>
+                      <div className="space-y-1 text-sm">
+                        {env.nome && <div>Nome: {env.nome as string}</div>}
+                        {env.cpf_cnpj && (
+                          <div>CPF/CNPJ: {env.cpf_cnpj as string}</div>
+                        )}
+                        {env.telefone && (
+                          <div>Telefone: {env.telefone as string}</div>
+                        )}
+                        {env.endereco && (
+                          <div>Endereço: {env.endereco as string}</div>
+                        )}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- include relacionado individuals when fetching an opportunity by id
- render involved parties on opportunity detail pages in the pipeline

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c5e0733840832694fdb0884f4060f4