### PR TITLE
Ensure database config is available in runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN useradd --create-home --shell /bin/false appuser \
 
 # copiar apenas o essencial do builder (artefatos + manifest)
 COPY --from=builder --chown=appuser:appuser /app/backend/dist /app/backend/dist
+COPY --from=builder --chown=appuser:appuser /app/backend/appsettings.json /app/backend/appsettings.json
 COPY --from=builder --chown=appuser:appuser /app/backend/package*.json /app/backend/
 
 # instalar apenas dependências de produção no final

--- a/backend/dist/services/db.js
+++ b/backend/dist/services/db.js
@@ -8,13 +8,24 @@ const fs_1 = require("fs");
 const path_1 = __importDefault(require("path"));
 let connectionString = process.env.DATABASE_URL;
 if (!connectionString) {
-    try {
-        const configPath = path_1.default.resolve(__dirname, '../../appsettings.json');
-        const config = JSON.parse((0, fs_1.readFileSync)(configPath, 'utf-8'));
-        connectionString = config.ConnectionStrings?.DefaultConnection;
-    }
-    catch (error) {
-        // appsettings.json is optional; we'll handle missing config below
+    const configPaths = [
+        path_1.default.resolve(__dirname, '../../appsettings.json'),
+        path_1.default.resolve(process.cwd(), 'appsettings.json'),
+    ];
+    for (const configPath of configPaths) {
+        if (!(0, fs_1.existsSync)(configPath)) {
+            continue;
+        }
+        try {
+            const config = JSON.parse((0, fs_1.readFileSync)(configPath, 'utf-8'));
+            connectionString = config.ConnectionStrings?.DefaultConnection;
+            if (connectionString) {
+                break;
+            }
+        }
+        catch (error) {
+            // appsettings.json is optional; we'll handle missing config below
+        }
     }
 }
 if (!connectionString) {

--- a/backend/src/services/db.ts
+++ b/backend/src/services/db.ts
@@ -1,16 +1,29 @@
 import { Pool } from 'pg';
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import path from 'path';
 
 let connectionString = process.env.DATABASE_URL;
 
 if (!connectionString) {
-  try {
-    const configPath = path.resolve(__dirname, '../../appsettings.json');
-    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
-    connectionString = config.ConnectionStrings?.DefaultConnection;
-  } catch (error) {
-    // appsettings.json is optional; we'll handle missing config below
+  const configPaths = [
+    path.resolve(__dirname, '../../appsettings.json'),
+    path.resolve(process.cwd(), 'appsettings.json'),
+  ];
+
+  for (const configPath of configPaths) {
+    if (!existsSync(configPath)) {
+      continue;
+    }
+
+    try {
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+      connectionString = config.ConnectionStrings?.DefaultConnection;
+      if (connectionString) {
+        break;
+      }
+    } catch (error) {
+      // appsettings.json is optional; we'll handle missing config below
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- allow the database service to look for appsettings.json in both the build output and the working directory
- include appsettings.json in the Docker runtime image so the fallback connection string is available when DATABASE_URL is unset

## Testing
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68c867a1a5ac8326a3715808885f038b