### PR TITLE
feat: adjust tipo evento endpoints for new schema

### DIFF
--- a/backend/src/controllers/tipoEventoController.ts
+++ b/backend/src/controllers/tipoEventoController.ts
@@ -4,7 +4,7 @@ import pool from '../services/db';
 export const listTiposEvento = async (_req: Request, res: Response) => {
   try {
     const result = await pool.query(
-      'SELECT id, nome, ativo, datacriacao, exibe_agenda, exibe_tarefa FROM public.tipo_evento'
+      'SELECT id, nome, ativo, datacriacao, agenda, tarefa FROM public.tipo_evento'
     );
     res.json(result.rows);
   } catch (error) {
@@ -14,11 +14,11 @@ export const listTiposEvento = async (_req: Request, res: Response) => {
 };
 
 export const createTipoEvento = async (req: Request, res: Response) => {
-  const { nome, ativo, exibe_agenda = true, exibe_tarefa = true } = req.body;
+  const { nome, ativo, agenda = true, tarefa = true } = req.body;
   try {
     const result = await pool.query(
-      'INSERT INTO public.tipo_evento (nome, ativo, exibe_agenda, exibe_tarefa, datacriacao) VALUES ($1, $2, $3, $4, NOW()) RETURNING id, nome, ativo, exibe_agenda, exibe_tarefa, datacriacao',
-      [nome, ativo, exibe_agenda, exibe_tarefa]
+      'INSERT INTO public.tipo_evento (nome, ativo, agenda, tarefa, datacriacao) VALUES ($1, $2, $3, $4, NOW()) RETURNING id, nome, ativo, agenda, tarefa, datacriacao',
+      [nome, ativo, agenda, tarefa]
     );
     res.status(201).json(result.rows[0]);
   } catch (error) {
@@ -29,11 +29,11 @@ export const createTipoEvento = async (req: Request, res: Response) => {
 
 export const updateTipoEvento = async (req: Request, res: Response) => {
   const { id } = req.params;
-  const { nome, ativo, exibe_agenda = true, exibe_tarefa = true } = req.body;
+  const { nome, ativo, agenda = true, tarefa = true } = req.body;
   try {
     const result = await pool.query(
-      'UPDATE public.tipo_evento SET nome = $1, ativo = $2, exibe_agenda = $3, exibe_tarefa = $4 WHERE id = $5 RETURNING id, nome, ativo, exibe_agenda, exibe_tarefa, datacriacao',
-      [nome, ativo, exibe_agenda, exibe_tarefa, id]
+      'UPDATE public.tipo_evento SET nome = $1, ativo = $2, agenda = $3, tarefa = $4 WHERE id = $5 RETURNING id, nome, ativo, agenda, tarefa, datacriacao',
+      [nome, ativo, agenda, tarefa, id]
     );
     if (result.rowCount === 0) {
       return res.status(404).json({ error: 'Tipo de evento não encontrado' });

--- a/backend/src/routes/tipoEventoRoutes.ts
+++ b/backend/src/routes/tipoEventoRoutes.ts
@@ -24,9 +24,9 @@ const router = Router();
  *           type: string
  *         ativo:
  *           type: boolean
- *         exibe_agenda:
+ *         agenda:
  *           type: boolean
- *         exibe_tarefa:
+ *         tarefa:
  *           type: boolean
  *         datacriacao:
  *           type: string
@@ -68,9 +68,9 @@ router.get('/tipo-eventos', listTiposEvento);
  *                 type: string
  *               ativo:
  *                 type: boolean
- *               exibe_agenda:
+ *               agenda:
  *                 type: boolean
- *               exibe_tarefa:
+ *               tarefa:
  *                 type: boolean
  *     responses:
  *       201:
@@ -105,9 +105,9 @@ router.post('/tipo-eventos', createTipoEvento);
  *                 type: string
  *               ativo:
  *                 type: boolean
- *               exibe_agenda:
+ *               agenda:
  *                 type: boolean
- *               exibe_tarefa:
+ *               tarefa:
  *                 type: boolean
  *     responses:
  *       200:

--- a/frontend/src/components/agenda/AppointmentForm.tsx
+++ b/frontend/src/components/agenda/AppointmentForm.tsx
@@ -103,13 +103,15 @@ export function AppointmentForm({ onSubmit, onCancel, initialDate }: Appointment
           throw new Error('Failed to load tipo-eventos');
         }
         const json = await response.json();
-        interface TipoEvento { id: number; nome: string }
+        interface TipoEvento { id: number; nome: string; agenda?: boolean }
         const rows: TipoEvento[] = Array.isArray(json)
           ? json
           : Array.isArray(json?.data)
             ? json.data
             : [];
-        const data: AppointmentType[] = rows.map((t) => t.nome as AppointmentType);
+        const data: AppointmentType[] = rows
+          .filter((t) => t.agenda !== false)
+          .map((t) => t.nome as AppointmentType);
         setTiposEvento(data);
         if (data.length > 0 && !data.includes(form.getValues('type') as AppointmentType)) {
           form.setValue('type', data[0]);

--- a/frontend/src/pages/configuracoes/parametros/TipoEvento.tsx
+++ b/frontend/src/pages/configuracoes/parametros/TipoEvento.tsx
@@ -9,8 +9,8 @@ export default function TipoEvento() {
       emptyMessage="Nenhum tipo cadastrado"
       endpoint="/api/tipo-eventos"
       booleanFields={[
-        { key: "exibe_agenda", label: "Exibe na agenda", default: true },
-        { key: "exibe_tarefa", label: "Exibe na tarefa", default: true },
+        { key: "agenda", label: "Exibe na agenda", default: true },
+        { key: "tarefa", label: "Exibe na tarefa", default: true },
       ]}
     />
   );

--- a/src/components/agenda/AppointmentForm.tsx
+++ b/src/components/agenda/AppointmentForm.tsx
@@ -103,13 +103,15 @@ export function AppointmentForm({ onSubmit, onCancel, initialDate }: Appointment
           throw new Error('Failed to load tipo-eventos');
         }
         const json = await response.json();
-        interface TipoEvento { id: number; nome: string }
+        interface TipoEvento { id: number; nome: string; agenda?: boolean }
         const rows: TipoEvento[] = Array.isArray(json)
           ? json
           : Array.isArray(json?.data)
             ? json.data
             : [];
-        const data: AppointmentType[] = rows.map((t) => t.nome as AppointmentType);
+        const data: AppointmentType[] = rows
+          .filter((t) => t.agenda !== false)
+          .map((t) => t.nome as AppointmentType);
         setTiposEvento(data);
         if (data.length > 0 && !data.includes(form.getValues('type') as AppointmentType)) {
           form.setValue('type', data[0]);

--- a/src/pages/configuracoes/parametros/TipoEvento.tsx
+++ b/src/pages/configuracoes/parametros/TipoEvento.tsx
@@ -9,8 +9,8 @@ export default function TipoEvento() {
       emptyMessage="Nenhum tipo cadastrado"
       endpoint="/api/tipo-eventos"
       booleanFields={[
-        { key: "exibe_agenda", label: "Exibe na agenda", default: true },
-        { key: "exibe_tarefa", label: "Exibe na tarefa", default: true },
+        { key: "agenda", label: "Exibe na agenda", default: true },
+        { key: "tarefa", label: "Exibe na tarefa", default: true },
       ]}
     />
   );


### PR DESCRIPTION
## Summary
- rename backend tipo_evento fields to agenda/tarefa
- update swagger docs and queries
- adapt frontend components to new field names and filter agenda types

## Testing
- `npm test` (backend)
- `npm test` (frontend) - missing script


------
https://chatgpt.com/codex/tasks/task_e_68c70858bb40832680e294c1c6787df2