### PR TITLE
Add support request menu and API

### DIFF
--- a/backend/src/controllers/supportController.ts
+++ b/backend/src/controllers/supportController.ts
@@ -1,0 +1,28 @@
+import { Request, Response } from 'express';
+
+interface SupportRequest {
+  id: number;
+  subject: string;
+  description: string;
+  createdAt: string;
+}
+
+const supportRequests: SupportRequest[] = [];
+
+export function createSupportRequest(req: Request, res: Response) {
+  const { subject, description } = req.body as {
+    subject?: string;
+    description?: string;
+  };
+  if (!subject || !description) {
+    return res.status(400).json({ message: 'Subject and description are required' });
+  }
+  const request: SupportRequest = {
+    id: supportRequests.length + 1,
+    subject,
+    description,
+    createdAt: new Date().toISOString(),
+  };
+  supportRequests.push(request);
+  return res.status(201).json(request);
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -23,6 +23,7 @@ import tarefaRoutes from './routes/tarefaRoutes';
 import tarefaResponsavelRoutes from './routes/tarefaResponsavelRoutes';
 import tipoDocumentoRoutes from './routes/tipoDocumentoRoutes';
 import clienteDocumentoRoutes from './routes/clienteDocumentoRoutes';
+import supportRoutes from './routes/supportRoutes';
 import swaggerUi from 'swagger-ui-express';
 import swaggerJsdoc from 'swagger-jsdoc';
 import swaggerOptions from './swagger';
@@ -92,6 +93,7 @@ app.use('/api', oportunidadeRoutes);
 app.use('/api', tarefaRoutes);
 app.use('/api', tarefaResponsavelRoutes);
 app.use('/api', clienteDocumentoRoutes);
+app.use('/api', supportRoutes);
 
 // Swagger
 const specs = swaggerJsdoc(swaggerOptions);

--- a/backend/src/routes/supportRoutes.ts
+++ b/backend/src/routes/supportRoutes.ts
@@ -1,0 +1,36 @@
+import { Router } from 'express';
+import { createSupportRequest } from '../controllers/supportController';
+
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   - name: Suporte
+ *     description: Endpoints para solicitações de suporte
+ */
+
+/**
+ * @swagger
+ * /api/support:
+ *   post:
+ *     summary: Cria uma nova solicitação de suporte
+ *     tags: [Suporte]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               subject:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Solicitação criada
+ */
+router.post('/support', createSupportRequest);
+
+export default router;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import TemplateEditor from "./pages/TemplateEditor";
 import FinancialFlows from "./pages/FinancialFlows";
 import Relatorios from "./pages/Relatorios";
 import MeuPlano from "./pages/MeuPlano";
+import Suporte from "./pages/Suporte";
 import AreaAtuacao from "./pages/configuracoes/parametros/AreaAtuacao";
 import SituacaoProcesso from "./pages/configuracoes/parametros/SituacaoProcesso";
 import TipoProcesso from "./pages/configuracoes/parametros/TipoProcesso";
@@ -90,6 +91,7 @@ const App = () => (
             <Route path="/financeiro/lancamentos" element={<FinancialFlows />} />
             <Route path="/relatorios" element={<Relatorios />} />
             <Route path="/meu-plano" element={<MeuPlano />} />
+            <Route path="/suporte" element={<Suporte />} />
             <Route
               path="/configuracoes"
               element={

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   DollarSign,
   BarChart3,
   CreditCard,
+  LifeBuoy,
   Scale,
   Settings,
   ChevronDown,
@@ -84,6 +85,7 @@ export function Sidebar() {
     { name: "Financeiro", href: "/financeiro/lancamentos", icon: DollarSign },
     { name: "Relatórios", href: "/relatorios", icon: BarChart3 },
     { name: "Meu Plano", href: "/meu-plano", icon: CreditCard },
+    { name: "Suporte", href: "/suporte", icon: LifeBuoy },
     {
       name: "Configurações",
       href: "/configuracoes",

--- a/frontend/src/pages/Suporte.tsx
+++ b/frontend/src/pages/Suporte.tsx
@@ -1,0 +1,104 @@
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+import { toast } from "@/components/ui/use-toast";
+
+const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3000";
+
+const formSchema = z.object({
+  subject: z.string().min(1, "Assunto é obrigatório"),
+  message: z.string().min(1, "Mensagem é obrigatória"),
+});
+
+export default function Suporte() {
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { subject: "", message: "" },
+  });
+
+  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+    try {
+      const res = await fetch(`${apiUrl}/api/support`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          subject: values.subject,
+          description: values.message,
+        }),
+      });
+      if (!res.ok) {
+        throw new Error("Failed to send support request");
+      }
+      toast({ title: "Solicitação enviada com sucesso" });
+      form.reset();
+    } catch (error) {
+      console.error("Erro ao enviar solicitação de suporte:", error);
+      toast({ title: "Erro ao enviar solicitação", variant: "destructive" });
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-foreground">Suporte</h1>
+        <p className="text-muted-foreground">
+          Envie uma nova solicitação de suporte
+        </p>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Nova Solicitação</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="subject"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Assunto</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Digite o assunto" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="message"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Mensagem</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Descreva sua solicitação"
+                        className="min-h-[150px]"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <Button type="submit">Enviar</Button>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Suporte menu and page for users to send support requests
- expose `/api/support` endpoint to receive support tickets
- wire frontend to backend endpoint

## Testing
- `cd backend && npm test`
- `cd frontend && npm test` *(fails: Missing script: "test")*
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7848b6db08326988e169f643adff3