### PR TITLE
Expand opportunity details view height

### DIFF
--- a/frontend/src/pages/VisualizarOportunidade.tsx
+++ b/frontend/src/pages/VisualizarOportunidade.tsx
@@ -518,7 +518,7 @@ export default function VisualizarOportunidade() {
         </CardHeader>
 
         <CardContent>
-          <ScrollArea className="max-h-[70vh]">
+          <ScrollArea className="max-h-[90vh]">
             <div className="space-y-6">
               {/* percorre as seções definidas e exibe apenas campos que existam */}
               {sectionsDef.map((section) => {

--- a/src/pages/VisualizarOportunidade.tsx
+++ b/src/pages/VisualizarOportunidade.tsx
@@ -238,7 +238,7 @@ export default function VisualizarOportunidade() {
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <ScrollArea className="max-h-[70vh]">
+          <ScrollArea className="max-h-[90vh]">
             <Table>
               <TableBody>
                 {Object.entries(opportunity)


### PR DESCRIPTION
## Summary
- increase VisualizarOportunidade scroll area to 90vh so details aren't cut off

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5f11004508326af10084e68e3bc0b