### PR TITLE
feat: add tarefa endpoints to backend

### DIFF
--- a/backend/src/controllers/tarefaController.ts
+++ b/backend/src/controllers/tarefaController.ts
@@ -1,0 +1,139 @@
+import { Request, Response } from 'express';
+import pool from '../services/db';
+
+export const listTarefas = async (_req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      'SELECT id, id_oportunidades, titulo, descricao, data, hora, dia_inteiro, prioridade, mostrar_na_agenda, privada, recorrente, repetir_quantas_vezes, repetir_cada_unidade, repetir_intervalo, criado_em, atualizado_em FROM public.tarefas'
+    );
+    res.json(result.rows);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+export const getTarefaById = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  try {
+    const result = await pool.query(
+      'SELECT id, id_oportunidades, titulo, descricao, data, hora, dia_inteiro, prioridade, mostrar_na_agenda, privada, recorrente, repetir_quantas_vezes, repetir_cada_unidade, repetir_intervalo, criado_em, atualizado_em FROM public.tarefas WHERE id = $1',
+      [id]
+    );
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: 'Tarefa não encontrada' });
+    }
+    res.json(result.rows[0]);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+export const createTarefa = async (req: Request, res: Response) => {
+  const {
+    id_oportunidades,
+    titulo,
+    descricao,
+    data,
+    hora,
+    dia_inteiro = false,
+    prioridade,
+    mostrar_na_agenda = true,
+    privada = true,
+    recorrente = false,
+    repetir_quantas_vezes = 1,
+    repetir_cada_unidade,
+    repetir_intervalo = 1,
+  } = req.body;
+
+  try {
+    const result = await pool.query(
+      `INSERT INTO public.tarefas (id_oportunidades, titulo, descricao, data, hora, dia_inteiro, prioridade, mostrar_na_agenda, privada, recorrente, repetir_quantas_vezes, repetir_cada_unidade, repetir_intervalo, criado_em, atualizado_em)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW(), NOW())
+       RETURNING id, id_oportunidades, titulo, descricao, data, hora, dia_inteiro, prioridade, mostrar_na_agenda, privada, recorrente, repetir_quantas_vezes, repetir_cada_unidade, repetir_intervalo, criado_em, atualizado_em`,
+      [
+        id_oportunidades,
+        titulo,
+        descricao,
+        data,
+        hora,
+        dia_inteiro,
+        prioridade,
+        mostrar_na_agenda,
+        privada,
+        recorrente,
+        repetir_quantas_vezes,
+        repetir_cada_unidade,
+        repetir_intervalo,
+      ]
+    );
+    res.status(201).json(result.rows[0]);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+export const updateTarefa = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const {
+    id_oportunidades,
+    titulo,
+    descricao,
+    data,
+    hora,
+    dia_inteiro = false,
+    prioridade,
+    mostrar_na_agenda = true,
+    privada = true,
+    recorrente = false,
+    repetir_quantas_vezes = 1,
+    repetir_cada_unidade,
+    repetir_intervalo = 1,
+  } = req.body;
+
+  try {
+    const result = await pool.query(
+      `UPDATE public.tarefas SET id_oportunidades = $1, titulo = $2, descricao = $3, data = $4, hora = $5, dia_inteiro = $6, prioridade = $7, mostrar_na_agenda = $8, privada = $9, recorrente = $10, repetir_quantas_vezes = $11, repetir_cada_unidade = $12, repetir_intervalo = $13, atualizado_em = NOW() WHERE id = $14
+       RETURNING id, id_oportunidades, titulo, descricao, data, hora, dia_inteiro, prioridade, mostrar_na_agenda, privada, recorrente, repetir_quantas_vezes, repetir_cada_unidade, repetir_intervalo, criado_em, atualizado_em`,
+      [
+        id_oportunidades,
+        titulo,
+        descricao,
+        data,
+        hora,
+        dia_inteiro,
+        prioridade,
+        mostrar_na_agenda,
+        privada,
+        recorrente,
+        repetir_quantas_vezes,
+        repetir_cada_unidade,
+        repetir_intervalo,
+        id,
+      ]
+    );
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: 'Tarefa não encontrada' });
+    }
+    res.json(result.rows[0]);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+export const deleteTarefa = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  try {
+    const result = await pool.query('DELETE FROM public.tarefas WHERE id = $1', [id]);
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: 'Tarefa não encontrada' });
+    }
+    res.status(204).send();
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,6 +19,7 @@ import financialRoutes from './routes/financialRoutes';
 import uploadRoutes from './routes/uploadRoutes';
 import oportunidadeRoutes from './routes/oportunidadeRoutes';
 import fluxoTrabalhoRoutes from './routes/fluxoTrabalhoRoutes';
+import tarefaRoutes from './routes/tarefaRoutes';
 import swaggerUi from 'swagger-ui-express';
 import swaggerJsdoc from 'swagger-jsdoc';
 import swaggerOptions from './swagger';
