### PR TITLE
docs: fix code block in backend readme

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -17,6 +17,8 @@ Instale as dependências e rode o servidor em modo desenvolvimento:
 npm install
 npm run dev
 
+```
+
 # Rodando testes
 
 ```bash


### PR DESCRIPTION
## Summary
- close development code block in backend README
- render test instructions separately

## Testing
- `npm test` *(fails: tsx Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68c793cf2398832691ec49acdd7b71cb