### PR TITLE
Fix task completion status logic in Tarefas page

### DIFF
--- a/frontend/src/pages/Tarefas.tsx
+++ b/frontend/src/pages/Tarefas.tsx
@@ -240,7 +240,7 @@ export default function Tarefas() {
           data.map(async (t) => {
             const dateStr = t.dia_inteiro ? t.data : `${t.data}${t.hora ? `T${t.hora}` : ''}`;
             const date = new Date(dateStr);
-            const status: Task['status'] = !t.concluido
+            const status: Task['status'] = t.concluido
               ? 'resolvida'
               : date < new Date()
               ? 'atrasada'
@@ -330,7 +330,7 @@ export default function Tarefas() {
       repetir_cada_unidade: data.recurring ? data.recurrenceUnit : null,
       repetir_intervalo: 1,
 
-      concluido: true,
+      concluido: false,
     };
 
     try {
@@ -359,7 +359,7 @@ export default function Tarefas() {
         ? created.data
         : `${created.data}${created.hora ? `T${created.hora}` : ''}`;
       const date = new Date(dateStr);
-      const status: Task['status'] = !created.concluido
+      const status: Task['status'] = created.concluido
         ? 'resolvida'
         : date < new Date()
         ? 'atrasada'


### PR DESCRIPTION
## Summary
- fix task status mapping to use `concluido` correctly
- default new tasks to `concluido: false`
- align created task status check with backend

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c61fabbcac8326a9f7a2708ec437a1