### PR TITLE
fix: allow creating clients without area

### DIFF
--- a/frontend/src/pages/NovoCliente.tsx
+++ b/frontend/src/pages/NovoCliente.tsx
@@ -44,7 +44,6 @@ const formSchema = z.object({
   city: z.string().min(1, "Cidade é obrigatória"),
   state: z.string().min(1, "UF é obrigatória"),
   type: z.enum(["pf", "pj"]),
-  area: z.string().min(1, "Área é obrigatória"),
 });
 
 export default function NovoCliente() {
@@ -74,7 +73,6 @@ export default function NovoCliente() {
       city: "",
       state: "",
       type: "pf",
-      area: "",
     },
   });
 
@@ -127,8 +125,8 @@ export default function NovoCliente() {
         </CardHeader>
         <CardContent>
           <Form {...form}>
-
-               <FormField
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
                 control={form.control}
                 name="type"
                 render={({ field }) => (
@@ -149,8 +147,6 @@ export default function NovoCliente() {
                   </FormItem>
                 )}
               />
-
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
               <FormField
                 control={form.control}
                 name="name"


### PR DESCRIPTION
## Summary
- remove unused field from new client form
- nest client type selector inside form element

## Testing
- `npm test` (backend, fails: tsx: Permission denied)
- `npm test` (frontend, fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c742c7ae3c8326a10e343d95eeed83