### PR TITLE
Use deployment origin as default API base

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -28,6 +28,17 @@ npm test
 ## Banco de dados
 
 O arquivo `sql/templates.sql` contém a estrutura mínima para as tabelas `templates` e `tags` utilizadas pelos novos endpoints de documentos. Execute esse script em um banco PostgreSQL antes de iniciar o servidor.
+
+## CORS
+
+Por padrão o backend libera requisições vindas de `localhost` e do domínio `https://jusconnec.quantumtecnologia.com.br`. Caso precise habilitar outros hosts, defina a variável de ambiente `CORS_ALLOWED_ORIGINS` com uma lista de URLs separadas por vírgula:
+
+```bash
+CORS_ALLOWED_ORIGINS="https://meusite.com,https://app.meusite.com" npm start
+```
+
+Para cenários específicos é possível liberar todas as origens definindo `CORS_ALLOW_ALL=true`, embora isso não seja recomendado em produção.
+
 ## Documentação
 Após iniciar o servidor, acesse [http://localhost:3001/api-docs](http://localhost:3001/api-docs) para visualizar a documentação Swagger.
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -37,19 +37,33 @@ const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 0;
 app.use(express.json({ limit: '50mb' }));
 app.use(express.urlencoded({ extended: true, limit: '50mb' }));
 
+const defaultAllowedOrigins = [
+  'http://localhost:5173',
+  'http://localhost:8080',
+  'http://127.0.0.1:8080',
+  'http://localhost:4200',
+  'https://jusconnec.quantumtecnologia.com.br',
+];
+
+const additionalAllowedOrigins = (process.env.CORS_ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+const allowedOrigins = new Set([
+  ...defaultAllowedOrigins,
+  ...additionalAllowedOrigins,
+]);
+
+const allowAllOrigins = process.env.CORS_ALLOW_ALL === 'true';
+
 /**
  * Middleware de CORS
  */
 app.use((req, res, next) => {
-  const allowedOrigins = [
-    'http://localhost:5173',
-    'http://localhost:8080',
-    'http://127.0.0.1:8080',
-    'http://localhost:4200',
-  ];
   const origin = req.headers.origin as string | undefined;
 
-  if (origin && allowedOrigins.includes(origin)) {
+  if (origin && (allowAllOrigins || allowedOrigins.has(origin))) {
     res.header('Access-Control-Allow-Origin', origin);
     res.header('Vary', 'Origin'); // boa prática p/ caches
   }

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -38,7 +38,7 @@ npm run dev
 
 ## Documentos Padrão
 
-O módulo de templates de documentos consome a API disponível em `http://localhost:3001/api`. Caso o backend esteja em outra URL, defina a variável de ambiente `VITE_API_URL` antes de iniciar o projeto.
+O módulo de templates de documentos consome a API disponível em `http://localhost:3001/api`. Caso o backend esteja em outra URL, defina a variável de ambiente `VITE_API_URL` antes de iniciar o projeto. Caso contrário, o frontend utilizará automaticamente o mesmo domínio em que estiver publicado.
 
 **Edit a file directly in GitHub**
 

--- a/frontend/src/components/agenda/AppointmentForm.tsx
+++ b/frontend/src/components/agenda/AppointmentForm.tsx
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { CalendarIcon, Clock, MapPin, Bell } from 'lucide-react';
+import { getApiBaseUrl } from '@/lib/api';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -19,7 +20,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 import { appointmentTypes, AppointmentType, Appointment } from '@/types/agenda';
 
-const apiUrl = (import.meta.env.VITE_API_URL as string) || 'http://localhost:3001';
+const apiUrl = getApiBaseUrl();
 
 function joinUrl(base: string, path = '') {
   const b = base.replace(/\/+$/, '');

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -21,6 +21,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { getApiBaseUrl } from "@/lib/api";
 
 interface NavItem {
   name: string;
@@ -38,8 +39,7 @@ export function Sidebar() {
   useEffect(() => {
     const fetchMenus = async () => {
       try {
-        const apiUrl =
-          (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+        const apiUrl = getApiBaseUrl();
         const res = await fetch(`${apiUrl}/api/fluxos-trabalho/menus`, {
           headers: { Accept: "application/json" },
         });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,55 @@
+const rawEnvApiUrl = (import.meta.env.VITE_API_URL as string | undefined)?.trim();
+
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+function stripApiSuffix(url: string): string {
+  const normalized = normalizeBaseUrl(url);
+  return normalized.toLowerCase().endsWith('/api')
+    ? normalized.slice(0, -4)
+    : normalized;
+}
+
+function resolveFallbackBaseUrl(): string {
+  if (rawEnvApiUrl && rawEnvApiUrl.length > 0) {
+    return stripApiSuffix(rawEnvApiUrl);
+  }
+
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return normalizeBaseUrl(window.location.origin);
+  }
+
+  return 'http://localhost:3001';
+}
+
+const API_BASE_URL = resolveFallbackBaseUrl();
+
+function joinPaths(base: string, path?: string): string {
+  const normalizedBase = base.replace(/\/+$/, '');
+
+  if (!path) {
+    return normalizedBase;
+  }
+
+  const normalizedPath = path.replace(/^\/+/, '');
+
+  if (!normalizedPath) {
+    return normalizedBase;
+  }
+
+  return `${normalizedBase}/${normalizedPath}`;
+}
+
+export function getApiBaseUrl(): string {
+  return API_BASE_URL;
+}
+
+export function getApiUrl(path = ''): string {
+  const apiRoot = joinPaths(API_BASE_URL, 'api');
+  return path ? joinPaths(apiRoot, path) : apiRoot;
+}
+
+export function joinUrl(base: string, path = ''): string {
+  return joinPaths(base, path);
+}

--- a/frontend/src/lib/flows.ts
+++ b/frontend/src/lib/flows.ts
@@ -1,3 +1,5 @@
+import { getApiUrl, joinUrl } from './api';
+
 export interface Flow {
   id: number;
   tipo: 'receita' | 'despesa';
@@ -8,16 +10,16 @@ export interface Flow {
   status: 'pendente' | 'pago';
 }
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001/api';
+const FLOWS_ENDPOINT = getApiUrl('financial/flows');
 
 export async function fetchFlows(): Promise<Flow[]> {
-  const res = await fetch(`${API_URL}/financial/flows`);
+  const res = await fetch(FLOWS_ENDPOINT);
   const data = await res.json();
   return data.items || data;
 }
 
 export async function createFlow(flow: Partial<Flow>): Promise<Flow> {
-  const res = await fetch(`${API_URL}/financial/flows`, {
+  const res = await fetch(FLOWS_ENDPOINT, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(flow),
@@ -27,7 +29,7 @@ export async function createFlow(flow: Partial<Flow>): Promise<Flow> {
 }
 
 export async function settleFlow(id: number, pagamentoData: string): Promise<Flow> {
-  const res = await fetch(`${API_URL}/financial/flows/${id}/settle`, {
+  const res = await fetch(joinUrl(FLOWS_ENDPOINT, `${id}/settle`), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ pagamentoData }),

--- a/frontend/src/lib/templates.ts
+++ b/frontend/src/lib/templates.ts
@@ -1,3 +1,5 @@
+import { getApiUrl } from './api';
+
 export interface Template {
   id: number;
   title: string;
@@ -12,20 +14,18 @@ export interface Tag {
   group_name?: string;
 }
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001/api';
-
 export async function fetchTemplates(): Promise<Template[]> {
-  const res = await fetch(`${API_URL}/templates`);
+  const res = await fetch(getApiUrl('templates'));
   return res.json();
 }
 
 export async function getTemplate(id: number): Promise<Template> {
-  const res = await fetch(`${API_URL}/templates/${id}`);
+  const res = await fetch(getApiUrl(`templates/${id}`));
   return res.json();
 }
 
 export async function createTemplate(template: Partial<Template>): Promise<Template> {
-  const res = await fetch(`${API_URL}/templates`, {
+  const res = await fetch(getApiUrl('templates'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(template),
@@ -34,7 +34,7 @@ export async function createTemplate(template: Partial<Template>): Promise<Templ
 }
 
 export async function updateTemplate(id: number, template: Partial<Template>): Promise<Template> {
-  const res = await fetch(`${API_URL}/templates/${id}`, {
+  const res = await fetch(getApiUrl(`templates/${id}`), {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(template),
@@ -43,22 +43,22 @@ export async function updateTemplate(id: number, template: Partial<Template>): P
 }
 
 export async function deleteTemplate(id: number): Promise<void> {
-  await fetch(`${API_URL}/templates/${id}`, { method: 'DELETE' });
+  await fetch(getApiUrl(`templates/${id}`), { method: 'DELETE' });
 }
 
 export async function fetchTags(): Promise<Tag[]> {
-  const res = await fetch(`${API_URL}/tags`);
+  const res = await fetch(getApiUrl('tags'));
   return res.json();
 }
 
 export async function generateWithAI(id: number): Promise<string> {
-  const res = await fetch(`${API_URL}/templates/${id}/generate`, { method: 'POST' });
+  const res = await fetch(getApiUrl(`templates/${id}/generate`), { method: 'POST' });
   const data = await res.json();
   return data.content;
 }
 
 export async function generateDocument(templateId: number, values: Record<string, string>): Promise<string> {
-  const res = await fetch(`${API_URL}/documents/generate`, {
+  const res = await fetch(getApiUrl('documents/generate'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ templateId, values }),

--- a/frontend/src/pages/Agenda.tsx
+++ b/frontend/src/pages/Agenda.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Calendar, Plus } from 'lucide-react';
+import { getApiBaseUrl } from '@/lib/api';
 
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -10,7 +11,7 @@ import { AppointmentList } from '@/components/agenda/AppointmentList';
 import { statusDotClass } from '@/components/agenda/status';
 import { Appointment, AppointmentType, AppointmentStatus } from '@/types/agenda';
 
-const apiUrl = (import.meta.env.VITE_API_URL as string) || 'http://localhost:3001';
+const apiUrl = getApiBaseUrl();
 
 function joinUrl(base: string, path = '') {
   const b = base.replace(/\/+$/, '');

--- a/frontend/src/pages/Clientes.tsx
+++ b/frontend/src/pages/Clientes.tsx
@@ -31,8 +31,9 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Client } from "@/types/client";
+import { getApiBaseUrl } from "@/lib/api";
 
-const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+const apiUrl = getApiBaseUrl();
 
 function joinUrl(base: string, path = "") {
   const b = base.replace(/\/+$/, "");

--- a/frontend/src/pages/EditarCliente.tsx
+++ b/frontend/src/pages/EditarCliente.tsx
@@ -22,8 +22,9 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { toast } from "@/components/ui/use-toast";
+import { getApiBaseUrl } from "@/lib/api";
 
-const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+const apiUrl = getApiBaseUrl();
 
 function joinUrl(base: string, path = "") {
   const b = base.replace(/\/+$/, "");

--- a/frontend/src/pages/EditarOportunidade.tsx
+++ b/frontend/src/pages/EditarOportunidade.tsx
@@ -30,6 +30,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { toast } from "@/components/ui/use-toast";
+import { getApiBaseUrl } from "@/lib/api";
 
 const formSchema = z.object({
   tipo_processo: z.string().min(1, "Tipo de Processo é obrigatório"),
@@ -89,7 +90,7 @@ interface ClientOption extends Option {
 }
 
 export default function EditarOportunidade() {
-  const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+  const apiUrl = getApiBaseUrl();
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
 
@@ -1159,4 +1160,3 @@ export default function EditarOportunidade() {
     </div>
   );
 }
-

--- a/frontend/src/pages/NovaOportunidade.tsx
+++ b/frontend/src/pages/NovaOportunidade.tsx
@@ -30,6 +30,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { toast } from "@/components/ui/use-toast";
+import { getApiBaseUrl } from "@/lib/api";
 
 const formSchema = z.object({
   tipo_processo: z.string().min(1, "Tipo de Processo é obrigatório"),
@@ -88,7 +89,7 @@ interface ClientOption extends Option {
 }
 
 export default function NovaOportunidade() {
-  const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+  const apiUrl = getApiBaseUrl();
   const navigate = useNavigate();
 
   const [clients, setClients] = useState<ClientOption[]>([]);
@@ -1044,4 +1045,3 @@ export default function NovaOportunidade() {
     </div>
   );
 }
-

--- a/frontend/src/pages/NovoCliente.tsx
+++ b/frontend/src/pages/NovoCliente.tsx
@@ -22,8 +22,9 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { toast } from "@/components/ui/use-toast";
+import { getApiBaseUrl } from "@/lib/api";
 
-const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+const apiUrl = getApiBaseUrl();
 
 function joinUrl(base: string, path = "") {
   const b = base.replace(/\/+$/, "");

--- a/frontend/src/pages/Pipeline.tsx
+++ b/frontend/src/pages/Pipeline.tsx
@@ -27,6 +27,7 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select";
+import { getApiBaseUrl } from "@/lib/api";
 
 interface Opportunity {
   id: number;
@@ -53,7 +54,7 @@ interface Flow {
 }
 
 export default function Pipeline() {
-  const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+  const apiUrl = getApiBaseUrl();
   const navigate = useNavigate();
   const { fluxoId } = useParams<{ fluxoId?: string }>();
 

--- a/frontend/src/pages/PipelineMenu.tsx
+++ b/frontend/src/pages/PipelineMenu.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Plus } from "lucide-react";
+import { getApiBaseUrl } from "@/lib/api";
 
 interface MenuItem {
   id: string;
@@ -10,7 +11,7 @@ interface MenuItem {
 }
 
 export default function PipelineMenu() {
-  const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+  const apiUrl = getApiBaseUrl();
   const [menus, setMenus] = useState<MenuItem[]>([]);
   const navigate = useNavigate();
 
@@ -78,4 +79,3 @@ export default function PipelineMenu() {
     </div>
   );
 }
-

--- a/frontend/src/pages/Suporte.tsx
+++ b/frontend/src/pages/Suporte.tsx
@@ -14,8 +14,9 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { toast } from "@/components/ui/use-toast";
+import { getApiBaseUrl } from "@/lib/api";
 
-const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+const apiUrl = getApiBaseUrl();
 
 const formSchema = z.object({
   subject: z.string().min(1, "Assunto é obrigatório"),

--- a/frontend/src/pages/Tarefas.tsx
+++ b/frontend/src/pages/Tarefas.tsx
@@ -60,6 +60,7 @@ import {
   TooltipContent,
   TooltipProvider,
 } from '@/components/ui/tooltip';
+import { getApiBaseUrl } from '@/lib/api';
 
 interface Task {
   id: number;
@@ -135,7 +136,7 @@ interface ApiTask {
   concluido?: boolean;
 }
 
-const apiUrl = (import.meta.env.VITE_API_URL as string) || 'http://localhost:3001';
+const apiUrl = getApiBaseUrl();
 
 function joinUrl(base: string, path = '') {
   const b = base.replace(/\/+$/, '');

--- a/frontend/src/pages/VisualizarCliente.tsx
+++ b/frontend/src/pages/VisualizarCliente.tsx
@@ -34,9 +34,10 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { getApiBaseUrl } from "@/lib/api";
 
 
-const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+const apiUrl = getApiBaseUrl();
 
 function joinUrl(base: string, path = "") {
   const b = base.replace(/\/+$/, "");

--- a/frontend/src/pages/VisualizarOportunidade.tsx
+++ b/frontend/src/pages/VisualizarOportunidade.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { getApiBaseUrl } from "@/lib/api";
 
 import { Badge } from "@/components/ui/badge";
 
@@ -36,7 +37,7 @@ interface ParticipantData {
 export default function VisualizarOportunidade() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+  const apiUrl = getApiBaseUrl();
 
   const [opportunity, setOpportunity] = useState<OpportunityData | null>(null);
   const [snack, setSnack] = useState<{ open: boolean; message?: string }>({ open: false });

--- a/frontend/src/pages/configuracoes/Empresas.tsx
+++ b/frontend/src/pages/configuracoes/Empresas.tsx
@@ -11,8 +11,9 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { getApiBaseUrl } from "@/lib/api";
 
-const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+const apiUrl = getApiBaseUrl();
 
 function joinUrl(base: string, path = "") {
   const b = base.replace(/\/+$/, "");

--- a/frontend/src/pages/configuracoes/NovaEmpresa.tsx
+++ b/frontend/src/pages/configuracoes/NovaEmpresa.tsx
@@ -14,8 +14,9 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { toast } from "@/components/ui/use-toast";
+import { getApiBaseUrl } from "@/lib/api";
 
-const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+const apiUrl = getApiBaseUrl();
 
 function joinUrl(base: string, path = "") {
   const b = base.replace(/\/+$/, "");
@@ -184,4 +185,3 @@ export default function NovaEmpresa() {
     </div>
   );
 }
-

--- a/frontend/src/pages/configuracoes/Planos.tsx
+++ b/frontend/src/pages/configuracoes/Planos.tsx
@@ -10,6 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { getApiBaseUrl } from "@/lib/api";
 
 interface Plano {
   id: number;
@@ -24,7 +25,7 @@ function joinUrl(base: string, path = "") {
 }
 
 export default function Planos() {
-  const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+  const apiUrl = getApiBaseUrl();
   const [planos, setPlanos] = useState<Plano[]>([]);
   const [newPlano, setNewPlano] = useState({ nome: "", valor: "" });
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -206,4 +207,3 @@ export default function Planos() {
     </div>
   );
 }
-

--- a/frontend/src/pages/configuracoes/parametros/Etiquetas.tsx
+++ b/frontend/src/pages/configuracoes/parametros/Etiquetas.tsx
@@ -11,6 +11,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Checkbox } from "@/components/ui/checkbox";
+import { getApiBaseUrl } from "@/lib/api";
 
 interface Etiqueta {
   id: number;
@@ -26,7 +27,7 @@ interface FluxoTrabalhoItem {
 }
 
 export default function Etiquetas() {
-  const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+  const apiUrl = getApiBaseUrl();
 
   const [items, setItems] = useState<Etiqueta[]>([]);
   const [fluxos, setFluxos] = useState<FluxoTrabalhoItem[]>([]);
@@ -425,4 +426,3 @@ export default function Etiquetas() {
     </div>
   );
 }
-

--- a/frontend/src/pages/configuracoes/parametros/FluxoTrabalho.tsx
+++ b/frontend/src/pages/configuracoes/parametros/FluxoTrabalho.tsx
@@ -11,6 +11,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Checkbox } from "@/components/ui/checkbox";
+import { getApiBaseUrl } from "@/lib/api";
 
 interface FluxoTrabalhoItem {
   id: number;
@@ -20,7 +21,7 @@ interface FluxoTrabalhoItem {
 }
 
 export default function FluxoTrabalho() {
-  const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+  const apiUrl = getApiBaseUrl();
 
   const [items, setItems] = useState<FluxoTrabalhoItem[]>([]);
   const [newNome, setNewNome] = useState("");
@@ -322,4 +323,3 @@ export default function FluxoTrabalho() {
     </div>
   );
 }
-

--- a/frontend/src/pages/configuracoes/parametros/ParameterPage.tsx
+++ b/frontend/src/pages/configuracoes/parametros/ParameterPage.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { getApiBaseUrl } from "@/lib/api";
 
 interface Item { id: number; nome: string; [key: string]: string | number | boolean }
 
@@ -28,7 +29,7 @@ function joinUrl(base: string, path = "") {
 export default function ParameterPage({
     title, description, placeholder, emptyMessage, endpoint, booleanFields,
 }: ParameterPageProps) {
-    const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+    const apiUrl = getApiBaseUrl();
 
     const [items, setItems] = useState<Item[]>([]);
     const [newItem, setNewItem] = useState("");

--- a/frontend/src/pages/configuracoes/usuarios/NovoUsuario.tsx
+++ b/frontend/src/pages/configuracoes/usuarios/NovoUsuario.tsx
@@ -26,8 +26,9 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Label } from "@/components/ui/label";
 import { Upload } from "lucide-react";
 import { toast } from "@/components/ui/use-toast";
+import { getApiBaseUrl } from "@/lib/api";
 
-const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+const apiUrl = getApiBaseUrl();
 
 function joinUrl(base: string, path = "") {
   const b = base.replace(/\/+$/, "");

--- a/frontend/src/pages/configuracoes/usuarios/Usuarios.tsx
+++ b/frontend/src/pages/configuracoes/usuarios/Usuarios.tsx
@@ -23,8 +23,9 @@ import {
 } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { User } from "@/types/user";
+import { getApiBaseUrl } from "@/lib/api";
 
-const apiUrl = (import.meta.env.VITE_API_URL as string) || "http://localhost:3001";
+const apiUrl = getApiBaseUrl();
 
 function joinUrl(base: string, path = "") {
   const b = base.replace(/\/+$/, "");


### PR DESCRIPTION
## Summary
- add a shared API helper that resolves the backend base URL from environment variables or the current window origin
- update frontend modules to consume the helper instead of hardcoding localhost defaults so production builds call the deployed API
- document that the frontend now defaults to the hosting domain when `VITE_API_URL` is not provided

## Testing
- npm run build (frontend)
- npm run build (backend)

------
https://chatgpt.com/codex/tasks/task_e_68c86edeb2608326a4cc8d4b7cf5d7fc