### PR TITLE
feat: add endpoint to list task responsaveis

### DIFF
--- a/backend/src/controllers/tarefaController.ts
+++ b/backend/src/controllers/tarefaController.ts
@@ -55,6 +55,28 @@ export const getTarefaById = async (req: Request, res: Response) => {
   }
 };
 
+export const getResponsavelByTarefa = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  try {
+    const result = await pool.query(
+      `SELECT tr.id_tarefa, tr.id_usuario, u.nome_completo AS nome_responsavel
+       FROM public.tarefas_responsaveis tr
+       JOIN public.usuarios u ON tr.id_usuario = u.id
+       WHERE tr.id_tarefa = $1`,
+      [id],
+    );
+    if (result.rowCount === 0) {
+      return res
+        .status(404)
+        .json({ error: 'Responsável não encontrado para esta tarefa' });
+    }
+    res.json(result.rows);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
 export const createTarefa = async (req: Request, res: Response) => {
   const {
     id_oportunidades,

--- a/backend/src/routes/tarefaRoutes.ts
+++ b/backend/src/routes/tarefaRoutes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import {
   listTarefas,
   getTarefaById,
+  getResponsavelByTarefa,
   createTarefa,
   updateTarefa,
   concluirTarefa,
@@ -110,6 +111,39 @@ router.get('/tarefas', listTarefas);
  *         description: Tarefa não encontrada
  */
 router.get('/tarefas/:id', getTarefaById);
+
+/**
+ * @swagger
+ * /api/tarefas/{id}/responsavel:
+ *   get:
+ *     summary: Recupera o nome do responsável pela tarefa
+ *     tags: [Tarefas]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *     responses:
+ *       200:
+ *         description: Responsáveis encontrados
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id_tarefa:
+ *                     type: integer
+ *                   id_usuario:
+ *                     type: integer
+ *                   nome_responsavel:
+ *                     type: string
+ *       404:
+ *         description: Responsável não encontrado
+ */
+router.get('/tarefas/:id/responsavel', getResponsavelByTarefa);
 
 /**
  * @swagger


### PR DESCRIPTION
## Summary
- expose API to fetch responsible users for a task
- document new endpoint in swagger routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6208f7e348326b3cda0c84f228ed6