### PR TITLE
feat: add qtde parcelas support

### DIFF
--- a/backend/src/controllers/oportunidadeController.ts
+++ b/backend/src/controllers/oportunidadeController.ts
@@ -6,7 +6,7 @@ export const listOportunidades = async (_req: Request, res: Response) => {
     const result = await pool.query(
       `SELECT id, tipo_processo_id, area_atuacao_id, responsavel_id, numero_processo_cnj, numero_protocolo,
               vara_ou_orgao, comarca, fase_id, etapa_id, prazo_proximo, status_id, solicitante_id,
-              valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, parcelas, contingenciamento,
+              valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, qtde_parcelas, contingenciamento,
               detalhes, documentos_anexados, criado_por, data_criacao, ultima_atualizacao
        FROM public.oportunidades`
     );
@@ -23,7 +23,7 @@ export const listOportunidadesByFase = async (req: Request, res: Response) => {
     const result = await pool.query(
       `SELECT id, tipo_processo_id, area_atuacao_id, responsavel_id, numero_processo_cnj, numero_protocolo,
               vara_ou_orgao, comarca, fase_id, etapa_id, prazo_proximo, status_id, solicitante_id,
-              valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, parcelas, contingenciamento,
+              valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, qtde_parcelas, contingenciamento,
               detalhes, documentos_anexados, criado_por, data_criacao, ultima_atualizacao
        FROM public.oportunidades WHERE fase_id = $1`,
       [faseId]
@@ -41,7 +41,7 @@ export const getOportunidadeById = async (req: Request, res: Response) => {
     const oportunidadeResult = await pool.query(
       `SELECT id, tipo_processo_id, area_atuacao_id, responsavel_id, numero_processo_cnj, numero_protocolo,
               vara_ou_orgao, comarca, fase_id, etapa_id, prazo_proximo, status_id, solicitante_id,
-              valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, parcelas, contingenciamento,
+              valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, qtde_parcelas, contingenciamento,
               detalhes, documentos_anexados, criado_por, data_criacao, ultima_atualizacao
        FROM public.oportunidades WHERE id = $1`,
       [id]
@@ -107,7 +107,7 @@ export const createOportunidade = async (req: Request, res: Response) => {
     valor_honorarios,
     percentual_honorarios,
     forma_pagamento,
-    parcelas,
+    qtde_parcelas,
     contingenciamento,
     detalhes,
     documentos_anexados,
@@ -120,12 +120,12 @@ export const createOportunidade = async (req: Request, res: Response) => {
       `INSERT INTO public.oportunidades
        (tipo_processo_id, area_atuacao_id, responsavel_id, numero_processo_cnj, numero_protocolo,
         vara_ou_orgao, comarca, fase_id, etapa_id, prazo_proximo, status_id, solicitante_id,
-        valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, parcelas, contingenciamento,
+        valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, qtde_parcelas, contingenciamento,
         detalhes, documentos_anexados, criado_por, data_criacao, ultima_atualizacao)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,NOW(),NOW())
        RETURNING id, tipo_processo_id, area_atuacao_id, responsavel_id, numero_processo_cnj, numero_protocolo,
                  vara_ou_orgao, comarca, fase_id, etapa_id, prazo_proximo, status_id, solicitante_id,
-                 valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, parcelas, contingenciamento,
+                 valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, qtde_parcelas, contingenciamento,
                  detalhes, documentos_anexados, criado_por, data_criacao, ultima_atualizacao`,
       [
         tipo_processo_id,
@@ -140,12 +140,12 @@ export const createOportunidade = async (req: Request, res: Response) => {
         prazo_proximo,
         status_id,
         solicitante_id,
-        valor_causa,
-        valor_honorarios,
-        percentual_honorarios,
-        forma_pagamento,
-        parcelas,
-        contingenciamento,
+          valor_causa,
+          valor_honorarios,
+          percentual_honorarios,
+          forma_pagamento,
+          qtde_parcelas,
+          contingenciamento,
         detalhes,
         documentos_anexados,
         criado_por,
@@ -196,7 +196,7 @@ export const updateOportunidade = async (req: Request, res: Response) => {
     valor_honorarios,
     percentual_honorarios,
     forma_pagamento,
-    parcelas,
+    qtde_parcelas,
     contingenciamento,
     detalhes,
     documentos_anexados,
@@ -223,7 +223,7 @@ export const updateOportunidade = async (req: Request, res: Response) => {
          valor_honorarios = $14,
          percentual_honorarios = $15,
          forma_pagamento = $16,
-         parcelas = $17,
+         qtde_parcelas = $17,
          contingenciamento = $18,
          detalhes = $19,
          documentos_anexados = $20,
@@ -232,7 +232,7 @@ export const updateOportunidade = async (req: Request, res: Response) => {
        WHERE id = $22
        RETURNING id, tipo_processo_id, area_atuacao_id, responsavel_id, numero_processo_cnj, numero_protocolo,
                  vara_ou_orgao, comarca, fase_id, etapa_id, prazo_proximo, status_id, solicitante_id,
-                 valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, parcelas, contingenciamento,
+                 valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, qtde_parcelas, contingenciamento,
                  detalhes, documentos_anexados, criado_por, data_criacao, ultima_atualizacao`,
       [
         tipo_processo_id,
@@ -251,7 +251,7 @@ export const updateOportunidade = async (req: Request, res: Response) => {
         valor_honorarios,
         percentual_honorarios,
         forma_pagamento,
-        parcelas,
+        qtde_parcelas,
         contingenciamento,
         detalhes,
         documentos_anexados,

--- a/backend/src/models/oportunidade.ts
+++ b/backend/src/models/oportunidade.ts
@@ -18,7 +18,7 @@ export interface Oportunidade {
   valor_honorarios: number | null;
   percentual_honorarios: number | null;
   forma_pagamento: string | null;
-  parcelas: number | null;
+  qtde_parcelas: number | null;
   contingenciamento: string | null;
   detalhes: string | null;
   documentos_anexados: number | null;

--- a/backend/src/routes/oportunidadeRoutes.ts
+++ b/backend/src/routes/oportunidadeRoutes.ts
@@ -74,7 +74,7 @@ const router = Router();
  *           type: number
  *         forma_pagamento:
  *           type: string
- *         parcelas:
+ *         qtde_parcelas:
  *           type: integer
  *         contingenciamento:
  *           type: string
@@ -232,7 +232,7 @@ router.get('/oportunidades/:id/envolvidos', listEnvolvidosByOportunidade);
 *                 type: number
 *               forma_pagamento:
 *                 type: string
- *               parcelas:
+ *               qtde_parcelas:
  *                 type: integer
 *               contingenciamento:
 *                 type: string
@@ -319,7 +319,7 @@ router.post('/oportunidades', createOportunidade);
 *                 type: number
 *               forma_pagamento:
 *                 type: string
- *               parcelas:
+ *               qtde_parcelas:
  *                 type: integer
 *               contingenciamento:
 *                 type: string

--- a/frontend/src/pages/EditarOportunidade.tsx
+++ b/frontend/src/pages/EditarOportunidade.tsx
@@ -66,7 +66,7 @@ const formSchema = z.object({
   valor_honorarios: z.string().optional(),
   percentual_honorarios: z.string().optional(),
   forma_pagamento: z.string().optional(),
-  parcelas: z.string().optional(),
+  qtde_parcelas: z.string().optional(),
   contingenciamento: z.string().optional(),
   detalhes: z.string().optional(),
   documentos_anexados: z.any().optional(),
@@ -129,7 +129,7 @@ export default function EditarOportunidade() {
       valor_honorarios: "",
       percentual_honorarios: "",
       forma_pagamento: "",
-      parcelas: "",
+        qtde_parcelas: "",
       contingenciamento: "",
       detalhes: "",
       documentos_anexados: undefined,
@@ -272,7 +272,7 @@ export default function EditarOportunidade() {
             ? String(data.percentual_honorarios)
             : "",
           forma_pagamento: data.forma_pagamento || "",
-          parcelas: data.parcelas ? String(data.parcelas) : "",
+            qtde_parcelas: data.qtde_parcelas ? String(data.qtde_parcelas) : "",
           contingenciamento: data.contingenciamento || "",
           detalhes: data.detalhes || "",
           documentos_anexados: undefined,
@@ -377,7 +377,7 @@ export default function EditarOportunidade() {
         valor_honorarios: parseCurrency(values.valor_honorarios || ""),
         percentual_honorarios: parsePercent(values.percentual_honorarios || ""),
         forma_pagamento: values.forma_pagamento || null,
-        parcelas: values.parcelas ? Number(values.parcelas) : null,
+        qtde_parcelas: values.qtde_parcelas ? Number(values.qtde_parcelas) : null,
         contingenciamento: values.contingenciamento || null,
         detalhes: values.detalhes || null,
         documentos_anexados: null,
@@ -1019,7 +1019,7 @@ export default function EditarOportunidade() {
                       {formaPagamento === "Parcelado" && (
                         <FormField
                           control={form.control}
-                          name="parcelas"
+                          name="qtde_parcelas"
                           render={({ field }) => (
                             <FormItem>
                               <FormLabel>Número de Parcelas</FormLabel>

--- a/frontend/src/pages/NovaOportunidade.tsx
+++ b/frontend/src/pages/NovaOportunidade.tsx
@@ -66,7 +66,7 @@ const formSchema = z.object({
   valor_honorarios: z.string().optional(),
   percentual_honorarios: z.string().optional(),
   forma_pagamento: z.string().optional(),
-  parcelas: z.string().optional(),
+  qtde_parcelas: z.string().optional(),
   contingenciamento: z.string().optional(),
   detalhes: z.string().optional(),
   documentos_anexados: z.any().optional(),
@@ -128,7 +128,7 @@ export default function NovaOportunidade() {
       valor_honorarios: "",
       percentual_honorarios: "",
       forma_pagamento: "",
-      parcelas: "",
+      qtde_parcelas: "",
       contingenciamento: "",
       detalhes: "",
       documentos_anexados: undefined,
@@ -290,7 +290,7 @@ export default function NovaOportunidade() {
         valor_honorarios: parseCurrency(values.valor_honorarios || ""),
         percentual_honorarios: parsePercent(values.percentual_honorarios || ""),
         forma_pagamento: values.forma_pagamento || null,
-        parcelas: values.parcelas ? Number(values.parcelas) : null,
+          qtde_parcelas: values.qtde_parcelas ? Number(values.qtde_parcelas) : null,
         contingenciamento: values.contingenciamento || null,
         detalhes: values.detalhes || null,
         documentos_anexados: null,
@@ -926,7 +926,7 @@ export default function NovaOportunidade() {
                       {formaPagamento === "Parcelado" && (
                         <FormField
                           control={form.control}
-                          name="parcelas"
+                            name="qtde_parcelas"
                           render={({ field }) => (
                             <FormItem>
                               <FormLabel>Número de Parcelas</FormLabel>

--- a/frontend/src/pages/VisualizarOportunidade.tsx
+++ b/frontend/src/pages/VisualizarOportunidade.tsx
@@ -234,7 +234,7 @@ export default function VisualizarOportunidade() {
     valor_honorarios: "Valor dos Honorários",
     percentual_honorarios: "% Honorários",
     forma_pagamento: "Forma de Pagamento",
-    parcelas: "Número de Parcelas",
+    qtde_parcelas: "Número de Parcelas",
     contingenciamento: "Contingenciamento",
     detalhes: "Detalhes",
     documentos_anexados: "Documentos Anexados",
@@ -360,7 +360,7 @@ export default function VisualizarOportunidade() {
     {
       key: "honorarios",
       label: "Honorários",
-      fields: ["valor_causa", "valor_honorarios", "percentual_honorarios", "forma_pagamento", "parcelas", "contingenciamento"],
+        fields: ["valor_causa", "valor_honorarios", "percentual_honorarios", "forma_pagamento", "qtde_parcelas", "contingenciamento"],
     },
     {
       key: "metadados",


### PR DESCRIPTION
## Summary
- handle `qtde_parcelas` in oportunidade controller queries, insert and update
- document and expose `qtde_parcelas` in opportunity model and swagger routes
- wire `qtde_parcelas` field through new, edit and view opportunity pages

## Testing
- `node node_modules/tsx/dist/cli.cjs --test tests/templateService.test.ts`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5fbfa94188326a764d2311e66fd5e