### PR TITLE
feat: calcular honorários e adicionar parcelamento

### DIFF
--- a/backend/src/controllers/oportunidadeController.ts
+++ b/backend/src/controllers/oportunidadeController.ts
@@ -6,7 +6,7 @@ export const listOportunidades = async (_req: Request, res: Response) => {
     const result = await pool.query(
       `SELECT id, tipo_processo_id, area_atuacao_id, responsavel_id, numero_processo_cnj, numero_protocolo,
               vara_ou_orgao, comarca, fase_id, etapa_id, prazo_proximo, status_id, solicitante_id,
-              valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, contingenciamento,
+              valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, parcelas, contingenciamento,
               detalhes, documentos_anexados, criado_por, data_criacao, ultima_atualizacao
        FROM public.oportunidades`
     );
@@ -23,7 +23,7 @@ export const listOportunidadesByFase = async (req: Request, res: Response) => {
     const result = await pool.query(
       `SELECT id, tipo_processo_id, area_atuacao_id, responsavel_id, numero_processo_cnj, numero_protocolo,
               vara_ou_orgao, comarca, fase_id, etapa_id, prazo_proximo, status_id, solicitante_id,
-              valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, contingenciamento,
+              valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, parcelas, contingenciamento,
               detalhes, documentos_anexados, criado_por, data_criacao, ultima_atualizacao
        FROM public.oportunidades WHERE fase_id = $1`,
       [faseId]
@@ -41,7 +41,7 @@ export const getOportunidadeById = async (req: Request, res: Response) => {
     const oportunidadeResult = await pool.query(
       `SELECT id, tipo_processo_id, area_atuacao_id, responsavel_id, numero_processo_cnj, numero_protocolo,
               vara_ou_orgao, comarca, fase_id, etapa_id, prazo_proximo, status_id, solicitante_id,
-              valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, contingenciamento,
+              valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, parcelas, contingenciamento,
               detalhes, documentos_anexados, criado_por, data_criacao, ultima_atualizacao
        FROM public.oportunidades WHERE id = $1`,
       [id]
@@ -107,6 +107,7 @@ export const createOportunidade = async (req: Request, res: Response) => {
     valor_honorarios,
     percentual_honorarios,
     forma_pagamento,
+    parcelas,
     contingenciamento,
     detalhes,
     documentos_anexados,
@@ -119,12 +120,12 @@ export const createOportunidade = async (req: Request, res: Response) => {
       `INSERT INTO public.oportunidades
        (tipo_processo_id, area_atuacao_id, responsavel_id, numero_processo_cnj, numero_protocolo,
         vara_ou_orgao, comarca, fase_id, etapa_id, prazo_proximo, status_id, solicitante_id,
-        valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, contingenciamento,
+        valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, parcelas, contingenciamento,
         detalhes, documentos_anexados, criado_por, data_criacao, ultima_atualizacao)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,NOW(),NOW())
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,NOW(),NOW())
        RETURNING id, tipo_processo_id, area_atuacao_id, responsavel_id, numero_processo_cnj, numero_protocolo,
                  vara_ou_orgao, comarca, fase_id, etapa_id, prazo_proximo, status_id, solicitante_id,
-                 valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, contingenciamento,
+                 valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, parcelas, contingenciamento,
                  detalhes, documentos_anexados, criado_por, data_criacao, ultima_atualizacao`,
       [
         tipo_processo_id,
@@ -143,6 +144,7 @@ export const createOportunidade = async (req: Request, res: Response) => {
         valor_honorarios,
         percentual_honorarios,
         forma_pagamento,
+        parcelas,
         contingenciamento,
         detalhes,
         documentos_anexados,
@@ -194,6 +196,7 @@ export const updateOportunidade = async (req: Request, res: Response) => {
     valor_honorarios,
     percentual_honorarios,
     forma_pagamento,
+    parcelas,
     contingenciamento,
     detalhes,
     documentos_anexados,
@@ -220,15 +223,16 @@ export const updateOportunidade = async (req: Request, res: Response) => {
          valor_honorarios = $14,
          percentual_honorarios = $15,
          forma_pagamento = $16,
-         contingenciamento = $17,
-         detalhes = $18,
-         documentos_anexados = $19,
-         criado_por = $20,
+         parcelas = $17,
+         contingenciamento = $18,
+         detalhes = $19,
+         documentos_anexados = $20,
+         criado_por = $21,
          ultima_atualizacao = NOW()
-       WHERE id = $21
+       WHERE id = $22
        RETURNING id, tipo_processo_id, area_atuacao_id, responsavel_id, numero_processo_cnj, numero_protocolo,
                  vara_ou_orgao, comarca, fase_id, etapa_id, prazo_proximo, status_id, solicitante_id,
-                 valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, contingenciamento,
+                 valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, parcelas, contingenciamento,
                  detalhes, documentos_anexados, criado_por, data_criacao, ultima_atualizacao`,
       [
         tipo_processo_id,
@@ -247,6 +251,7 @@ export const updateOportunidade = async (req: Request, res: Response) => {
         valor_honorarios,
         percentual_honorarios,
         forma_pagamento,
+        parcelas,
         contingenciamento,
         detalhes,
         documentos_anexados,

--- a/backend/src/models/oportunidade.ts
+++ b/backend/src/models/oportunidade.ts
@@ -18,6 +18,7 @@ export interface Oportunidade {
   valor_honorarios: number | null;
   percentual_honorarios: number | null;
   forma_pagamento: string | null;
+  parcelas: number | null;
   contingenciamento: string | null;
   detalhes: string | null;
   documentos_anexados: number | null;

--- a/backend/src/routes/oportunidadeRoutes.ts
+++ b/backend/src/routes/oportunidadeRoutes.ts
@@ -74,6 +74,8 @@ const router = Router();
  *           type: number
  *         forma_pagamento:
  *           type: string
+ *         parcelas:
+ *           type: integer
  *         contingenciamento:
  *           type: string
  *         detalhes:
@@ -226,12 +228,14 @@ router.get('/oportunidades/:id/envolvidos', listEnvolvidosByOportunidade);
  *                 type: number
  *               valor_honorarios:
  *                 type: number
- *               percentual_honorarios:
- *                 type: number
- *               forma_pagamento:
- *                 type: string
- *               contingenciamento:
- *                 type: string
+*               percentual_honorarios:
+*                 type: number
+*               forma_pagamento:
+*                 type: string
+ *               parcelas:
+ *                 type: integer
+*               contingenciamento:
+*                 type: string
  *               detalhes:
  *                 type: string
  *               documentos_anexados:
@@ -311,12 +315,14 @@ router.post('/oportunidades', createOportunidade);
  *                 type: number
  *               valor_honorarios:
  *                 type: number
- *               percentual_honorarios:
- *                 type: number
- *               forma_pagamento:
- *                 type: string
- *               contingenciamento:
- *                 type: string
+*               percentual_honorarios:
+*                 type: number
+*               forma_pagamento:
+*                 type: string
+ *               parcelas:
+ *                 type: integer
+*               contingenciamento:
+*                 type: string
  *               detalhes:
  *                 type: string
  *               documentos_anexados:

--- a/frontend/src/pages/EditarOportunidade.tsx
+++ b/frontend/src/pages/EditarOportunidade.tsx
@@ -66,6 +66,7 @@ const formSchema = z.object({
   valor_honorarios: z.string().optional(),
   percentual_honorarios: z.string().optional(),
   forma_pagamento: z.string().optional(),
+  parcelas: z.string().optional(),
   contingenciamento: z.string().optional(),
   detalhes: z.string().optional(),
   documentos_anexados: z.any().optional(),
@@ -128,6 +129,7 @@ export default function EditarOportunidade() {
       valor_honorarios: "",
       percentual_honorarios: "",
       forma_pagamento: "",
+      parcelas: "",
       contingenciamento: "",
       detalhes: "",
       documentos_anexados: undefined,
@@ -270,6 +272,7 @@ export default function EditarOportunidade() {
             ? String(data.percentual_honorarios)
             : "",
           forma_pagamento: data.forma_pagamento || "",
+          parcelas: data.parcelas ? String(data.parcelas) : "",
           contingenciamento: data.contingenciamento || "",
           detalhes: data.detalhes || "",
           documentos_anexados: undefined,
@@ -313,6 +316,7 @@ export default function EditarOportunidade() {
   }, [id, apiUrl, form]);
 
   const faseValue = form.watch("fase");
+  const formaPagamento = form.watch("forma_pagamento");
   useEffect(() => {
     if (!faseValue) return;
     const loadEtapas = async () => {
@@ -341,6 +345,17 @@ export default function EditarOportunidade() {
     return digits ? Number(digits) : null;
   };
 
+  const valorCausaWatch = form.watch("valor_causa");
+  const valorHonorariosWatch = form.watch("valor_honorarios");
+  useEffect(() => {
+    const vc = parseCurrency(valorCausaWatch || "");
+    const vh = parseCurrency(valorHonorariosWatch || "");
+    if (vc && vc > 0 && vh !== null) {
+      const percent = Math.round((vh / vc) * 100);
+      form.setValue("percentual_honorarios", `${percent}%`);
+    }
+  }, [valorCausaWatch, valorHonorariosWatch, form]);
+
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     try {
       const payload = {
@@ -362,6 +377,7 @@ export default function EditarOportunidade() {
         valor_honorarios: parseCurrency(values.valor_honorarios || ""),
         percentual_honorarios: parsePercent(values.percentual_honorarios || ""),
         forma_pagamento: values.forma_pagamento || null,
+        parcelas: values.parcelas ? Number(values.parcelas) : null,
         contingenciamento: values.contingenciamento || null,
         detalhes: values.detalhes || null,
         documentos_anexados: null,
@@ -999,6 +1015,33 @@ export default function EditarOportunidade() {
                           </FormItem>
                         )}
                       />
+
+                      {formaPagamento === "Parcelado" && (
+                        <FormField
+                          control={form.control}
+                          name="parcelas"
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Número de Parcelas</FormLabel>
+                              <Select onValueChange={field.onChange} value={field.value}>
+                                <FormControl>
+                                  <SelectTrigger>
+                                    <SelectValue placeholder="Selecione" />
+                                  </SelectTrigger>
+                                </FormControl>
+                                <SelectContent>
+                                  {[...Array(12)].map((_, i) => (
+                                    <SelectItem key={i + 1} value={String(i + 1)}>
+                                      {i + 1}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      )}
 
                       <FormField
                         control={form.control}

--- a/frontend/src/pages/NovaOportunidade.tsx
+++ b/frontend/src/pages/NovaOportunidade.tsx
@@ -66,6 +66,7 @@ const formSchema = z.object({
   valor_honorarios: z.string().optional(),
   percentual_honorarios: z.string().optional(),
   forma_pagamento: z.string().optional(),
+  parcelas: z.string().optional(),
   contingenciamento: z.string().optional(),
   detalhes: z.string().optional(),
   documentos_anexados: z.any().optional(),
@@ -127,6 +128,7 @@ export default function NovaOportunidade() {
       valor_honorarios: "",
       percentual_honorarios: "",
       forma_pagamento: "",
+      parcelas: "",
       contingenciamento: "",
       detalhes: "",
       documentos_anexados: undefined,
@@ -227,6 +229,7 @@ export default function NovaOportunidade() {
   }, [apiUrl]);
 
   const faseValue = form.watch("fase");
+  const formaPagamento = form.watch("forma_pagamento");
   useEffect(() => {
     if (!faseValue) return;
     const loadEtapas = async () => {
@@ -255,6 +258,17 @@ export default function NovaOportunidade() {
     return digits ? Number(digits) : null;
   };
 
+  const valorCausaWatch = form.watch("valor_causa");
+  const valorHonorariosWatch = form.watch("valor_honorarios");
+  useEffect(() => {
+    const vc = parseCurrency(valorCausaWatch || "");
+    const vh = parseCurrency(valorHonorariosWatch || "");
+    if (vc && vc > 0 && vh !== null) {
+      const percent = Math.round((vh / vc) * 100);
+      form.setValue("percentual_honorarios", `${percent}%`);
+    }
+  }, [valorCausaWatch, valorHonorariosWatch, form]);
+
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     try {
       const payload = {
@@ -276,6 +290,7 @@ export default function NovaOportunidade() {
         valor_honorarios: parseCurrency(values.valor_honorarios || ""),
         percentual_honorarios: parsePercent(values.percentual_honorarios || ""),
         forma_pagamento: values.forma_pagamento || null,
+        parcelas: values.parcelas ? Number(values.parcelas) : null,
         contingenciamento: values.contingenciamento || null,
         detalhes: values.detalhes || null,
         documentos_anexados: null,
@@ -907,6 +922,33 @@ export default function NovaOportunidade() {
                           </FormItem>
                         )}
                       />
+
+                      {formaPagamento === "Parcelado" && (
+                        <FormField
+                          control={form.control}
+                          name="parcelas"
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Número de Parcelas</FormLabel>
+                              <Select onValueChange={field.onChange} value={field.value}>
+                                <FormControl>
+                                  <SelectTrigger>
+                                    <SelectValue placeholder="Selecione" />
+                                  </SelectTrigger>
+                                </FormControl>
+                                <SelectContent>
+                                  {[...Array(12)].map((_, i) => (
+                                    <SelectItem key={i + 1} value={String(i + 1)}>
+                                      {i + 1}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      )}
 
                       <FormField
                         control={form.control}

--- a/frontend/src/pages/VisualizarOportunidade.tsx
+++ b/frontend/src/pages/VisualizarOportunidade.tsx
@@ -234,6 +234,7 @@ export default function VisualizarOportunidade() {
     valor_honorarios: "Valor dos Honorários",
     percentual_honorarios: "% Honorários",
     forma_pagamento: "Forma de Pagamento",
+    parcelas: "Número de Parcelas",
     contingenciamento: "Contingenciamento",
     detalhes: "Detalhes",
     documentos_anexados: "Documentos Anexados",
@@ -359,7 +360,7 @@ export default function VisualizarOportunidade() {
     {
       key: "honorarios",
       label: "Honorários",
-      fields: ["valor_causa", "valor_honorarios", "percentual_honorarios", "forma_pagamento", "contingenciamento"],
+      fields: ["valor_causa", "valor_honorarios", "percentual_honorarios", "forma_pagamento", "parcelas", "contingenciamento"],
     },
     {
       key: "metadados",
@@ -429,6 +430,20 @@ export default function VisualizarOportunidade() {
 
     if (/valor|honorarios|valor_causa|valor_honorarios|valor_total/i.test(key)) {
       return <span>{formatCurrency(value)}</span>;
+    }
+
+    if (key === "percentual_honorarios") {
+      let percent = value;
+      if (
+        (percent === null || percent === undefined || percent === "") &&
+        entriesMap.get("valor_causa") &&
+        entriesMap.get("valor_honorarios")
+      ) {
+        const vc = Number(entriesMap.get("valor_causa"));
+        const vh = Number(entriesMap.get("valor_honorarios"));
+        if (vc) percent = (vh / vc) * 100;
+      }
+      return <span>{formatPercent(percent)}</span>;
     }
 
     if (/percentual|%|percent/i.test(key)) {


### PR DESCRIPTION
## Summary
- calcula automaticamente o percentual de honorários a partir do valor da causa
- exibe seleção de parcelas quando o pagamento é parcelado
- registra o número de parcelas no backend

## Testing
- `cd backend && npm test`
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5f627e77c832685b3d8ac97bd8360