### PR TITLE
feat: allow completing tasks

### DIFF
--- a/backend/src/controllers/tarefaController.ts
+++ b/backend/src/controllers/tarefaController.ts
@@ -128,6 +128,23 @@ export const updateTarefa = async (req: Request, res: Response) => {
   }
 };
 
+export const concluirTarefa = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  try {
+    const result = await pool.query(
+      `UPDATE public.tarefas SET concluido = true, atualizado_em = NOW() WHERE id = $1 RETURNING id, id_oportunidades, titulo, descricao, data, hora, dia_inteiro, prioridade, mostrar_na_agenda, privada, recorrente, repetir_quantas_vezes, repetir_cada_unidade, repetir_intervalo, criado_em, atualizado_em, concluido`,
+      [id],
+    );
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: 'Tarefa não encontrada' });
+    }
+    res.json(result.rows[0]);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
 export const deleteTarefa = async (req: Request, res: Response) => {
   const { id } = req.params;
   try {

--- a/backend/src/routes/tarefaRoutes.ts
+++ b/backend/src/routes/tarefaRoutes.ts
@@ -4,6 +4,7 @@ import {
   getTarefaById,
   createTarefa,
   updateTarefa,
+  concluirTarefa,
   deleteTarefa,
 } from '../controllers/tarefaController';
 
@@ -152,6 +153,30 @@ router.post('/tarefas', createTarefa);
  *         description: Tarefa não encontrada
  */
 router.put('/tarefas/:id', updateTarefa);
+
+/**
+ * @swagger
+ * /api/tarefas/{id}/concluir:
+ *   patch:
+ *     summary: Marca tarefa como concluída
+ *     tags: [Tarefas]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *     responses:
+ *       200:
+ *         description: Tarefa concluída
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Tarefa'
+ *       404:
+ *         description: Tarefa não encontrada
+ */
+router.patch('/tarefas/:id/concluir', concluirTarefa);
 
 /**
  * @swagger

--- a/frontend/src/pages/Tarefas.tsx
+++ b/frontend/src/pages/Tarefas.tsx
@@ -394,8 +394,15 @@ export default function Tarefas() {
     { name: 'Resolvidas', value: done },
   ];
 
-  const markDone = (id: number) => {
-    setTasks((prev) => prev.map((t) => (t.id === id ? { ...t, status: 'resolvida' } : t)));
+  const markDone = async (id: number) => {
+    try {
+      const url = joinUrl(apiUrl, `/api/tarefas/${id}/concluir`);
+      const res = await fetch(url, { method: 'PATCH', headers: { Accept: 'application/json' } });
+      if (!res.ok) throw new Error('Failed to conclude task');
+      setTasks((prev) => prev.map((t) => (t.id === id ? { ...t, status: 'resolvida' } : t)));
+    } catch (e) {
+      console.error('Erro ao concluir tarefa:', e);
+    }
   };
 
   const deleteTask = (id: number) => {


### PR DESCRIPTION
## Summary
- add backend controller and route to mark tasks as concluded
- call new endpoint from tasks page to conclude items

## Testing
- `npm test` (backend) *(fails: tsx permission denied)*
- `npm test` (frontend) *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c61b17befc8326ae5811954695b2f2