### PR TITLE
Implement support module

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -29,6 +29,8 @@ npm test
 
 O arquivo `sql/templates.sql` contém a estrutura mínima para as tabelas `templates` e `tags` utilizadas pelos novos endpoints de documentos. Execute esse script em um banco PostgreSQL antes de iniciar o servidor.
 
+O script `sql/support.sql` cria a tabela `support_requests` utilizada pelo módulo de suporte.
+
 ## CORS
 
 Por padrão o backend libera requisições vindas de `localhost` e do domínio `https://jusconnec.quantumtecnologia.com.br`. Caso precise habilitar outros hosts, defina a variável de ambiente `CORS_ALLOWED_ORIGINS` com uma lista de URLs separadas por vírgula:

--- a/backend/dist/controllers/supportController.js
+++ b/backend/dist/controllers/supportController.js
@@ -1,18 +1,173 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.createSupportRequest = createSupportRequest;
-const supportRequests = [];
-function createSupportRequest(req, res) {
-    const { subject, description } = req.body;
-    if (!subject || !description) {
-        return res.status(400).json({ message: 'Subject and description are required' });
+exports.listSupportRequests = listSupportRequests;
+exports.getSupportRequest = getSupportRequest;
+exports.updateSupportRequest = updateSupportRequest;
+const supportService_1 = __importStar(require("../services/supportService"));
+const supportService = new supportService_1.default();
+function parseIdParam(param) {
+    const value = Number(param);
+    if (!Number.isInteger(value) || value <= 0) {
+        return null;
     }
-    const request = {
-        id: supportRequests.length + 1,
-        subject,
-        description,
-        createdAt: new Date().toISOString(),
+    return value;
+}
+function extractStatus(value) {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+    const normalized = value.trim().toLowerCase();
+    return normalized ? normalized : undefined;
+}
+async function createSupportRequest(req, res) {
+    const { subject, description, requesterName, requesterEmail, status } = req.body;
+    const input = {
+        subject: subject ?? '',
+        description: description ?? '',
+        requesterName: requesterName ?? undefined,
+        requesterEmail: requesterEmail ?? undefined,
     };
-    supportRequests.push(request);
-    return res.status(201).json(request);
+    if (typeof status === 'string' && status.trim()) {
+        input.status = status.trim().toLowerCase();
+    }
+    try {
+        const request = await supportService.create(input);
+        return res.status(201).json(request);
+    }
+    catch (error) {
+        if (error instanceof supportService_1.ValidationError) {
+            return res.status(400).json({ error: error.message });
+        }
+        console.error('Failed to create support request:', error);
+        return res.status(500).json({ error: 'Internal server error' });
+    }
+}
+async function listSupportRequests(req, res) {
+    const options = {};
+    const pageParam = req.query.page;
+    const pageSizeParam = req.query.pageSize ?? req.query.limit; // allow limit alias
+    if (typeof pageParam === 'string') {
+        const parsed = Number(pageParam);
+        if (Number.isFinite(parsed) && parsed > 0) {
+            options.page = Math.floor(parsed);
+        }
+        else {
+            return res.status(400).json({ error: 'Invalid page parameter' });
+        }
+    }
+    if (typeof pageSizeParam === 'string') {
+        const parsed = Number(pageSizeParam);
+        if (Number.isFinite(parsed) && parsed > 0) {
+            options.pageSize = Math.floor(parsed);
+        }
+        else {
+            return res.status(400).json({ error: 'Invalid pageSize parameter' });
+        }
+    }
+    const statusFilter = extractStatus(req.query.status);
+    if (statusFilter) {
+        options.status = statusFilter;
+    }
+    if (typeof req.query.search === 'string') {
+        options.search = req.query.search;
+    }
+    try {
+        const result = await supportService.list(options);
+        return res.json(result);
+    }
+    catch (error) {
+        if (error instanceof supportService_1.ValidationError) {
+            return res.status(400).json({ error: error.message });
+        }
+        console.error('Failed to list support requests:', error);
+        return res.status(500).json({ error: 'Internal server error' });
+    }
+}
+async function getSupportRequest(req, res) {
+    const requestId = parseIdParam(req.params.id);
+    if (!requestId) {
+        return res.status(400).json({ error: 'Invalid support request id' });
+    }
+    try {
+        const request = await supportService.findById(requestId);
+        if (!request) {
+            return res.status(404).json({ error: 'Support request not found' });
+        }
+        return res.json(request);
+    }
+    catch (error) {
+        console.error('Failed to fetch support request:', error);
+        return res.status(500).json({ error: 'Internal server error' });
+    }
+}
+async function updateSupportRequest(req, res) {
+    const requestId = parseIdParam(req.params.id);
+    if (!requestId) {
+        return res.status(400).json({ error: 'Invalid support request id' });
+    }
+    const { subject, description, requesterName, requesterEmail, status } = req.body;
+    const updates = {};
+    if (subject !== undefined) {
+        updates.subject = subject;
+    }
+    if (description !== undefined) {
+        updates.description = description;
+    }
+    if (requesterName !== undefined) {
+        updates.requesterName = requesterName;
+    }
+    if (requesterEmail !== undefined) {
+        updates.requesterEmail = requesterEmail;
+    }
+    if (typeof status === 'string' && status.trim()) {
+        updates.status = status.trim().toLowerCase();
+    }
+    try {
+        const updated = await supportService.update(requestId, updates);
+        if (!updated) {
+            return res.status(404).json({ error: 'Support request not found' });
+        }
+        return res.json(updated);
+    }
+    catch (error) {
+        if (error instanceof supportService_1.ValidationError) {
+            return res.status(400).json({ error: error.message });
+        }
+        console.error('Failed to update support request:', error);
+        return res.status(500).json({ error: 'Internal server error' });
+    }
 }

--- a/backend/dist/routes/supportRoutes.js
+++ b/backend/dist/routes/supportRoutes.js
@@ -12,9 +12,97 @@ const router = (0, express_1.Router)();
 /**
  * @swagger
  * /api/support:
+ *   get:
+ *     summary: Lista solicitações de suporte
+ *     tags: [Suporte]
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *       - in: query
+ *         name: pageSize
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: [open, in_progress, resolved, closed]
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Lista de solicitações de suporte
+ */
+router.get('/support', supportController_1.listSupportRequests);
+/**
+ * @swagger
+ * /api/support:
  *   post:
  *     summary: Cria uma nova solicitação de suporte
  *     tags: [Suporte]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - subject
+ *               - description
+ *             properties:
+ *               subject:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *               requesterName:
+ *                 type: string
+ *               requesterEmail:
+ *                 type: string
+ *               status:
+ *                 type: string
+ *                 enum: [open, in_progress, resolved, closed]
+ *     responses:
+ *       201:
+ *         description: Solicitação criada
+ */
+router.post('/support', supportController_1.createSupportRequest);
+/**
+ * @swagger
+ * /api/support/{id}:
+ *   get:
+ *     summary: Obtém uma solicitação de suporte pelo ID
+ *     tags: [Suporte]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Solicitação encontrada
+ *       404:
+ *         description: Solicitação não encontrada
+ */
+router.get('/support/:id', supportController_1.getSupportRequest);
+/**
+ * @swagger
+ * /api/support/{id}:
+ *   patch:
+ *     summary: Atualiza uma solicitação de suporte
+ *     tags: [Suporte]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
  *     requestBody:
  *       required: true
  *       content:
@@ -26,9 +114,18 @@ const router = (0, express_1.Router)();
  *                 type: string
  *               description:
  *                 type: string
+ *               requesterName:
+ *                 type: string
+ *               requesterEmail:
+ *                 type: string
+ *               status:
+ *                 type: string
+ *                 enum: [open, in_progress, resolved, closed]
  *     responses:
- *       201:
- *         description: Solicitação criada
+ *       200:
+ *         description: Solicitação atualizada
+ *       404:
+ *         description: Solicitação não encontrada
  */
-router.post('/support', supportController_1.createSupportRequest);
+router.patch('/support/:id', supportController_1.updateSupportRequest);
 exports.default = router;

--- a/backend/dist/services/supportService.js
+++ b/backend/dist/services/supportService.js
@@ -1,0 +1,172 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.SupportService = exports.ValidationError = exports.SUPPORT_STATUS_VALUES = void 0;
+const db_1 = __importDefault(require("./db"));
+exports.SUPPORT_STATUS_VALUES = ['open', 'in_progress', 'resolved', 'closed'];
+class ValidationError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'ValidationError';
+    }
+}
+exports.ValidationError = ValidationError;
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 100;
+function normalizeText(value) {
+    if (value === null || value === undefined) {
+        return null;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+}
+function assertValidStatus(status) {
+    if (!exports.SUPPORT_STATUS_VALUES.includes(status)) {
+        throw new ValidationError('Invalid status provided');
+    }
+}
+function formatDate(value) {
+    if (value instanceof Date) {
+        return value.toISOString();
+    }
+    return new Date(value).toISOString();
+}
+function mapRow(row) {
+    return {
+        id: row.id,
+        subject: row.subject,
+        description: row.description,
+        status: row.status,
+        requesterName: row.requester_name,
+        requesterEmail: row.requester_email,
+        createdAt: formatDate(row.created_at),
+        updatedAt: formatDate(row.updated_at),
+    };
+}
+class SupportService {
+    constructor(db = db_1.default) {
+        this.db = db;
+    }
+    async create(input) {
+        const subject = normalizeText(input.subject ?? null);
+        const description = normalizeText(input.description ?? null);
+        if (!subject) {
+            throw new ValidationError('Subject is required');
+        }
+        if (!description) {
+            throw new ValidationError('Description is required');
+        }
+        const status = input.status ?? 'open';
+        assertValidStatus(status);
+        const requesterName = normalizeText(input.requesterName);
+        const requesterEmail = normalizeText(input.requesterEmail);
+        const result = await this.db.query(`INSERT INTO support_requests (subject, description, status, requester_name, requester_email)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING id, subject, description, status, requester_name, requester_email, created_at, updated_at`, [subject, description, status, requesterName, requesterEmail]);
+        return mapRow(result.rows[0]);
+    }
+    async list(options = {}) {
+        const page = options.page && options.page > 0 ? Math.floor(options.page) : 1;
+        const pageSizeRaw = options.pageSize && options.pageSize > 0 ? Math.floor(options.pageSize) : DEFAULT_PAGE_SIZE;
+        const pageSize = Math.min(pageSizeRaw, MAX_PAGE_SIZE);
+        const offset = (page - 1) * pageSize;
+        const conditions = [];
+        const values = [];
+        if (options.status) {
+            assertValidStatus(options.status);
+            values.push(options.status);
+            conditions.push(`status = $${values.length}`);
+        }
+        if (options.search) {
+            const searchValue = `%${options.search.trim()}%`;
+            values.push(searchValue);
+            conditions.push(`(subject ILIKE $${values.length} OR description ILIKE $${values.length})`);
+        }
+        const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+        const baseQuery = `SELECT id, subject, description, status, requester_name, requester_email, created_at, updated_at
+      FROM support_requests
+      ${whereClause}
+      ORDER BY created_at DESC`;
+        const dataQuery = `${baseQuery}
+      LIMIT $${values.length + 1}
+      OFFSET $${values.length + 2}`;
+        const dataValues = [...values, pageSize, offset];
+        const itemsResult = await this.db.query(dataQuery, dataValues);
+        const totalResult = await this.db.query(`SELECT COUNT(*)::int AS total FROM support_requests ${whereClause}`, values);
+        const totalRow = totalResult.rows[0];
+        const total = totalRow ? Number(totalRow.total) : 0;
+        return {
+            items: itemsResult.rows.map(mapRow),
+            total,
+            page,
+            pageSize,
+        };
+    }
+    async findById(id) {
+        const result = await this.db.query(`SELECT id, subject, description, status, requester_name, requester_email, created_at, updated_at
+       FROM support_requests
+       WHERE id = $1`, [id]);
+        if (result.rowCount === 0) {
+            return null;
+        }
+        return mapRow(result.rows[0]);
+    }
+    async update(id, updates) {
+        const fields = [];
+        const values = [];
+        let index = 1;
+        if (typeof updates.subject === 'string') {
+            const subject = normalizeText(updates.subject);
+            if (!subject) {
+                throw new ValidationError('Subject cannot be empty');
+            }
+            fields.push(`subject = $${index}`);
+            values.push(subject);
+            index += 1;
+        }
+        if (typeof updates.description === 'string') {
+            const description = normalizeText(updates.description);
+            if (!description) {
+                throw new ValidationError('Description cannot be empty');
+            }
+            fields.push(`description = $${index}`);
+            values.push(description);
+            index += 1;
+        }
+        if (updates.status !== undefined) {
+            assertValidStatus(updates.status);
+            fields.push(`status = $${index}`);
+            values.push(updates.status);
+            index += 1;
+        }
+        if (updates.requesterName !== undefined) {
+            const name = normalizeText(updates.requesterName);
+            fields.push(`requester_name = $${index}`);
+            values.push(name);
+            index += 1;
+        }
+        if (updates.requesterEmail !== undefined) {
+            const email = normalizeText(updates.requesterEmail);
+            fields.push(`requester_email = $${index}`);
+            values.push(email);
+            index += 1;
+        }
+        if (fields.length === 0) {
+            throw new ValidationError('No fields provided to update');
+        }
+        const query = `UPDATE support_requests
+      SET ${fields.join(', ')}, updated_at = NOW()
+      WHERE id = $${index}
+      RETURNING id, subject, description, status, requester_name, requester_email, created_at, updated_at`;
+        values.push(id);
+        const result = await this.db.query(query, values);
+        if (result.rowCount === 0) {
+            return null;
+        }
+        return mapRow(result.rows[0]);
+    }
+}
+exports.SupportService = SupportService;
+exports.default = SupportService;

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true });\"",
     "build": "npm run clean && tsc -p tsconfig.build.json",
     "start": "node dist/index.js",
