### PR TITLE
feat(db): use env db url when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,13 @@ Após iniciar, acesse o frontend em `http://localhost:5173` e utilize o menu **D
 ```bash
 cd backend
 npm run build
+# Defina DATABASE_URL ou certifique-se de que appsettings.json contenha a conexão
 DATABASE_URL="postgres://user:pass@host:port/db" npm start
 ```
+
+Se `DATABASE_URL` não estiver definido, o servidor buscará a cadeia de conexão em
+`appsettings.json`. Esse arquivo é opcional, mas se ambos estiverem ausentes o
+backend encerrará com um erro informativo.
 
 ### Frontend
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -38,4 +38,6 @@ npm run build
 DATABASE_URL="postgres://user:pass@host:port/db" npm start
 ```
 
-Se a variável de ambiente `DATABASE_URL` não estiver definida, o valor de `appsettings.json` será utilizado como conexão padrão.
+Se `DATABASE_URL` não estiver definida, o servidor tentará utilizar a conexão
+descrita em `appsettings.json`. Esse arquivo é opcional; caso ambos estejam
+ausentes, a inicialização falhará com um erro descritivo.

--- a/backend/src/services/db.ts
+++ b/backend/src/services/db.ts
@@ -1,12 +1,24 @@
 import { Pool } from 'pg';
 import { readFileSync } from 'fs';
 
-const config = JSON.parse(
-  readFileSync(new URL('../../appsettings.json', import.meta.url), 'utf-8')
-);
+let connectionString = process.env.DATABASE_URL;
 
-const connectionString =
-  process.env.DATABASE_URL || config.ConnectionStrings.DefaultConnection;
+if (!connectionString) {
+  try {
+    const config = JSON.parse(
+      readFileSync(new URL('../../appsettings.json', import.meta.url), 'utf-8')
+    );
+    connectionString = config.ConnectionStrings?.DefaultConnection;
+  } catch (error) {
+    // appsettings.json is optional; we'll handle missing config below
+  }
+}
+
+if (!connectionString) {
+  throw new Error(
+    'Database connection string not provided. Set DATABASE_URL or add appsettings.json.'
+  );
+}
 
 const pool = new Pool({
   connectionString,


### PR DESCRIPTION
## Summary
- load appsettings.json only when `DATABASE_URL` is absent and fail with a clear error if neither is provided
- document optional `appsettings.json` usage for production

## Testing
- `npm test` *(fails: tsx Permission denied)*
- `node node_modules/tsx/dist/cli.cjs --test tests/templateService.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c793ce69e88326bf19070868134c95