### PR TITLE
Add explicit esbuild dependency for backend runtime

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "backend",
       "version": "1.0.0",
       "dependencies": {
+        "esbuild": "~0.25.0",
         "express": "^4.19.2",
         "pg": "^8.11.3",
         "swagger-jsdoc": "^6.2.8",
@@ -79,7 +80,7 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
+        "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -941,7 +942,7 @@
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
       "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
-      "dev": true,
+      "dev": false,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
 
   },
   "dependencies": {
+    "esbuild": "~0.25.0",
     "express": "^4.19.2",
     "pg": "^8.11.3",
     "swagger-jsdoc": "^6.2.8",


### PR DESCRIPTION
## Summary
- add esbuild as a direct backend dependency so tsx can resolve its runtime requirements
- mark the esbuild lockfile entry as a production dependency to prevent it from being pruned

## Testing
- npm --prefix backend start

------
https://chatgpt.com/codex/tasks/task_e_68c84f9b3cec832698094795923538f2