### PR TITLE
Fix TypeScript build setup and controller

### DIFF
--- a/backend/src/controllers/agendaController.ts
+++ b/backend/src/controllers/agendaController.ts
@@ -27,10 +27,8 @@ export const getTotalCompromissosHoje = async (_req: Request, res: Response) => 
 
 export const createAgenda = async (req: Request, res: Response) => {
   const {
-    id,
     titulo,
-    id_evento,
-    tipo_evento,
+    tipo,
     descricao,
     data,
     hora_inicio,

--- a/backend/src/swagger.ts
+++ b/backend/src/swagger.ts
@@ -1,11 +1,10 @@
-import { SwaggerOptions } from 'swagger-jsdoc';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const swaggerOptions: SwaggerOptions = {
+const swaggerOptions = {
   definition: {
     openapi: '3.0.0',
     info: {

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,13 +1,12 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "ES2020",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true, // ADICIONE isto temporariamente
+    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "./dist",
-    "..."
+    "outDir": "./dist"
   },
   "include": [ "src", "src/types" ]
 }


### PR DESCRIPTION
## Summary
- remove invalid placeholder and switch to ES2020 modules in tsconfig
- clean up swagger options definition
- fix agenda controller to reference existing `tipo` field

## Testing
- `npm run build` *(fails: Cannot find module 'express')*
- `npm test` *(fails: tsx: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68c817c82ee88326bd76f2b9d625815b