@@ -41,7 +42,7 @@ app.use((req, res, next) => {
 
   if (origin && allowedOrigins.includes(origin)) {
     res.header('Access-Control-Allow-Origin', origin);
-    res.header('Vary', 'Origin'); // boa pr·tica p/ caches
+    res.header('Vary', 'Origin'); // boa pr√°tica p/ caches
   }
 
   res.header('Access-Control-Allow-Credentials', 'true');
@@ -81,6 +82,7 @@ app.use('/api', financialRoutes);
 app.use('/api', uploadRoutes);
 app.use('/api', oportunidadeRoutes);
 app.use('/api', fluxoTrabalhoRoutes);
+app.use('/api', tarefaRoutes);
 
 // Swagger
 const specs = swaggerJsdoc(swaggerOptions);

--- a/backend/src/models/tarefa.ts
+++ b/backend/src/models/tarefa.ts
@@ -1,0 +1,18 @@
+export interface Tarefa {
+  id: number;
+  id_oportunidades: number;
+  titulo: string;
+  descricao: string | null;
+  data: string;
+  hora: string;
+  dia_inteiro: boolean;
+  prioridade: number | null;
+  mostrar_na_agenda: boolean;
+  privada: boolean;
+  recorrente: boolean;
+  repetir_quantas_vezes: number;
+  repetir_cada_unidade: 'Minutos' | 'Horas' | 'Dias' | 'Semanas' | 'Meses' | null;
+  repetir_intervalo: number;
+  criado_em: string;
+  atualizado_em: string;
+}

--- a/backend/src/routes/tarefaRoutes.ts
+++ b/backend/src/routes/tarefaRoutes.ts
@@ -1,0 +1,174 @@
+import { Router } from 'express';
+import {
+  listTarefas,
+  getTarefaById,
+  createTarefa,
+  updateTarefa,
+  deleteTarefa,
+} from '../controllers/tarefaController';
+
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   - name: Tarefas
+ *     description: Endpoints para gerenciamento de tarefas
+ * components:
+ *   schemas:
+ *     Tarefa:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *         id_oportunidades:
+ *           type: integer
+ *         titulo:
+ *           type: string
+ *         descricao:
+ *           type: string
+ *         data:
+ *           type: string
+ *           format: date
+ *         hora:
+ *           type: string
+ *           format: time
+ *         dia_inteiro:
+ *           type: boolean
+ *         prioridade:
+ *           type: integer
+ *         mostrar_na_agenda:
+ *           type: boolean
+ *         privada:
+ *           type: boolean
+ *         recorrente:
+ *           type: boolean
+ *         repetir_quantas_vezes:
+ *           type: integer
+ *         repetir_cada_unidade:
+ *           type: string
+ *         repetir_intervalo:
+ *           type: integer
+ *         criado_em:
+ *           type: string
+ *           format: date-time
+ *         atualizado_em:
+ *           type: string
+ *           format: date-time
+ */
+
+/**
+ * @swagger
+ * /api/tarefas:
+ *   get:
+ *     summary: Lista todas as tarefas
+ *     tags: [Tarefas]
+ *     responses:
+ *       200:
+ *         description: Lista de tarefas
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Tarefa'
+ */
+router.get('/tarefas', listTarefas);
+
+/**
+ * @swagger
+ * /api/tarefas/{id}:
+ *   get:
+ *     summary: Obter tarefa por ID
+ *     tags: [Tarefas]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *     responses:
+ *       200:
+ *         description: Tarefa encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Tarefa'
+ *       404:
+ *         description: Tarefa não encontrada
+ */
+router.get('/tarefas/:id', getTarefaById);
+
+/**
+ * @swagger
+ * /api/tarefas:
+ *   post:
+ *     summary: Cria uma nova tarefa
+ *     tags: [Tarefas]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Tarefa'
+ *     responses:
+ *       201:
+ *         description: Tarefa criada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Tarefa'
+ */
+router.post('/tarefas', createTarefa);
+
+/**
+ * @swagger
+ * /api/tarefas/{id}:
+ *   put:
+ *     summary: Atualiza uma tarefa
+ *     tags: [Tarefas]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Tarefa'
+ *     responses:
+ *       200:
+ *         description: Tarefa atualizada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Tarefa'
+ *       404:
+ *         description: Tarefa não encontrada
+ */
+router.put('/tarefas/:id', updateTarefa);
+
+/**
+ * @swagger
+ * /api/tarefas/{id}:
+ *   delete:
+ *     summary: Remove uma tarefa
+ *     tags: [Tarefas]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *     responses:
+ *       204:
+ *         description: Tarefa removida
+ *       404:
+ *         description: Tarefa não encontrada
+ */
+router.delete('/tarefas/:id', deleteTarefa);
+
+export default router;


### PR DESCRIPTION
## Summary
- add tarefa model
- implement CRUD controller and routes for tarefas
- register tarefa routes in server

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6089356e883268d1f9b30a46e604f