### PR TITLE
Atualiza endpoint de planos com novos campos

### DIFF
--- a/backend/src/controllers/planoController.ts
+++ b/backend/src/controllers/planoController.ts
@@ -1,10 +1,28 @@
 import { Request, Response } from 'express';
 import pool from '../services/db';
 
+const RECORRENCIAS_PERMITIDAS = ['mensal', 'anual', 'nenhuma'] as const;
+type Recorrencia = (typeof RECORRENCIAS_PERMITIDAS)[number];
+
+const isRecorrenciaValida = (value: unknown): value is Recorrencia =>
+  typeof value === 'string' && RECORRENCIAS_PERMITIDAS.includes(value as Recorrencia);
+
+type PlanoRow = {
+  id: number;
+  nome: string;
+  valor: number;
+  ativo: boolean;
+  datacadastro: Date;
+  descricao: string;
+  recorrencia: Recorrencia | null;
+  qtde_usuarios: number | null;
+  recursos: string | null;
+};
+
 export const listPlanos = async (_req: Request, res: Response) => {
   try {
     const result = await pool.query(
-      'SELECT id, nome, valor, ativo, datacadastro FROM public.planos'
+      'SELECT id, nome, valor, ativo, datacadastro, descricao, recorrencia, qtde_usuarios, recursos FROM public.planos'
     );
     res.json(result.rows);
   } catch (error) {
@@ -14,11 +32,29 @@ export const listPlanos = async (_req: Request, res: Response) => {
 };
 
 export const createPlano = async (req: Request, res: Response) => {
-  const { nome, valor, ativo } = req.body;
+  const {
+    nome,
+    valor,
+    ativo = true,
+    descricao,
+    recorrencia = 'nenhuma',
+    qtde_usuarios,
+    recursos,
+  } = req.body;
+
+  const descricaoValue: string = descricao ?? '';
+  const ativoValue: boolean = ativo ?? true;
+  const qtdeUsuariosValue = qtde_usuarios ?? null;
+  const recursosValue = recursos ?? null;
+
+  if (recorrencia !== null && !isRecorrenciaValida(recorrencia)) {
+    return res.status(400).json({ error: 'Recorrência inválida' });
+  }
+
   try {
     const result = await pool.query(
-      'INSERT INTO public.planos (nome, valor, ativo, datacadastro) VALUES ($1, $2, $3, NOW()) RETURNING id, nome, valor, ativo, datacadastro',
-      [nome, valor, ativo]
+      'INSERT INTO public.planos (nome, valor, ativo, datacadastro, descricao, recorrencia, qtde_usuarios, recursos) VALUES ($1, $2, $3, NOW(), $4, $5, $6, $7) RETURNING id, nome, valor, ativo, datacadastro, descricao, recorrencia, qtde_usuarios, recursos',
+      [nome, valor, ativoValue, descricaoValue, recorrencia, qtdeUsuariosValue, recursosValue]
     );
     res.status(201).json(result.rows[0]);
   } catch (error) {
@@ -29,15 +65,69 @@ export const createPlano = async (req: Request, res: Response) => {
 
 export const updatePlano = async (req: Request, res: Response) => {
   const { id } = req.params;
-  const { nome, valor, ativo } = req.body;
+  const {
+    nome,
+    valor,
+    ativo,
+    descricao,
+    recorrencia,
+    qtde_usuarios,
+    recursos,
+  } = req.body;
+
   try {
-    const result = await pool.query(
-      'UPDATE public.planos SET nome = $1, valor = $2, ativo = $3 WHERE id = $4 RETURNING id, nome, valor, ativo, datacadastro',
-      [nome, valor, ativo, id]
+    const existingResult = await pool.query(
+      'SELECT id, nome, valor, ativo, datacadastro, descricao, recorrencia, qtde_usuarios, recursos FROM public.planos WHERE id = $1',
+      [id]
     );
-    if (result.rowCount === 0) {
+
+    if (existingResult.rowCount === 0) {
       return res.status(404).json({ error: 'Plano não encontrado' });
     }
+
+    const currentPlano = existingResult.rows[0] as PlanoRow;
+
+    const hasQtdeUsuarios = Object.prototype.hasOwnProperty.call(req.body, 'qtde_usuarios');
+    const hasRecursos = Object.prototype.hasOwnProperty.call(req.body, 'recursos');
+    const hasRecorrencia = Object.prototype.hasOwnProperty.call(req.body, 'recorrencia');
+
+    let updatedRecorrencia: Recorrencia | null;
+    if (hasRecorrencia) {
+      if (recorrencia === null) {
+        updatedRecorrencia = null;
+      } else if (recorrencia === undefined) {
+        updatedRecorrencia = currentPlano.recorrencia;
+      } else {
+        updatedRecorrencia = recorrencia;
+      }
+    } else {
+      updatedRecorrencia = currentPlano.recorrencia;
+    }
+
+    if (updatedRecorrencia !== null && !isRecorrenciaValida(updatedRecorrencia)) {
+      return res.status(400).json({ error: 'Recorrência inválida' });
+    }
+
+    const updatedQtdeUsuarios = hasQtdeUsuarios
+      ? qtde_usuarios ?? null
+      : currentPlano.qtde_usuarios;
+
+    const updatedRecursos = hasRecursos ? recursos ?? null : currentPlano.recursos;
+
+    const result = await pool.query(
+      'UPDATE public.planos SET nome = $1, valor = $2, ativo = $3, descricao = $4, recorrencia = $5, qtde_usuarios = $6, recursos = $7 WHERE id = $8 RETURNING id, nome, valor, ativo, datacadastro, descricao, recorrencia, qtde_usuarios, recursos',
+      [
+        nome ?? currentPlano.nome,
+        valor ?? currentPlano.valor,
+        ativo ?? currentPlano.ativo,
+        (descricao ?? currentPlano.descricao) ?? '',
+        updatedRecorrencia,
+        updatedQtdeUsuarios,
+        updatedRecursos,
+        id,
+      ]
+    );
+
     res.json(result.rows[0]);
   } catch (error) {
     console.error(error);

--- a/backend/src/routes/planoRoutes.ts
+++ b/backend/src/routes/planoRoutes.ts
@@ -27,6 +27,18 @@ const router = Router();
  *           format: float
  *         ativo:
  *           type: boolean
+ *         descricao:
+ *           type: string
+ *         recorrencia:
+ *           type: string
+ *           enum: [mensal, anual, nenhuma]
+ *           nullable: true
+ *         qtde_usuarios:
+ *           type: integer
+ *           nullable: true
+ *         recursos:
+ *           type: string
+ *           nullable: true
  *         datacadastro:
  *           type: string
  *           format: date-time
@@ -70,6 +82,18 @@ router.get('/planos', listPlanos);
  *                 format: float
  *               ativo:
  *                 type: boolean
+ *               descricao:
+ *                 type: string
+ *               recorrencia:
+ *                 type: string
+ *                 enum: [mensal, anual, nenhuma]
+ *                 nullable: true
+ *               qtde_usuarios:
+ *                 type: integer
+ *                 nullable: true
+ *               recursos:
+ *                 type: string
+ *                 nullable: true
  *     responses:
  *       201:
  *         description: Plano criado
@@ -106,6 +130,18 @@ router.post('/planos', createPlano);
  *                 format: float
  *               ativo:
  *                 type: boolean
+ *               descricao:
+ *                 type: string
+ *               recorrencia:
+ *                 type: string
+ *                 enum: [mensal, anual, nenhuma]
+ *                 nullable: true
+ *               qtde_usuarios:
+ *                 type: integer
+ *                 nullable: true
+ *               recursos:
+ *                 type: string
+ *                 nullable: true
  *     responses:
  *       200:
  *         description: Plano atualizado


### PR DESCRIPTION
## Summary
- inclui suporte aos campos descricao, recorrencia, qtde_usuarios e recursos em todas as operações do endpoint de planos
- adiciona validacao basica da recorrencia e atualiza a documentacao Swagger para refletir a nova estrutura

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c874a678c08326827c29be60da6b94