### PR TITLE
feat: allow event types to toggle agenda and task visibility

### DIFF
--- a/backend/src/controllers/tipoEventoController.ts
+++ b/backend/src/controllers/tipoEventoController.ts
@@ -4,7 +4,7 @@ import pool from '../services/db';
 export const listTiposEvento = async (_req: Request, res: Response) => {
   try {
     const result = await pool.query(
-      'SELECT id, nome, ativo, datacriacao FROM public.tipo_evento'
+      'SELECT id, nome, ativo, datacriacao, exibe_agenda, exibe_tarefa FROM public.tipo_evento'
     );
     res.json(result.rows);
   } catch (error) {
@@ -14,11 +14,11 @@ export const listTiposEvento = async (_req: Request, res: Response) => {
 };
 
 export const createTipoEvento = async (req: Request, res: Response) => {
-  const { nome, ativo } = req.body;
+  const { nome, ativo, exibe_agenda = true, exibe_tarefa = true } = req.body;
   try {
     const result = await pool.query(
-      'INSERT INTO public.tipo_evento (nome, ativo, datacriacao) VALUES ($1, $2, NOW()) RETURNING id, nome, ativo, datacriacao',
-      [nome, ativo]
+      'INSERT INTO public.tipo_evento (nome, ativo, exibe_agenda, exibe_tarefa, datacriacao) VALUES ($1, $2, $3, $4, NOW()) RETURNING id, nome, ativo, exibe_agenda, exibe_tarefa, datacriacao',
+      [nome, ativo, exibe_agenda, exibe_tarefa]
     );
     res.status(201).json(result.rows[0]);
   } catch (error) {
@@ -29,11 +29,11 @@ export const createTipoEvento = async (req: Request, res: Response) => {
 
 export const updateTipoEvento = async (req: Request, res: Response) => {
   const { id } = req.params;
-  const { nome, ativo } = req.body;
+  const { nome, ativo, exibe_agenda = true, exibe_tarefa = true } = req.body;
   try {
     const result = await pool.query(
-      'UPDATE public.tipo_evento SET nome = $1, ativo = $2 WHERE id = $3 RETURNING id, nome, ativo, datacriacao',
-      [nome, ativo, id]
+      'UPDATE public.tipo_evento SET nome = $1, ativo = $2, exibe_agenda = $3, exibe_tarefa = $4 WHERE id = $5 RETURNING id, nome, ativo, exibe_agenda, exibe_tarefa, datacriacao',
+      [nome, ativo, exibe_agenda, exibe_tarefa, id]
     );
     if (result.rowCount === 0) {
       return res.status(404).json({ error: 'Tipo de evento não encontrado' });

--- a/backend/src/routes/tipoEventoRoutes.ts
+++ b/backend/src/routes/tipoEventoRoutes.ts
@@ -24,6 +24,10 @@ const router = Router();
  *           type: string
  *         ativo:
  *           type: boolean
+ *         exibe_agenda:
+ *           type: boolean
+ *         exibe_tarefa:
+ *           type: boolean
  *         datacriacao:
  *           type: string
  *           format: date-time
@@ -64,6 +68,10 @@ router.get('/tipo-eventos', listTiposEvento);
  *                 type: string
  *               ativo:
  *                 type: boolean
+ *               exibe_agenda:
+ *                 type: boolean
+ *               exibe_tarefa:
+ *                 type: boolean
  *     responses:
  *       201:
  *         description: Tipo de evento criado
@@ -96,6 +104,10 @@ router.post('/tipo-eventos', createTipoEvento);
  *               nome:
  *                 type: string
  *               ativo:
+ *                 type: boolean
+ *               exibe_agenda:
+ *                 type: boolean
+ *               exibe_tarefa:
  *                 type: boolean
  *     responses:
  *       200:

--- a/frontend/src/pages/configuracoes/parametros/TipoEvento.tsx
+++ b/frontend/src/pages/configuracoes/parametros/TipoEvento.tsx
@@ -8,7 +8,10 @@ export default function TipoEvento() {
       placeholder="Novo tipo de evento"
       emptyMessage="Nenhum tipo cadastrado"
       endpoint="/api/tipo-eventos"
-
+      booleanFields={[
+        { key: "exibe_agenda", label: "Exibe na agenda", default: true },
+        { key: "exibe_tarefa", label: "Exibe na tarefa", default: true },
+      ]}
     />
   );
 }

--- a/src/pages/configuracoes/parametros/TipoEvento.tsx
+++ b/src/pages/configuracoes/parametros/TipoEvento.tsx
@@ -8,7 +8,10 @@ export default function TipoEvento() {
       placeholder="Novo tipo de evento"
       emptyMessage="Nenhum tipo cadastrado"
       endpoint="/api/tipo-eventos"
-
+      booleanFields={[
+        { key: "exibe_agenda", label: "Exibe na agenda", default: true },
+        { key: "exibe_tarefa", label: "Exibe na tarefa", default: true },
+      ]}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add `exibe_agenda` and `exibe_tarefa` flags to event type API
- support boolean parameter fields and checkboxes in parameter pages
- expose agenda/task visibility toggles in event type configuration UI

## Testing
- `cd backend && npm test`
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c704579ddc8326a1201098f3d8026c