### PR TITLE
fix: add node-based Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Build stage
+FROM node:20-bullseye AS builder
+WORKDIR /app
+
+# Install backend dependencies
+COPY backend/package*.json backend/
+RUN npm --prefix backend install
+
+# Install frontend dependencies
+COPY frontend/package*.json frontend/
+RUN npm --prefix frontend install
+
+# Copy application source
+COPY . .
+
+# Build backend and frontend
+RUN npm --prefix backend run build && npm --prefix frontend run build
+
+# Production stage
+FROM node:20-bullseye-slim
+WORKDIR /app
+
+# Copy built applications
+COPY --from=builder /app/backend /app/backend
+COPY --from=builder /app/frontend /app/frontend
+
+ENV NODE_ENV=production
+
+CMD ["npm", "--prefix", "backend", "start"]


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile using Node 20 to build backend and frontend
- switch Dockerfile to use `npm install` for dependency installation

## Testing
- `npm --prefix backend test` *(fails: tsx Permission denied)*
- `npm --prefix backend install` *(fails: 403 Forbidden to npm registry)*
- `npm --prefix frontend run build` *(partials: transformed modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c799ab3f188326ad729f924e20bea2