### PR TITLE
feat: show client name in proposal options

### DIFF
--- a/frontend/src/pages/Tarefas.tsx
+++ b/frontend/src/pages/Tarefas.tsx
@@ -110,6 +110,9 @@ interface ApiOpportunity {
   id: number;
   data_criacao?: string;
   solicitante_nome?: string;
+  solicitante?: {
+    nome?: string;
+  };
 }
 
 const apiUrl = (import.meta.env.VITE_API_URL as string) || 'http://localhost:3000';
@@ -203,7 +206,11 @@ export default function Tarefas() {
           : Array.isArray(json?.data)
           ? json.data
           : [];
-        setOpportunities(data);
+        const extended = data.map((o) => ({
+          ...o,
+          solicitante_nome: o.solicitante_nome || o.solicitante?.nome,
+        }));
+        setOpportunities(extended);
       } catch (err) {
         console.error('Erro ao buscar propostas:', err);
       }


### PR DESCRIPTION
## Summary
- append client name to proposal labels for easier identification

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c612cd5624832688106ef2be7b79c2