### PR TITLE
Add 'Meu Plano' menu option

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import DocumentTemplates from "./pages/DocumentTemplates";
 import TemplateEditor from "./pages/TemplateEditor";
 import FinancialFlows from "./pages/FinancialFlows";
 import Relatorios from "./pages/Relatorios";
+import MeuPlano from "./pages/MeuPlano";
 import AreaAtuacao from "./pages/configuracoes/parametros/AreaAtuacao";
 import SituacaoProcesso from "./pages/configuracoes/parametros/SituacaoProcesso";
 import TipoProcesso from "./pages/configuracoes/parametros/TipoProcesso";
@@ -88,6 +89,7 @@ const App = () => (
             <Route path="/documentos/:id" element={<TemplateEditor />} />
             <Route path="/financeiro/lancamentos" element={<FinancialFlows />} />
             <Route path="/relatorios" element={<Relatorios />} />
+            <Route path="/meu-plano" element={<MeuPlano />} />
             <Route
               path="/configuracoes"
               element={

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   FileText,
   DollarSign,
   BarChart3,
+  CreditCard,
   Scale,
   Settings,
   ChevronDown,
@@ -82,6 +83,7 @@ export function Sidebar() {
     { name: "Documentos", href: "/documentos", icon: FileText },
     { name: "Financeiro", href: "/financeiro/lancamentos", icon: DollarSign },
     { name: "Relatórios", href: "/relatorios", icon: BarChart3 },
+    { name: "Meu Plano", href: "/meu-plano", icon: CreditCard },
     {
       name: "Configurações",
       href: "/configuracoes",

--- a/frontend/src/pages/MeuPlano.tsx
+++ b/frontend/src/pages/MeuPlano.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function MeuPlano() {
+  return (
+    <div className="p-6">
+      <h1 className="text-3xl font-bold">Meu Plano</h1>
+      <p className="text-muted-foreground">Em desenvolvimento</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add dedicated Meu Plano page and navigation entry
- wire Meu Plano route into application

## Testing
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run lint`
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68c76f28b6cc832680e158857c0e69a4