### PR TITLE
fix: show CPF when editing opportunity

### DIFF
--- a/frontend/src/pages/EditarOportunidade.tsx
+++ b/frontend/src/pages/EditarOportunidade.tsx
@@ -258,7 +258,7 @@ export default function EditarOportunidade() {
             data.envolvidos && data.envolvidos.length > 0
               ? data.envolvidos.map((env: any) => ({
                   nome: env.nome || "",
-                  cpf_cnpj: env.documento || "",
+                  cpf_cnpj: env.cpf_cnpj || env.documento || "",
                   telefone: env.telefone || "",
                   endereco: env.endereco || "",
                   relacao: env.relacao || "",


### PR DESCRIPTION
## Summary
- ensure CPF/CNPJ of envolvidos is populated when editing an opportunity

## Testing
- `npm test` (frontend, fails: Missing script: "test")
- `npm run lint`
- `node node_modules/tsx/dist/cli.cjs --test tests/templateService.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5f1a43ca4832695bcc1f7c467f5b9