### PR TITLE
Exibir apenas o tipo de processo nos cards do pipeline

### DIFF
--- a/frontend/src/pages/Pipeline.tsx
+++ b/frontend/src/pages/Pipeline.tsx
@@ -539,16 +539,9 @@ export default function Pipeline() {
                   >
                     <CardHeader className="pb-2">
                       <div className="flex items-start justify-between">
-                        <div className="flex items-center gap-2">
-                          <CardTitle className="text-sm font-medium leading-tight">
-                            {opportunity.title}
-                          </CardTitle>
-                          {opportunity.processType && (
-                            <span className="text-xs text-muted-foreground">
-                              {opportunity.processType}
-                            </span>
-                          )}
-                        </div>
+                        <CardTitle className="text-sm font-medium leading-tight">
+                          {opportunity.processType}
+                        </CardTitle>
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
                             <Button

--- a/src/pages/Pipeline.tsx
+++ b/src/pages/Pipeline.tsx
@@ -430,7 +430,7 @@ export default function Pipeline() {
                     <CardHeader className="pb-2">
                       <div className="flex items-start justify-between">
                         <CardTitle className="text-sm font-medium leading-tight">
-                          {opportunity.title}
+                          {opportunity.area}
                         </CardTitle>
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>


### PR DESCRIPTION
## Summary
- Mostrar somente o tipo de processo como título dos cards do pipeline

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c6026f38e08326b1e2598a44a3d32a