### PR TITLE
Handle single child in tooltip trigger

### DIFF
--- a/frontend/src/pages/Tarefas.tsx
+++ b/frontend/src/pages/Tarefas.tsx
@@ -610,13 +610,11 @@ export default function Tarefas() {
                   <TooltipProvider>
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        {task.status === 'pendente' && (
+                        {task.status === 'pendente' ? (
                           <Clock className="h-4 w-4 text-amber-500" />
-                        )}
-                        {task.status === 'atrasada' && (
+                        ) : task.status === 'atrasada' ? (
                           <AlertTriangle className="h-4 w-4 text-destructive" />
-                        )}
-                        {task.status === 'resolvida' && (
+                        ) : (
                           <CheckCircle2 className="h-4 w-4 text-green-500" />
                         )}
                       </TooltipTrigger>


### PR DESCRIPTION
## Summary
- avoid passing multiple elements to TooltipTrigger to prevent Slot errors

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6272e35fc83269c7ed1b96e4d2637