### PR TITLE
fix: ensure tsx is installed in production builds

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,7 +11,8 @@
         "express": "^4.19.2",
         "pg": "^8.11.3",
         "swagger-jsdoc": "^6.2.8",
-        "swagger-ui-express": "^5.0.1"
+        "swagger-ui-express": "^5.0.1",
+        "tsx": "^4.7.2"
       },
       "devDependencies": {
         "@types/body-parser": "^1.19.6",
@@ -24,7 +25,6 @@
         "@types/serve-static": "^1.15.8",
         "@types/swagger-jsdoc": "^6.0.1",
         "@types/swagger-ui-express": "^4.1.8",
-        "tsx": "^4.7.2",
         "typescript": "^5.8.3"
       }
     },
@@ -1903,7 +1903,6 @@
       "version": "4.20.5",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz",
       "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.25.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,8 @@
     "express": "^4.19.2",
     "pg": "^8.11.3",
     "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-ui-express": "^5.0.1",
+    "tsx": "^4.7.2"
   },
   "devDependencies": {
     "@types/body-parser": "^1.19.6",
@@ -27,7 +28,6 @@
     "@types/serve-static": "^1.15.8",
     "@types/swagger-jsdoc": "^6.0.1",
     "@types/swagger-ui-express": "^4.1.8",
-    "tsx": "^4.7.2",
     "typescript": "^5.8.3"
   }
 }


### PR DESCRIPTION
## Summary
- move the tsx runtime from devDependencies to dependencies so production installs include it
- update the lockfile to reflect the dependency change

## Testing
- npm --prefix backend run build

------
https://chatgpt.com/codex/tasks/task_e_68c8446c6db88326827e565c90c20e5d