### PR TITLE
feat: add task and document buttons

### DIFF
--- a/frontend/src/pages/VisualizarOportunidade.tsx
+++ b/frontend/src/pages/VisualizarOportunidade.tsx
@@ -419,6 +419,14 @@ export default function VisualizarOportunidade() {
   };
   const onPrint = () => window.print();
 
+  const onCreateTask = () => {
+    navigate(`/tarefas?oportunidade=${id}`);
+  };
+
+  const onCreateDocument = () => {
+    navigate(`/documentos?oportunidade=${id}`);
+  };
+
   const renderFormatted = (key: string, value: unknown) => {
     if (value === null || value === undefined || value === "") {
       return <span className="text-muted-foreground">—</span>;
@@ -518,6 +526,12 @@ export default function VisualizarOportunidade() {
           </Button>
           <Button variant="destructive" onClick={onDelete} aria-label="Excluir oportunidade">
             Excluir
+          </Button>
+          <Button onClick={onCreateTask} aria-label="Criar tarefa">
+            Criar Tarefa
+          </Button>
+          <Button onClick={onCreateDocument} aria-label="Criar documento">
+            Criar Documento
           </Button>
           <Button variant="ghost" onClick={onPrint} aria-label="Imprimir">
             Imprimir

--- a/src/pages/VisualizarOportunidade.tsx
+++ b/src/pages/VisualizarOportunidade.tsx
@@ -203,6 +203,14 @@ export default function VisualizarOportunidade() {
     return String(value);
   };
 
+  const onCreateTask = () => {
+    navigate(`/tarefas?oportunidade=${id}`);
+  };
+
+  const onCreateDocument = () => {
+    navigate(`/documentos?oportunidade=${id}`);
+  };
+
   if (!opportunity) {
     return (
       <div className="p-6 space-y-4">
@@ -226,9 +234,13 @@ export default function VisualizarOportunidade() {
             Detalhes completos da oportunidade
           </p>
         </div>
-        <Button variant="outline" onClick={() => navigate(-1)}>
-          Voltar
-        </Button>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => navigate(-1)}>
+            Voltar
+          </Button>
+          <Button onClick={onCreateTask}>Criar Tarefa</Button>
+          <Button onClick={onCreateDocument}>Criar Documento</Button>
+        </div>
       </div>
 
       <Card>


### PR DESCRIPTION
## Summary
- add create task and document actions to opportunity view
- expose navigation to tasks and documents pages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5fd4ea6c48326b9541b53c4dff71c