-    "test": "node --test --import tsx tests/templateService.test.ts"
+    "test": "node --test --import tsx tests/*.test.ts"
 
   },
   "dependencies": {

--- a/backend/sql/support.sql
+++ b/backend/sql/support.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS support_requests (
+  id SERIAL PRIMARY KEY,
+  subject TEXT NOT NULL,
+  description TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'in_progress', 'resolved', 'closed')),
+  requester_name TEXT,
+  requester_email TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_support_requests_status ON support_requests (status);
+CREATE INDEX IF NOT EXISTS idx_support_requests_created_at ON support_requests (created_at DESC);

--- a/backend/src/controllers/supportController.ts
+++ b/backend/src/controllers/supportController.ts
@@ -1,28 +1,166 @@
 import { Request, Response } from 'express';
+import SupportService, {
+  CreateSupportRequestInput,
+  ListSupportRequestsOptions,
+  SupportStatus,
+  UpdateSupportRequestInput,
+  ValidationError,
+} from '../services/supportService';
 
-interface SupportRequest {
-  id: number;
-  subject: string;
-  description: string;
-  createdAt: string;
+const supportService = new SupportService();
+
+function parseIdParam(param: string): number | null {
+  const value = Number(param);
+  if (!Number.isInteger(value) || value <= 0) {
+    return null;
+  }
+  return value;
 }
 
-const supportRequests: SupportRequest[] = [];
+function extractStatus(value: unknown): SupportStatus | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized ? (normalized as SupportStatus) : undefined;
+}
 
