### PR TITLE
Fix pipeline card click navigation

### DIFF
--- a/frontend/src/pages/Pipeline.tsx
+++ b/frontend/src/pages/Pipeline.tsx
@@ -617,8 +617,12 @@ export default function Pipeline() {
                     onDragEnd={handleDragEnd}
                     onDragOver={handleDragOver}
                     onClick={() => {
-                      if (isDragging.current) return;
-                      navigate(`/pipeline/oportunidade/${opportunity.id}`);
+                      const targetId = opportunity.id;
+                      setTimeout(() => {
+                        if (!isDragging.current) {
+                          navigate(`/pipeline/oportunidade/${targetId}`);
+                        }
+                      }, 0);
                     }}
                   >
                     <CardHeader className="pb-2">


### PR DESCRIPTION
## Summary
- aguarde o ciclo de eventos após soltar o card do pipeline antes de navegar
- mantém a navegação bloqueada quando um arrasto real está ocorrendo

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c88f94d3a48326bbe02cb1efa794cc