### PR TITLE
Improve pipeline card click handling

### DIFF
--- a/frontend/src/pages/Pipeline.tsx
+++ b/frontend/src/pages/Pipeline.tsx
@@ -230,7 +230,7 @@ export default function Pipeline() {
   }, [selectedFlow, apiUrl]);
 
   const [opportunities, setOpportunities] = useState<Opportunity[]>([]);
-  const isDragging = useRef(false);
+  const dragStartedSincePointerDown = useRef(false);
 
   useEffect(() => {
     const fetchOpportunities = async () => {
@@ -413,14 +413,8 @@ export default function Pipeline() {
     event: React.DragEvent<HTMLDivElement>,
     opportunityId: number,
   ) => {
-    isDragging.current = true;
+    dragStartedSincePointerDown.current = true;
     event.dataTransfer.setData("text/plain", opportunityId.toString());
-  };
-
-  const handleDragEnd = () => {
-    setTimeout(() => {
-      isDragging.current = false;
-    }, 0);
   };
 
   const handleDrop = async (
@@ -613,12 +607,18 @@ export default function Pipeline() {
                     key={opportunity.id}
                     className="cursor-pointer hover:shadow-md transition-all duration-200"
                     draggable
+                    onPointerDown={() => {
+                      dragStartedSincePointerDown.current = false;
+                    }}
                     onDragStart={(e) => handleDragStart(e, opportunity.id)}
-                    onDragEnd={handleDragEnd}
                     onDragOver={handleDragOver}
                     onClick={() => {
-                      if (isDragging.current) return;
-                      navigate(`/pipeline/oportunidade/${opportunity.id}`);
+                      const dragged = dragStartedSincePointerDown.current;
+                      dragStartedSincePointerDown.current = false;
+
+                      if (!dragged) {
+                        navigate(`/pipeline/oportunidade/${opportunity.id}`);
+                      }
                     }}
                   >
                     <CardHeader className="pb-2">


### PR DESCRIPTION
## Summary
- monitora pointer down e início do arrasto para liberar a navegação ao clicar nos cards do pipeline sem afetar o drag-and-drop

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c88f94d3a48326bbe02cb1efa794cc