-export function createSupportRequest(req: Request, res: Response) {
-  const { subject, description } = req.body as {
+export async function createSupportRequest(req: Request, res: Response) {
+  const { subject, description, requesterName, requesterEmail, status } = req.body as {
     subject?: string;
     description?: string;
+    requesterName?: string | null;
+    requesterEmail?: string | null;
+    status?: string;
   };
-  if (!subject || !description) {
-    return res.status(400).json({ message: 'Subject and description are required' });
+
+  const input: CreateSupportRequestInput = {
+    subject: subject ?? '',
+    description: description ?? '',
+    requesterName: requesterName ?? undefined,
+    requesterEmail: requesterEmail ?? undefined,
+  };
+
+  if (typeof status === 'string' && status.trim()) {
+    input.status = status.trim().toLowerCase() as SupportStatus;
   }
-  const request: SupportRequest = {
-    id: supportRequests.length + 1,
-    subject,
-    description,
-    createdAt: new Date().toISOString(),
+
+  try {
+    const request = await supportService.create(input);
+    return res.status(201).json(request);
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return res.status(400).json({ error: error.message });
+    }
+    console.error('Failed to create support request:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}
+
+export async function listSupportRequests(req: Request, res: Response) {
+  const options: ListSupportRequestsOptions = {};
+
+  const pageParam = req.query.page;
+  const pageSizeParam = req.query.pageSize ?? req.query.limit; // allow limit alias
+
+  if (typeof pageParam === 'string') {
+    const parsed = Number(pageParam);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      options.page = Math.floor(parsed);
+    } else {
+      return res.status(400).json({ error: 'Invalid page parameter' });
+    }
+  }
+
+  if (typeof pageSizeParam === 'string') {
+    const parsed = Number(pageSizeParam);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      options.pageSize = Math.floor(parsed);
+    } else {
+      return res.status(400).json({ error: 'Invalid pageSize parameter' });
+    }
+  }
+
+  const statusFilter = extractStatus(req.query.status);
+  if (statusFilter) {
+    options.status = statusFilter;
+  }
+
+  if (typeof req.query.search === 'string') {
+    options.search = req.query.search;
+  }
+
+  try {
+    const result = await supportService.list(options);
+    return res.json(result);
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return res.status(400).json({ error: error.message });
+    }
+    console.error('Failed to list support requests:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}
+
+export async function getSupportRequest(req: Request, res: Response) {
+  const requestId = parseIdParam(req.params.id);
+
+  if (!requestId) {
+    return res.status(400).json({ error: 'Invalid support request id' });
+  }
+
+  try {
+    const request = await supportService.findById(requestId);
+    if (!request) {
+      return res.status(404).json({ error: 'Support request not found' });
+    }
+    return res.json(request);
+  } catch (error) {
+    console.error('Failed to fetch support request:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}
+
+export async function updateSupportRequest(req: Request, res: Response) {
+  const requestId = parseIdParam(req.params.id);
+
+  if (!requestId) {
+    return res.status(400).json({ error: 'Invalid support request id' });
+  }
+
+  const { subject, description, requesterName, requesterEmail, status } = req.body as UpdateSupportRequestInput & {
+    status?: string;
   };
-  supportRequests.push(request);
-  return res.status(201).json(request);
+
+  const updates: UpdateSupportRequestInput = {};
+
+  if (subject !== undefined) {
+    updates.subject = subject;
+  }
+  if (description !== undefined) {
+    updates.description = description;
+  }
+  if (requesterName !== undefined) {
+    updates.requesterName = requesterName;
+  }
+  if (requesterEmail !== undefined) {
+    updates.requesterEmail = requesterEmail;
+  }
+  if (typeof status === 'string' && status.trim()) {
+    updates.status = status.trim().toLowerCase() as SupportStatus;
+  }
+
+  try {
+    const updated = await supportService.update(requestId, updates);
+    if (!updated) {
+      return res.status(404).json({ error: 'Support request not found' });
+    }
+    return res.json(updated);
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return res.status(400).json({ error: error.message });
+    }
+    console.error('Failed to update support request:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
 }

--- a/backend/src/routes/supportRoutes.ts
+++ b/backend/src/routes/supportRoutes.ts
@@ -1,5 +1,10 @@
 import { Router } from 'express';
-import { createSupportRequest } from '../controllers/supportController';
+import {
+  createSupportRequest,
+  getSupportRequest,
+  listSupportRequests,
+  updateSupportRequest,
+} from '../controllers/supportController';
 
 const router = Router();
 
@@ -13,9 +18,100 @@ const router = Router();
 /**
  * @swagger
  * /api/support:
+ *   get:
+ *     summary: Lista solicitações de suporte
+ *     tags: [Suporte]
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *       - in: query
+ *         name: pageSize
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: [open, in_progress, resolved, closed]
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Lista de solicitações de suporte
+ */
+router.get('/support', listSupportRequests);
+
+/**
+ * @swagger
+ * /api/support:
  *   post:
  *     summary: Cria uma nova solicitação de suporte
  *     tags: [Suporte]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - subject
+ *               - description
+ *             properties:
+ *               subject:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *               requesterName:
+ *                 type: string
+ *               requesterEmail:
+ *                 type: string
+ *               status:
+ *                 type: string
+ *                 enum: [open, in_progress, resolved, closed]
+ *     responses:
+ *       201:
+ *         description: Solicitação criada
+ */
+router.post('/support', createSupportRequest);
+
+/**
+ * @swagger
+ * /api/support/{id}:
+ *   get:
+ *     summary: Obtém uma solicitação de suporte pelo ID
+ *     tags: [Suporte]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Solicitação encontrada
+ *       404:
+ *         description: Solicitação não encontrada
+ */
+router.get('/support/:id', getSupportRequest);
+
+/**
+ * @swagger
+ * /api/support/{id}:
+ *   patch:
+ *     summary: Atualiza uma solicitação de suporte
+ *     tags: [Suporte]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
  *     requestBody:
  *       required: true
  *       content:
@@ -27,10 +123,19 @@ const router = Router();
  *                 type: string
  *               description:
  *                 type: string
+ *               requesterName:
+ *                 type: string
+ *               requesterEmail:
+ *                 type: string
+ *               status:
+ *                 type: string
+ *                 enum: [open, in_progress, resolved, closed]
  *     responses:
- *       201:
- *         description: Solicitação criada
+ *       200:
+ *         description: Solicitação atualizada
+ *       404:
+ *         description: Solicitação não encontrada
  */
-router.post('/support', createSupportRequest);
+router.patch('/support/:id', updateSupportRequest);
 
 export default router;

--- a/backend/src/services/supportService.ts
+++ b/backend/src/services/supportService.ts
@@ -1,0 +1,270 @@
+import pool from './db';
+import { QueryResultRow } from 'pg';
+
+export const SUPPORT_STATUS_VALUES = ['open', 'in_progress', 'resolved', 'closed'] as const;
+export type SupportStatus = (typeof SUPPORT_STATUS_VALUES)[number];
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
+  }
+}
+
+type Queryable = {
+  query: (text: string, params?: unknown[]) => Promise<{ rows: QueryResultRow[]; rowCount: number }>;
+};
+
+export interface SupportRequest {
+  id: number;
+  subject: string;
+  description: string;
+  status: SupportStatus;
+  requesterName: string | null;
+  requesterEmail: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateSupportRequestInput {
+  subject: string;
+  description: string;
+  requesterName?: string | null;
+  requesterEmail?: string | null;
+  status?: SupportStatus;
+}
+
+export interface UpdateSupportRequestInput {
+  subject?: string;
+  description?: string;
+  status?: SupportStatus;
+  requesterName?: string | null;
+  requesterEmail?: string | null;
+}
+
+export interface ListSupportRequestsOptions {
+  status?: SupportStatus;
+  search?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface SupportRequestList {
+  items: SupportRequest[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+interface SupportRequestRow extends QueryResultRow {
+  id: number;
+  subject: string;
+  description: string;
+  status: SupportStatus;
+  requester_name: string | null;
+  requester_email: string | null;
+  created_at: string | Date;
+  updated_at: string | Date;
+}
+
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 100;
+
+function normalizeText(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function assertValidStatus(status: string): asserts status is SupportStatus {
+  if (!SUPPORT_STATUS_VALUES.includes(status as SupportStatus)) {
+    throw new ValidationError('Invalid status provided');
+  }
+}
+
+function formatDate(value: string | Date): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  return new Date(value).toISOString();
+}
+
+function mapRow(row: SupportRequestRow): SupportRequest {
+  return {
+    id: row.id,
+    subject: row.subject,
+    description: row.description,
+    status: row.status,
+    requesterName: row.requester_name,
+    requesterEmail: row.requester_email,
+    createdAt: formatDate(row.created_at),
+    updatedAt: formatDate(row.updated_at),
+  };
+}
+
+export class SupportService {
+  constructor(private readonly db: Queryable = pool) {}
+
+  async create(input: CreateSupportRequestInput): Promise<SupportRequest> {
+    const subject = normalizeText(input.subject ?? null);
+    const description = normalizeText(input.description ?? null);
+
+    if (!subject) {
+      throw new ValidationError('Subject is required');
+    }
+
+    if (!description) {
+      throw new ValidationError('Description is required');
+    }
+
+    const status = input.status ?? 'open';
+    assertValidStatus(status);
+
+    const requesterName = normalizeText(input.requesterName);
+    const requesterEmail = normalizeText(input.requesterEmail);
+
+    const result = await this.db.query(
+      `INSERT INTO support_requests (subject, description, status, requester_name, requester_email)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING id, subject, description, status, requester_name, requester_email, created_at, updated_at`,
+      [subject, description, status, requesterName, requesterEmail]
+    );
+
+    return mapRow(result.rows[0] as SupportRequestRow);
+  }
+
+  async list(options: ListSupportRequestsOptions = {}): Promise<SupportRequestList> {
+    const page = options.page && options.page > 0 ? Math.floor(options.page) : 1;
+    const pageSizeRaw = options.pageSize && options.pageSize > 0 ? Math.floor(options.pageSize) : DEFAULT_PAGE_SIZE;
+    const pageSize = Math.min(pageSizeRaw, MAX_PAGE_SIZE);
+    const offset = (page - 1) * pageSize;
+
+    const conditions: string[] = [];
+    const values: unknown[] = [];
+
+    if (options.status) {
+      assertValidStatus(options.status);
+      values.push(options.status);
+      conditions.push(`status = $${values.length}`);
+    }
+
+    if (options.search) {
+      const searchValue = `%${options.search.trim()}%`;
+      values.push(searchValue);
+      conditions.push(`(subject ILIKE $${values.length} OR description ILIKE $${values.length})`);
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const baseQuery = `SELECT id, subject, description, status, requester_name, requester_email, created_at, updated_at
+      FROM support_requests
+      ${whereClause}
+      ORDER BY created_at DESC`;
+
+    const dataQuery = `${baseQuery}
+      LIMIT $${values.length + 1}
+      OFFSET $${values.length + 2}`;
+
+    const dataValues = [...values, pageSize, offset];
+
+    const itemsResult = await this.db.query(dataQuery, dataValues);
+    const totalResult = await this.db.query(
+      `SELECT COUNT(*)::int AS total FROM support_requests ${whereClause}`,
+      values
+    );
+
+    const totalRow = totalResult.rows[0] as { total: number } | undefined;
+    const total = totalRow ? Number(totalRow.total) : 0;
+
+    return {
+      items: (itemsResult.rows as SupportRequestRow[]).map(mapRow),
+      total,
+      page,
+      pageSize,
+    };
+  }
+
+  async findById(id: number): Promise<SupportRequest | null> {
+    const result = await this.db.query(
+      `SELECT id, subject, description, status, requester_name, requester_email, created_at, updated_at
+       FROM support_requests
+       WHERE id = $1`,
+      [id]
+    );
+
+    if (result.rowCount === 0) {
+      return null;
+    }
+
+    return mapRow(result.rows[0] as SupportRequestRow);
+  }
+
+  async update(id: number, updates: UpdateSupportRequestInput): Promise<SupportRequest | null> {
+    const fields: string[] = [];
+    const values: unknown[] = [];
+    let index = 1;
+
+    if (typeof updates.subject === 'string') {
+      const subject = normalizeText(updates.subject);
+      if (!subject) {
+        throw new ValidationError('Subject cannot be empty');
+      }
+      fields.push(`subject = $${index}`);
+      values.push(subject);
+      index += 1;
+    }
+
+    if (typeof updates.description === 'string') {
+      const description = normalizeText(updates.description);
+      if (!description) {
+        throw new ValidationError('Description cannot be empty');
+      }
+      fields.push(`description = $${index}`);
+      values.push(description);
+      index += 1;
+    }
+
+    if (updates.status !== undefined) {
+      assertValidStatus(updates.status);
+      fields.push(`status = $${index}`);
+      values.push(updates.status);
+      index += 1;
+    }
+
+    if (updates.requesterName !== undefined) {
+      const name = normalizeText(updates.requesterName);
+      fields.push(`requester_name = $${index}`);
+      values.push(name);
+      index += 1;
+    }
+
+    if (updates.requesterEmail !== undefined) {
+      const email = normalizeText(updates.requesterEmail);
+      fields.push(`requester_email = $${index}`);
+      values.push(email);
+      index += 1;
+    }
+
+    if (fields.length === 0) {
+      throw new ValidationError('No fields provided to update');
+    }
+
+    const query = `UPDATE support_requests
+      SET ${fields.join(', ')}, updated_at = NOW()
+      WHERE id = $${index}
+      RETURNING id, subject, description, status, requester_name, requester_email, created_at, updated_at`;
+
+    values.push(id);
+
+    const result = await this.db.query(query, values);
+
+    if (result.rowCount === 0) {
+      return null;
+    }
+
+    return mapRow(result.rows[0] as SupportRequestRow);
+  }
+}
+
+export default SupportService;

--- a/backend/tests/supportService.test.ts
+++ b/backend/tests/supportService.test.ts
@@ -1,0 +1,193 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import SupportService, {
+  CreateSupportRequestInput,
+  SupportRequest,
+  SupportStatus,
+  ValidationError,
+} from '../src/services/supportService';
+
+type QueryCall = { text: string; values?: unknown[] };
+type QueryResponse = { rows: any[]; rowCount: number };
+
+class FakePool {
+  public readonly calls: QueryCall[] = [];
+
+  constructor(private readonly responses: QueryResponse[] = []) {}
+
+  async query(text: string, values?: unknown[]) {
+    this.calls.push({ text, values });
+    if (this.responses.length === 0) {
+      throw new Error('No response configured for query');
+    }
+    return this.responses.shift()!;
+  }
+}
+
+test('SupportService.create normalizes payload and returns persisted request', async () => {
+  const insertedRow = {
+    id: 1,
+    subject: 'Test subject',
+    description: 'Detailed description',
+    status: 'open' as SupportStatus,
+    requester_name: 'Maria',
+    requester_email: 'maria@example.com',
+    created_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z',
+  };
+
+  const pool = new FakePool([
+    { rows: [insertedRow], rowCount: 1 },
+  ]);
+
+  const service = new SupportService(pool as any);
+
+  const payload: CreateSupportRequestInput = {
+    subject: '  Test subject  ',
+    description: '\nDetailed description  ',
+    requesterName: ' Maria ',
+    requesterEmail: ' maria@example.com ',
+  };
+
+  const result = await service.create(payload);
+
+  assert.equal(pool.calls.length, 1);
+  const call = pool.calls[0];
+  assert.match(call.text, /INSERT INTO support_requests/i);
+  assert.deepEqual(call.values, [
+    'Test subject',
+    'Detailed description',
+    'open',
+    'Maria',
+    'maria@example.com',
+  ]);
+
+  const expected: SupportRequest = {
+    id: 1,
+    subject: 'Test subject',
+    description: 'Detailed description',
+    status: 'open',
+    requesterName: 'Maria',
+    requesterEmail: 'maria@example.com',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+  };
+
+  assert.deepEqual(result, expected);
+});
+
+test('SupportService.create validates required fields', async () => {
+  const pool = new FakePool([]);
+  const service = new SupportService(pool as any);
+
+  await assert.rejects(
+    () => service.create({ subject: '   ', description: 'valid' }),
+    ValidationError,
+  );
+
+  await assert.rejects(
+    () => service.create({ subject: 'Valid', description: '' }),
+    ValidationError,
+  );
+});
+
+test('SupportService.list applies filters and pagination', async () => {
+  const rows = [
+    {
+      id: 10,
+      subject: 'First issue',
+      description: 'Pending issue',
+      status: 'resolved' as SupportStatus,
+      requester_name: null,
+      requester_email: 'client@example.com',
+      created_at: '2024-01-02T12:00:00.000Z',
+      updated_at: '2024-01-03T12:00:00.000Z',
+    },
+  ];
+
+  const pool = new FakePool([
+    { rows, rowCount: rows.length },
+    { rows: [{ total: '5' }], rowCount: 1 },
+  ]);
+
+  const service = new SupportService(pool as any);
+
+  const result = await service.list({
+    status: 'resolved',
+    search: 'issue',
+    page: 2,
+    pageSize: 5,
+  });
+
+  assert.equal(pool.calls.length, 2);
+
+  const [listQuery, countQuery] = pool.calls;
+  assert.match(listQuery.text, /SELECT id, subject, description, status/);
+  assert.ok(listQuery.text.includes('ORDER BY created_at DESC'));
+  assert.ok(listQuery.text.includes('LIMIT $3'));
+  assert.deepEqual(listQuery.values, ['resolved', '%issue%', 5, 5]);
+
+  assert.match(countQuery.text, /SELECT COUNT\(\*\)::int AS total FROM support_requests/);
+  assert.deepEqual(countQuery.values, ['resolved', '%issue%']);
+
+  assert.equal(result.total, 5);
+  assert.equal(result.page, 2);
+  assert.equal(result.pageSize, 5);
+  assert.equal(result.items.length, 1);
+  assert.equal(result.items[0].id, 10);
+  assert.equal(result.items[0].status, 'resolved');
+});
+
+test('SupportService.update builds dynamic query and handles not found', async () => {
+  const updatedRow = {
+    id: 7,
+    subject: 'Updated subject',
+    description: 'Updated description',
+    status: 'in_progress' as SupportStatus,
+    requester_name: null,
+    requester_email: null,
+    created_at: '2024-01-05T10:00:00.000Z',
+    updated_at: '2024-01-05T11:00:00.000Z',
+  };
+
+  const pool = new FakePool([
+    { rows: [updatedRow], rowCount: 1 },
+    { rows: [], rowCount: 0 },
+  ]);
+
+  const service = new SupportService(pool as any);
+
+  const updated = await service.update(7, {
+    subject: ' Updated subject ',
+    description: 'Updated description',
+    status: 'in_progress',
+    requesterName: '   ',
+    requesterEmail: null,
+  });
+
+  assert.ok(pool.calls[0].text.startsWith('UPDATE support_requests'));
+  assert.deepEqual(pool.calls[0].values, [
+    'Updated subject',
+    'Updated description',
+    'in_progress',
+    null,
+    null,
+    7,
+  ]);
+  assert.equal(updated?.id, 7);
+  assert.equal(updated?.status, 'in_progress');
+  assert.equal(updated?.requesterName, null);
+
+  const notFound = await service.update(99, { status: 'resolved' });
+  assert.equal(pool.calls.length, 2);
+  assert.deepEqual(pool.calls[1].values, ['resolved', 99]);
+  assert.equal(notFound, null);
+});
+
+test('SupportService.update requires at least one field', async () => {
+  const pool = new FakePool([]);
+  const service = new SupportService(pool as any);
+
+  await assert.rejects(() => service.update(1, {}), ValidationError);
+});
+


### PR DESCRIPTION
## Summary
- add a SupportService with CRUD helpers that persist tickets in PostgreSQL
- wire the support controller and routes to expose listing, retrieval and update endpoints with Swagger docs
- document the new database script and add unit tests covering the service logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8843ce69c83269d004a69471ace1f