### PR TITLE
Ocultar submenu Empresas e Planos em Configurações

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -94,14 +94,6 @@ export function Sidebar() {
           href: "/configuracoes/usuarios",
         },
         {
-          name: "Empresas",
-          href: "/configuracoes/empresas",
-        },
-        {
-          name: "Planos",
-          href: "/configuracoes/planos",
-        },
-        {
           name: "Parâmetros",
           children: [
             {


### PR DESCRIPTION
## Summary
- oculta os itens de submenu Empresas e Planos dentro de Configurações

## Testing
- `npm test` (erro: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c77ccf405483269ce6a216b10db24f