### PR TITLE
feat: allow updating opportunity status from view

### DIFF
--- a/backend/src/controllers/oportunidadeController.ts
+++ b/backend/src/controllers/oportunidadeController.ts
@@ -291,6 +291,40 @@ export const updateOportunidade = async (req: Request, res: Response) => {
   }
 };
 
+export const updateOportunidadeStatus = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const { status_id } = req.body as { status_id?: unknown };
+
+  const parsedStatus =
+    status_id === null || status_id === undefined || status_id === ''
+      ? null
+      : Number(status_id);
+
+  if (parsedStatus !== null && Number.isNaN(parsedStatus)) {
+    return res.status(400).json({ error: 'status_id inválido' });
+  }
+
+  try {
+    const result = await pool.query(
+      `UPDATE public.oportunidades
+       SET status_id = $1,
+           ultima_atualizacao = NOW()
+       WHERE id = $2
+       RETURNING id, status_id, ultima_atualizacao`,
+      [parsedStatus, id]
+    );
+
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: 'Oportunidade não encontrada' });
+    }
+
+    res.json(result.rows[0]);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
 export const updateOportunidadeEtapa = async (req: Request, res: Response) => {
   const { id } = req.params;
   const { etapa_id } = req.body;

--- a/backend/src/routes/oportunidadeRoutes.ts
+++ b/backend/src/routes/oportunidadeRoutes.ts
@@ -6,6 +6,7 @@ import {
   listEnvolvidosByOportunidade,
   createOportunidade,
   updateOportunidade,
+  updateOportunidadeStatus,
   updateOportunidadeEtapa,
   deleteOportunidade,
 } from '../controllers/oportunidadeController';
@@ -355,6 +356,39 @@ router.post('/oportunidades', createOportunidade);
  *         description: Oportunidade não encontrada
  */
 router.put('/oportunidades/:id', updateOportunidade);
+
+/**
+ * @swagger
+ * /api/oportunidades/{id}/status:
+ *   patch:
+ *     summary: Atualiza o status de uma oportunidade
+ *     tags: [Oportunidades]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               status_id:
+ *                 type: integer
+ *     responses:
+ *       200:
+ *         description: Status atualizado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Oportunidade'
+ *       404:
+ *         description: Oportunidade não encontrada
+ */
+router.patch('/oportunidades/:id/status', updateOportunidadeStatus);
 
 /**
  * @swagger


### PR DESCRIPTION
## Summary
- add a dedicated PATCH endpoint to update only the status of an oportunidade
- load available status options and surface them in the visualizar proposta header
- persist inline status changes with feedback while keeping existing details intact

## Testing
- npm run build (backend)
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68c8821744308326859727893666d416