### PR TITLE
fix: load tasks even when user list fetch fails

### DIFF
--- a/frontend/src/pages/Tarefas.tsx
+++ b/frontend/src/pages/Tarefas.tsx
@@ -230,7 +230,6 @@ export default function Tarefas() {
 
   useEffect(() => {
     const fetchTasks = async () => {
-      if (!users.length) return;
       try {
         const url = joinUrl(apiUrl, '/api/tarefas');
         const response = await fetch(url, { headers: { Accept: 'application/json' } });
@@ -301,7 +300,7 @@ export default function Tarefas() {
       }
     };
     fetchTasks();
-  }, [users, opportunities]);
+  }, [opportunities]);
 
 
   const onSubmit = async (data: FormValues) => {


### PR DESCRIPTION
## Summary
- allow tasks page to fetch tasks regardless of user data availability

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c625d8ca7483269f3798e9991f5926