### PR TITLE
feat: support users alias and localhost 4200

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -40,6 +40,7 @@ app.use((req, res, next) => {
     'http://localhost:5173',
     'http://localhost:8080',
     'http://127.0.0.1:8080',
+    'http://localhost:4200',
   ];
   const origin = req.headers.origin as string | undefined;
 
@@ -77,6 +78,7 @@ app.use('/api', situacaoClienteRoutes);
 app.use('/api', etiquetaRoutes);
 app.use('/api', empresaRoutes);
 app.use('/api', usuarioRoutes);
+app.use('/api/v1', usuarioRoutes);
 app.use('/api', clienteRoutes);
 app.use('/api', agendaRoutes);
 app.use('/api', templateRoutes);

--- a/backend/src/routes/usuarioRoutes.ts
+++ b/backend/src/routes/usuarioRoutes.ts
@@ -217,5 +217,12 @@ router.put('/usuarios/:id', updateUsuario);
  */
 router.delete('/usuarios/:id', deleteUsuario);
 
+// Alias em inglês para compatibilidade com consumidores da API
+router.get('/users', listUsuarios);
+router.get('/users/:id', getUsuarioById);
+router.post('/users', createUsuario);
+router.put('/users/:id', updateUsuario);
+router.delete('/users/:id', deleteUsuario);
+
 export default router;
 


### PR DESCRIPTION
## Summary
- allow frontend on `localhost:4200` via CORS
- expose `/api/v1/users` endpoints alongside Portuguese paths

## Testing
- `node --import tsx --test tests/templateService.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c71f91f88c8326b50138d270a5d66c