### PR TITLE
Add conversations workspace with mock chat UI

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -40,6 +40,34 @@ npm run dev
 
 O módulo de templates de documentos consome a API disponível em `http://localhost:3001/api`. Caso o backend esteja em outra URL, defina a variável de ambiente `VITE_API_URL` antes de iniciar o projeto. Caso contrário, o frontend utilizará automaticamente o mesmo domínio em que estiver publicado.
 
+## Conversas (Chat Omnichannel)
+
+Este projeto inclui uma área de conversas inspirada na experiência de mensageria profissional:
+
+- **Atalhos de teclado**: `Ctrl + K` foca a busca de contatos, `Ctrl + N` abre a modal de nova conversa e `Esc` fecha modais em destaque.
+- **Lista de conversas**: filtragem em tempo real, badges de não lidos, ordenação por atividade recente e navegação por teclado.
+- **Janela de chat**: cabeçalho com ações rápidas, histórico virtualizado (renderiza apenas um bloco de mensagens para manter a performance) e carregamento incremental ao rolar para o topo.
+- **Entrada de mensagem**: suporte a emoji, anexos simulados, colagem de imagens e envio com Enter (Shift+Enter cria nova linha).
+- **Modal de dispositivos**: tela dedicada para pareamento por QR code, mantendo a interface acessível e responsiva.
+
+### Como rodar
+
+```sh
+cd frontend
+npm install
+npm run dev
+```
+
+A aplicação estará disponível em `http://localhost:5173`. O servidor mockado de conversas é inicializado automaticamente no carregamento do módulo.
+
+### Ajustando os dados fictícios
+
+- **Conversas e mensagens**: edite `src/features/chat/data/chatData.json` para alterar contatos, mensagens e status.
+- **Comportamento da API**: endpoints simulados ficam em `src/features/chat/services/mockServer.ts`. Ali é possível ajustar paginação, ordenação e payloads retornados.
+- **Estilos do chat**: cada componente usa CSS Modules (por exemplo, `ChatSidebar.module.css`, `ChatWindow.module.css`). As variáveis de cor aproveitam o tema existente do CRM.
+
+Sempre que alterar os mocks, salve o arquivo e a aplicação será recarregada automaticamente pelo Vite.
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import Relatorios from "./pages/Relatorios";
 import MeuPerfil from "./pages/MeuPerfil";
 import MeuPlano from "./pages/MeuPlano";
 import Suporte from "./pages/Suporte";
+import Conversas from "./pages/Conversas";
 import AreaAtuacao from "./pages/configuracoes/parametros/AreaAtuacao";
 import SituacaoProcesso from "./pages/configuracoes/parametros/SituacaoProcesso";
 import TipoProcesso from "./pages/configuracoes/parametros/TipoProcesso";
@@ -66,6 +67,7 @@ const App = () => (
           <Route path="/recuperar-senha" element={<RecuperarSenha />} />
           <Route element={<CRMLayout />}>
             <Route path="/" element={<Dashboard />} />
+            <Route path="/conversas" element={<Conversas />} />
             <Route path="/clientes" element={<Clientes />} />
             <Route path="/clientes/novo" element={<NovoCliente />} />
             <Route path="/clientes/:id/editar" element={<EditarCliente />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
   Target,
   Calendar,
   CheckSquare,
+  MessageCircle,
   Gavel,
   FileText,
   DollarSign,
@@ -77,6 +78,7 @@ export function Sidebar() {
 
   const navigation: NavItem[] = [
     { name: "Dashboard", href: "/", icon: LayoutDashboard },
+    { name: "Conversas", href: "/conversas", icon: MessageCircle },
     { name: "Clientes", href: "/clientes", icon: Users },
     { name: "Pipeline", href: "/pipeline", icon: Target, children: pipelineMenus },
     { name: "Agenda", href: "/agenda", icon: Calendar },

--- a/frontend/src/features/chat/ChatPage.module.css
+++ b/frontend/src/features/chat/ChatPage.module.css
@@ -1,0 +1,12 @@
+.layout {
+  display: flex;
+  min-height: calc(100vh - 4rem);
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+}
+
+@media (max-width: 900px) {
+  .layout {
+    flex-direction: column;
+  }
+}

--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { setupMockChatServer } from "./services/mockServer";
+import {
+  fetchConversations,
+  createConversation,
+  markConversationRead,
+} from "./services/chatApi";
+import type { ConversationSummary, SendMessageInput } from "./types";
+import { ChatSidebar } from "./components/ChatSidebar";
+import { ChatWindow } from "./components/ChatWindow";
+import { NewConversationModal } from "./components/NewConversationModal";
+import { useChatMessages } from "./hooks/useChatMessages";
+import styles from "./ChatPage.module.css";
+
+export const ChatPage = () => {
+  const [selectedConversationId, setSelectedConversationId] = useState<string | undefined>();
+  const [searchValue, setSearchValue] = useState("");
+  const [newConversationOpen, setNewConversationOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    // Inicializa o interceptador de fetch para simular uma API REST sem backend real.
+    setupMockChatServer();
+  }, []);
+
+  const conversationsQuery = useQuery({
+    queryKey: ["conversations"],
+    queryFn: fetchConversations,
+    staleTime: 30_000,
+  });
+
+  const conversations = useMemo(
+    () => conversationsQuery.data ?? [],
+    [conversationsQuery.data],
+  );
+
+  useEffect(() => {
+    if (!selectedConversationId && conversations.length > 0) {
+      setSelectedConversationId(conversations[0]!.id);
+    }
+  }, [conversations, selectedConversationId]);
+
+  const markReadMutation = useMutation({
+    mutationFn: (conversationId: string) => markConversationRead(conversationId),
+    onSuccess: (_, conversationId) => {
+      queryClient.setQueryData<ConversationSummary[]>(["conversations"], (old) => {
+        if (!old) return old;
+        return old.map((item) =>
+          item.id === conversationId ? { ...item, unreadCount: 0 } : item,
+        );
+      });
+    },
+  });
+
+  const createConversationMutation = useMutation({
+    mutationFn: createConversation,
+    onSuccess: (createdConversation) => {
+      queryClient.setQueryData<ConversationSummary[]>(["conversations"], (old) => {
+        const list = old ? old.filter((item) => item.id !== createdConversation.id) : [];
+        return [createdConversation, ...list];
+      });
+      setSelectedConversationId(createdConversation.id);
+      setSearchValue("");
+    },
+  });
+
+  const {
+    messages,
+    hasMore,
+    isLoading: messagesLoading,
+    isLoadingMore,
+    loadOlder,
+    sendMessage,
+  } = useChatMessages(selectedConversationId);
+
+  const handleSelectConversation = (conversationId: string) => {
+    setSelectedConversationId(conversationId);
+    markReadMutation.mutate(conversationId);
+  };
+
+  const handleSendMessage = async (payload: SendMessageInput) => {
+    await sendMessage(payload);
+    queryClient.invalidateQueries({ queryKey: ["conversations"] });
+  };
+
+  useEffect(() => {
+    const handleShortcuts = (event: KeyboardEvent) => {
+      if (event.ctrlKey && (event.key === "k" || event.key === "K")) {
+        event.preventDefault();
+        setNewConversationOpen(false);
+        searchInputRef.current?.focus();
+      }
+      if (event.ctrlKey && (event.key === "n" || event.key === "N")) {
+        event.preventDefault();
+        setNewConversationOpen(true);
+      }
+      if (event.key === "Escape") {
+        setNewConversationOpen(false);
+      }
+    };
+    window.addEventListener("keydown", handleShortcuts);
+    return () => window.removeEventListener("keydown", handleShortcuts);
+  }, []);
+
+  const selectedConversation = useMemo(
+    () => conversations.find((conversation) => conversation.id === selectedConversationId),
+    [conversations, selectedConversationId],
+  );
+
+  return (
+    <div className={styles.layout}>
+      <ChatSidebar
+        conversations={conversations}
+        activeConversationId={selectedConversationId}
+        searchValue={searchValue}
+        onSearchChange={setSearchValue}
+        onSelectConversation={handleSelectConversation}
+        onNewConversation={() => setNewConversationOpen(true)}
+        searchInputRef={searchInputRef}
+        loading={conversationsQuery.isLoading}
+      />
+      <ChatWindow
+        conversation={selectedConversation}
+        messages={messages}
+        hasMore={hasMore}
+        isLoading={messagesLoading}
+        isLoadingMore={isLoadingMore}
+        onSendMessage={handleSendMessage}
+        onLoadOlder={loadOlder}
+      />
+      <NewConversationModal
+        open={newConversationOpen}
+        suggestions={conversations}
+        onClose={() => setNewConversationOpen(false)}
+        onSelectConversation={(conversationId) => {
+          handleSelectConversation(conversationId);
+          setNewConversationOpen(false);
+        }}
+        onCreateConversation={async (name) => {
+          const trimmed = name.trim();
+          if (!trimmed) return null;
+          const created = await createConversationMutation.mutateAsync({ name: trimmed });
+          return created.id;
+        }}
+      />
+    </div>
+  );
+};

--- a/frontend/src/features/chat/components/ChatInput.module.css
+++ b/frontend/src/features/chat/components/ChatInput.module.css
@@ -1,0 +1,154 @@
+.container {
+  border-top: 1px solid hsl(var(--border));
+  padding: 0.75rem 1rem 1rem;
+  background: hsl(var(--background));
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.iconButton {
+  border: none;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.iconButton:hover,
+.iconButton:focus-visible {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}
+
+.textareaWrapper {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+}
+
+.textarea {
+  flex: 1;
+  min-height: 3rem;
+  max-height: 8rem;
+  resize: none;
+  border: 1px solid hsl(var(--border));
+  border-radius: 1rem;
+  padding: 0.75rem 1rem;
+  background: hsl(var(--input));
+  color: inherit;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.textarea:focus {
+  outline: 2px solid hsl(var(--primary));
+  border-color: hsl(var(--primary));
+}
+
+.sendButton {
+  border: none;
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  border-radius: 999px;
+  width: 3rem;
+  height: 3rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.sendButton[disabled] {
+  cursor: not-allowed;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+}
+
+.sendButton:not([disabled]):hover,
+.sendButton:not([disabled]):focus-visible {
+  background: hsl(var(--primary-hover));
+}
+
+.popover {
+  position: absolute;
+  bottom: 110%;
+  left: 0;
+  background: hsl(var(--card));
+  color: hsl(var(--card-foreground));
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.85rem;
+  padding: 0.75rem;
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 0.35rem;
+  min-width: 200px;
+  z-index: 20;
+}
+
+.popover button {
+  border: none;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.5rem;
+  border-radius: 0.65rem;
+  cursor: pointer;
+  color: inherit;
+}
+
+.popover button:hover,
+.popover button:focus-visible {
+  background: hsl(var(--muted));
+}
+
+.emojiPicker {
+  position: absolute;
+  bottom: 110%;
+  right: 3.5rem;
+  display: grid;
+  grid-template-columns: repeat(6, 2rem);
+  gap: 0.35rem;
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.9rem;
+  padding: 0.6rem;
+  box-shadow: var(--shadow-card);
+  z-index: 20;
+}
+
+.emojiButton {
+  border: none;
+  background: transparent;
+  font-size: 1.3rem;
+  cursor: pointer;
+  line-height: 1;
+  border-radius: 0.6rem;
+  transition: var(--transition-fast);
+}
+
+.emojiButton:hover,
+.emojiButton:focus-visible {
+  background: hsl(var(--muted));
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 0.75rem;
+  }
+}

--- a/frontend/src/features/chat/components/ChatSidebar.module.css
+++ b/frontend/src/features/chat/components/ChatSidebar.module.css
@@ -1,0 +1,205 @@
+.sidebar {
+  width: 360px;
+  max-width: 100%;
+  background: hsl(var(--sidebar-background));
+  color: hsl(var(--sidebar-foreground));
+  border-right: 1px solid hsl(var(--sidebar-border));
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.header {
+  padding: 1.5rem 1.25rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.titleRow {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.titleRow h1 {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.newButton {
+  border: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  border-radius: 999px;
+  padding: 0.55rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.newButton:hover,
+.newButton:focus-visible {
+  background: hsl(var(--primary-hover));
+}
+
+.searchBox {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  background: hsl(var(--sidebar-accent));
+  border-radius: 999px;
+  padding: 0.5rem 0.75rem;
+}
+
+.searchInput {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 0.95rem;
+}
+
+.searchInput:focus {
+  outline: none;
+}
+
+.listContainer {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem 0.75rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.itemButton {
+  width: 100%;
+  border: none;
+  background: transparent;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem 0.9rem;
+  border-radius: 1rem;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.itemButton:hover,
+.itemButton:focus-visible {
+  background: hsl(var(--sidebar-accent));
+}
+
+.itemButton[data-focused="true"] {
+  box-shadow: 0 0 0 2px hsl(var(--sidebar-ring));
+}
+
+.itemButton[data-active="true"] {
+  background: hsl(var(--sidebar-primary));
+  color: hsl(var(--sidebar-primary-foreground));
+  transform: translateY(-1px);
+  box-shadow: 0 15px 25px rgba(15, 23, 42, 0.16);
+}
+
+.avatar {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 999px;
+  object-fit: cover;
+  border: 2px solid transparent;
+}
+
+.itemButton[data-active="true"] .avatar {
+  border-color: rgba(255, 255, 255, 0.45);
+}
+
+.itemContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.itemTitle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.itemPreview {
+  font-size: 0.85rem;
+  color: hsl(var(--muted-foreground));
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  line-height: 1.4;
+}
+
+.itemButton[data-active="true"] .itemPreview {
+  color: hsl(var(--sidebar-primary-foreground));
+  opacity: 0.85;
+}
+
+.timestamp {
+  font-size: 0.8rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.itemButton[data-active="true"] .timestamp {
+  color: hsl(var(--sidebar-primary-foreground));
+}
+
+.unreadBadge {
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  border-radius: 999px;
+  padding: 0.1rem 0.55rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.empty {
+  color: hsl(var(--muted-foreground));
+  text-align: center;
+  padding: 2rem 1rem;
+}
+
+.footer {
+  padding: 0.75rem 1.25rem 1.5rem;
+  color: hsl(var(--muted-foreground));
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 1200px) {
+  .sidebar {
+    width: 320px;
+  }
+}
+
+@media (max-width: 900px) {
+  .sidebar {
+    width: 100%;
+    max-width: none;
+    height: 50vh;
+  }
+}

--- a/frontend/src/features/chat/components/ChatSidebar.tsx
+++ b/frontend/src/features/chat/components/ChatSidebar.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useMemo, useState } from "react";
+import { MessageCircle, Plus, Search, Pin } from "lucide-react";
+import type { ConversationSummary } from "../types";
+import { formatConversationTimestamp, normalizeText } from "../utils/format";
+import styles from "./ChatSidebar.module.css";
+
+interface ChatSidebarProps {
+  conversations: ConversationSummary[];
+  activeConversationId?: string;
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  onSelectConversation: (conversationId: string) => void;
+  onNewConversation: () => void;
+  searchInputRef: React.RefObject<HTMLInputElement>;
+  loading?: boolean;
+}
+
+export const ChatSidebar = ({
+  conversations,
+  activeConversationId,
+  searchValue,
+  onSearchChange,
+  onSelectConversation,
+  onNewConversation,
+  searchInputRef,
+  loading = false,
+}: ChatSidebarProps) => {
+  const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
+  const filtered = useMemo(() => {
+    const normalizedQuery = normalizeText(searchValue);
+    if (!normalizedQuery) {
+      return conversations;
+    }
+    return conversations.filter((conversation) => {
+      const normalizedName = normalizeText(conversation.name);
+      const normalizedDescription = normalizeText(conversation.description ?? "");
+      const lastMessage = conversation.lastMessage?.preview ? normalizeText(conversation.lastMessage.preview) : "";
+      return (
+        normalizedName.includes(normalizedQuery) ||
+        normalizedDescription.includes(normalizedQuery) ||
+        lastMessage.includes(normalizedQuery)
+      );
+    });
+  }, [conversations, searchValue]);
+
+  useEffect(() => {
+    if (!filtered.length) {
+      setFocusedIndex(null);
+      return;
+    }
+    if (activeConversationId) {
+      const index = filtered.findIndex((conversation) => conversation.id === activeConversationId);
+      if (index >= 0) {
+        setFocusedIndex(index);
+        return;
+      }
+    }
+    setFocusedIndex(0);
+  }, [activeConversationId, filtered]);
+
+  useEffect(() => {
+    if (focusedIndex === null) return;
+    const conversation = filtered[focusedIndex];
+    if (!conversation) return;
+    const element = document.getElementById(`conversation-item-${conversation.id}`);
+    element?.scrollIntoView({ block: "nearest" });
+  }, [focusedIndex, filtered]);
+
+  const handleKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (event) => {
+    if (!filtered.length) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setFocusedIndex((current) => {
+        const next = current === null ? 0 : Math.min(filtered.length - 1, current + 1);
+        return next;
+      });
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setFocusedIndex((current) => {
+        const next = current === null ? 0 : Math.max(0, current - 1);
+        return next;
+      });
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      setFocusedIndex(0);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      setFocusedIndex(filtered.length - 1);
+    } else if (event.key === "Enter" && focusedIndex !== null) {
+      event.preventDefault();
+      const conversation = filtered[focusedIndex];
+      if (conversation) {
+        onSelectConversation(conversation.id);
+      }
+    }
+  };
+
+  return (
+    <aside className={styles.sidebar} aria-label="Lista de conversas">
+      <div className={styles.header}>
+        <div className={styles.titleRow}>
+          <h1>Conversas</h1>
+          <button type="button" className={styles.newButton} onClick={onNewConversation} aria-label="Iniciar nova conversa">
+            <Plus size={18} aria-hidden="true" /> Nova conversa
+          </button>
+        </div>
+        <div className={styles.searchBox}>
+          <Search size={18} aria-hidden="true" />
+          <input
+            ref={searchInputRef}
+            className={styles.searchInput}
+            type="search"
+            value={searchValue}
+            onChange={(event) => onSearchChange(event.target.value)}
+            placeholder="Buscar"
+            aria-label="Buscar conversa"
+          />
+          <kbd aria-hidden="true">Ctrl K</kbd>
+        </div>
+      </div>
+      <div
+        className={styles.listContainer}
+        role="listbox"
+        aria-activedescendant={
+          focusedIndex !== null && filtered[focusedIndex]
+            ? `conversation-item-${filtered[focusedIndex]!.id}`
+            : undefined
+        }
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+      >
+        {loading ? (
+          <div className={styles.empty}>Carregando conversas...</div>
+        ) : filtered.length === 0 ? (
+          <div className={styles.empty}>Nenhuma conversa encontrada.</div>
+        ) : (
+          <ul className={styles.list}>
+            {filtered.map((conversation, index) => {
+              const isActive = conversation.id === activeConversationId;
+              const isFocused = index === focusedIndex;
+              const preview = conversation.lastMessage?.preview ?? "Nova conversa";
+              const timestamp = conversation.lastMessage?.timestamp
+                ? formatConversationTimestamp(conversation.lastMessage.timestamp)
+                : "";
+              return (
+                <li key={conversation.id}>
+                  <button
+                    type="button"
+                    id={`conversation-item-${conversation.id}`}
+                    className={styles.itemButton}
+                    data-active={isActive}
+                    data-focused={isFocused}
+                    role="option"
+                    onClick={() => onSelectConversation(conversation.id)}
+                    aria-selected={isActive}
+                  >
+                    <img src={conversation.avatar} alt="" className={styles.avatar} aria-hidden="true" />
+                    <div className={styles.itemContent}>
+                      <div className={styles.itemTitle}>
+                        <span>{conversation.name}</span>
+                        {conversation.pinned && (
+                          <span role="img" aria-label="Conversação fixada">
+                            <Pin size={14} aria-hidden="true" />
+                          </span>
+                        )}
+                      </div>
+                      <div className={styles.itemPreview}>
+                        {conversation.lastMessage?.sender === "me" && <span>Você:</span>}
+                        <span>{preview}</span>
+                      </div>
+                    </div>
+                    <div>
+                      {timestamp && <div className={styles.timestamp}>{timestamp}</div>}
+                      {conversation.unreadCount > 0 && (
+                        <div className={styles.unreadBadge} aria-label={`${conversation.unreadCount} mensagens não lidas`}>
+                          {conversation.unreadCount}
+                        </div>
+                      )}
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+      <div className={styles.footer}>
+        <MessageCircle size={16} aria-hidden="true" /> Ctrl+N cria nova conversa • Esc fecha modais
+      </div>
+    </aside>
+  );
+};

--- a/frontend/src/features/chat/components/ChatWindow.module.css
+++ b/frontend/src/features/chat/components/ChatWindow.module.css
@@ -1,0 +1,151 @@
+.wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: hsl(var(--background));
+}
+
+.header {
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid hsl(var(--border));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.headerInfo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.headerInfo img {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 999px;
+  object-fit: cover;
+}
+
+.headerText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.headerText h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.status {
+  font-size: 0.9rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.actionButton {
+  border: none;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.actionButton:hover,
+.actionButton:focus-visible {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}
+
+.menu {
+  position: relative;
+}
+
+.menuPanel {
+  position: absolute;
+  right: 0;
+  top: 110%;
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.75rem;
+  box-shadow: var(--shadow-card);
+  padding: 0.35rem;
+  display: grid;
+  gap: 0.25rem;
+  min-width: 200px;
+  z-index: 30;
+}
+
+.menuPanel button {
+  border: none;
+  background: transparent;
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.65rem;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: inherit;
+}
+
+.menuPanel button:hover,
+.menuPanel button:focus-visible {
+  background: hsl(var(--muted));
+}
+
+.placeholder {
+  flex: 1;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  color: hsl(var(--muted-foreground));
+  padding: 2rem;
+  gap: 1rem;
+}
+
+.placeholder h3 {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.loadingOverlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: hsl(var(--background) / 0.7);
+  backdrop-filter: blur(3px);
+  z-index: 40;
+  font-weight: 600;
+}
+
+.viewportWrapper {
+  position: relative;
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+@media (max-width: 900px) {
+  .header {
+    padding: 0.75rem 1rem;
+  }
+
+  .headerInfo img {
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+}

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Phone, Video, MoreVertical, Search, Archive, Monitor } from "lucide-react";
+import type { ConversationSummary, Message, SendMessageInput } from "../types";
+import { ChatInput } from "./ChatInput";
+import { MessageViewport } from "./MessageViewport";
+import { DeviceLinkModal } from "./DeviceLinkModal";
+import styles from "./ChatWindow.module.css";
+
+interface ChatWindowProps {
+  conversation?: ConversationSummary;
+  messages: Message[];
+  hasMore: boolean;
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  onSendMessage: (payload: SendMessageInput) => Promise<void>;
+  onLoadOlder: () => Promise<Message[]>;
+}
+
+export const ChatWindow = ({
+  conversation,
+  messages,
+  hasMore,
+  isLoading,
+  isLoadingMore,
+  onSendMessage,
+  onLoadOlder,
+}: ChatWindowProps) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [deviceModalOpen, setDeviceModalOpen] = useState(false);
+  const [stickToBottom, setStickToBottom] = useState(true);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const previousConversationRef = useRef<string | undefined>(undefined);
+  const previousLengthRef = useRef(0);
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      if (menuOpen && menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("click", handleClick);
+    return () => document.removeEventListener("click", handleClick);
+  }, [menuOpen]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  // Mantemos o foco no final da conversa sempre que o usuário estiver no final do histórico.
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+    const conversationChanged = previousConversationRef.current !== conversation?.id;
+    const appendedMessage = messages.length > previousLengthRef.current;
+    if (conversationChanged) {
+      container.scrollTop = container.scrollHeight;
+    } else if (appendedMessage && stickToBottom) {
+      container.scrollTo({ top: container.scrollHeight, behavior: messages.length < 4 ? "auto" : "smooth" });
+    }
+    previousConversationRef.current = conversation?.id;
+    previousLengthRef.current = messages.length;
+  }, [conversation?.id, messages, stickToBottom]);
+
+  const handleSend = async (payload: SendMessageInput) => {
+    if (!conversation) return;
+    await onSendMessage(payload);
+    setStickToBottom(true);
+  };
+
+  const placeholder = useMemo(() => (
+    <div className={styles.placeholder}>
+      <div>
+        <h3>Selecione uma conversa</h3>
+        <p>
+          Utilize a barra lateral para escolher um contato, iniciar um novo chat ou pesquisar processos.
+          Os atalhos Ctrl+K e Ctrl+N aceleram sua navegação.
+        </p>
+      </div>
+    </div>
+  ), []);
+
+  if (!conversation) {
+    return <div className={styles.wrapper}>{placeholder}</div>;
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <header className={styles.header}>
+        <div className={styles.headerInfo}>
+          <img src={conversation.avatar} alt="" aria-hidden="true" />
+          <div className={styles.headerText}>
+            <h2>{conversation.name}</h2>
+            <span className={styles.status}>{conversation.shortStatus}</span>
+          </div>
+        </div>
+        <div className={styles.actions} ref={menuRef}>
+          <button type="button" className={styles.actionButton} aria-label="Iniciar ligação">
+            <Phone size={18} aria-hidden="true" />
+          </button>
+          <button type="button" className={styles.actionButton} aria-label="Iniciar chamada de vídeo">
+            <Video size={18} aria-hidden="true" />
+          </button>
+          <div className={styles.menu}>
+            <button
+              type="button"
+              className={styles.actionButton}
+              aria-haspopup="true"
+              aria-expanded={menuOpen}
+              aria-label="Abrir menu de ações"
+              onClick={() => setMenuOpen((open) => !open)}
+            >
+              <MoreVertical size={18} aria-hidden="true" />
+            </button>
+            {menuOpen && (
+              <div className={styles.menuPanel} role="menu">
+                <button type="button" onClick={() => setMenuOpen(false)} role="menuitem">
+                  <Search size={16} aria-hidden="true" /> Pesquisar nesta conversa
+                </button>
+                <button type="button" onClick={() => setMenuOpen(false)} role="menuitem">
+                  <Archive size={16} aria-hidden="true" /> Arquivar conversa
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setDeviceModalOpen(true);
+                    setMenuOpen(false);
+                  }}
+                  role="menuitem"
+                >
+                  <Monitor size={16} aria-hidden="true" /> Conectar dispositivo
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </header>
+      <div className={styles.viewportWrapper}>
+        {isLoading && <div className={styles.loadingOverlay}>Carregando conversa...</div>}
+        <MessageViewport
+          messages={messages}
+          avatarUrl={conversation.avatar}
+          containerRef={scrollRef}
+          hasMore={hasMore}
+          isLoadingMore={isLoadingMore}
+          onLoadMore={onLoadOlder}
+          onStickToBottomChange={setStickToBottom}
+        />
+      </div>
+      <ChatInput onSend={handleSend} disabled={isLoading} />
+      <DeviceLinkModal open={deviceModalOpen} onClose={() => setDeviceModalOpen(false)} />
+    </div>
+  );
+};

--- a/frontend/src/features/chat/components/DeviceLinkModal.module.css
+++ b/frontend/src/features/chat/components/DeviceLinkModal.module.css
@@ -1,0 +1,170 @@
+.container {
+  display: flex;
+  gap: 2rem;
+  padding: 2rem;
+  align-items: stretch;
+}
+
+.qrSection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  min-width: 220px;
+}
+
+.qrFrame {
+  position: relative;
+  width: 220px;
+  aspect-ratio: 1;
+  border-radius: 1.25rem;
+  border: 1px solid hsl(var(--border));
+  background: linear-gradient(135deg, hsl(var(--accent)), hsl(var(--secondary)));
+  display: grid;
+  place-items: center;
+  padding: 1.75rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+
+.qrPattern {
+  width: 100%;
+  height: 100%;
+  border-radius: 1rem;
+  background-image: repeating-linear-gradient(
+      45deg,
+      rgba(30, 64, 175, 0.9) 0,
+      rgba(30, 64, 175, 0.9) 6px,
+      rgba(255, 255, 255, 0.95) 6px,
+      rgba(255, 255, 255, 0.95) 12px
+    ),
+    repeating-linear-gradient(
+      -45deg,
+      rgba(15, 23, 42, 0.9) 0,
+      rgba(15, 23, 42, 0.9) 6px,
+      rgba(255, 255, 255, 0.95) 6px,
+      rgba(255, 255, 255, 0.95) 12px
+    );
+  position: relative;
+  overflow: hidden;
+}
+
+.codeChip {
+  position: absolute;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(15, 23, 42, 0.75);
+  color: #fff;
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.refreshButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: none;
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.refreshButton:hover,
+.refreshButton:focus-visible {
+  background: hsl(var(--primary-hover));
+}
+
+.instructions {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.instructions h2 {
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.instructions p {
+  color: hsl(var(--muted-foreground));
+  line-height: 1.6;
+}
+
+.steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.stepItem {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: 0.85rem;
+}
+
+.stepBadge {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+}
+
+.stepContent h3 {
+  font-size: 1rem;
+  margin-bottom: 0.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.stepIcon {
+  width: 1.15rem;
+  height: 1.15rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: hsl(var(--accent-foreground));
+}
+
+.stepContent p {
+  margin: 0;
+  color: hsl(var(--muted-foreground));
+}
+
+@media (max-width: 900px) {
+  .container {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .instructions {
+    align-items: center;
+  }
+
+  .stepItem {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    text-align: center;
+  }
+
+  .stepBadge {
+    margin-bottom: 0.35rem;
+  }
+}

--- a/frontend/src/features/chat/components/DeviceLinkModal.tsx
+++ b/frontend/src/features/chat/components/DeviceLinkModal.tsx
@@ -1,0 +1,100 @@
+import { useMemo, useState } from "react";
+import { RefreshCw, Smartphone, QrCode, ShieldCheck } from "lucide-react";
+import { Modal } from "./Modal";
+import styles from "./DeviceLinkModal.module.css";
+
+interface DeviceLinkModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const generateCode = () => {
+  const segment = () => Math.floor(100 + Math.random() * 899).toString();
+  const letters = "ABCDEFGHJKLMNPQRSTUVWXYZ";
+  const suffix = letters[Math.floor(Math.random() * letters.length)]!;
+  return `${segment()}-${suffix}${segment().slice(0, 1)}`;
+};
+
+export const DeviceLinkModal = ({ open, onClose }: DeviceLinkModalProps) => {
+  const [code, setCode] = useState(() => generateCode());
+  const [refreshing, setRefreshing] = useState(false);
+
+  const steps = useMemo(
+    () => [
+      {
+        title: "Abra o JusConnect Mobile",
+        description:
+          "No aplicativo, toque em Mais > Dispositivos Conectados e selecione \"Conectar novo dispositivo\".",
+        icon: <Smartphone size={18} aria-hidden="true" />,
+      },
+      {
+        title: "Escaneie o código",
+        description:
+          "Aponte a câmera para este código para autenticar a sessão com criptografia ponta a ponta.",
+        icon: <QrCode size={18} aria-hidden="true" />,
+      },
+      {
+        title: "Pronto para conversar",
+        description:
+          "As conversas serão sincronizadas instantaneamente com o painel web, mantendo notificações e filtros.",
+        icon: <ShieldCheck size={18} aria-hidden="true" />,
+      },
+    ],
+    [],
+  );
+
+  const handleRefresh = () => {
+    setRefreshing(true);
+    setTimeout(() => {
+      setCode(generateCode());
+      setRefreshing(false);
+    }, 420);
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} ariaLabel="Conectar um novo dispositivo">
+      <div className={styles.container}>
+        <section className={styles.qrSection} aria-labelledby="qr-title">
+          <h2 id="qr-title" className="sr-only">
+            Código QR para emparelhar dispositivo
+          </h2>
+          <div className={styles.qrFrame} aria-hidden="true">
+            <div className={styles.qrPattern} />
+            <span className={styles.codeChip}>{code}</span>
+          </div>
+          <button
+            type="button"
+            onClick={handleRefresh}
+            className={styles.refreshButton}
+            aria-label="Atualizar código QR"
+            disabled={refreshing}
+          >
+            <RefreshCw size={16} aria-hidden="true" />
+            {refreshing ? "Gerando..." : "Atualizar código"}
+          </button>
+        </section>
+        <div className={styles.instructions}>
+          <h2>Sincronize o chat com o seu celular</h2>
+          <p>
+            Conecte um dispositivo móvel para responder clientes pelo painel web mantendo a segurança
+            das conversas com autenticação temporária.
+          </p>
+          <ol className={styles.steps}>
+            {steps.map((step, index) => (
+              <li key={step.title} className={styles.stepItem}>
+                <span className={styles.stepBadge}>{index + 1}</span>
+                <div className={styles.stepContent}>
+                  <h3>
+                    <span className={styles.stepIcon}>{step.icon}</span>
+                    {step.title}
+                  </h3>
+                  <p>{step.description}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/frontend/src/features/chat/components/MessageBubble.module.css
+++ b/frontend/src/features/chat/components/MessageBubble.module.css
@@ -1,0 +1,76 @@
+.row {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.6rem;
+  margin: 0.35rem 0;
+}
+
+.outgoing {
+  justify-content: flex-end;
+}
+
+.incoming {
+  justify-content: flex-start;
+}
+
+.bubble {
+  max-width: min(75%, 520px);
+  padding: 0.65rem 0.75rem 0.55rem;
+  border-radius: 1rem;
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  position: relative;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.outgoing .bubble {
+  background: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary-hover)));
+  color: hsl(var(--primary-foreground));
+}
+
+.text {
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.45;
+}
+
+.meta {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  opacity: 0.85;
+}
+
+.attachment {
+  width: clamp(180px, 40vw, 320px);
+  border-radius: 0.85rem;
+  object-fit: cover;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.2);
+}
+
+.avatar {
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 999px;
+  object-fit: cover;
+  margin-bottom: 0.2rem;
+}
+
+.avatarPlaceholder {
+  width: 2.4rem;
+  height: 2.4rem;
+}
+
+.grouped {
+  margin-top: 0.1rem;
+}
+
+.statusIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/frontend/src/features/chat/components/MessageBubble.tsx
+++ b/frontend/src/features/chat/components/MessageBubble.tsx
@@ -1,0 +1,63 @@
+import { forwardRef } from "react";
+import { CheckCheck } from "lucide-react";
+import clsx from "clsx";
+import type { Message } from "../types";
+import { formatTime } from "../utils/format";
+import styles from "./MessageBubble.module.css";
+
+interface MessageBubbleProps {
+  message: Message;
+  isOwnMessage: boolean;
+  isFirstOfGroup: boolean;
+  avatarUrl?: string;
+}
+
+export const MessageBubble = forwardRef<HTMLDivElement, MessageBubbleProps>(
+  ({ message, isOwnMessage, isFirstOfGroup, avatarUrl }, ref) => {
+    const containerClass = clsx(styles.row, isOwnMessage ? styles.outgoing : styles.incoming, {
+      [styles.grouped]: !isFirstOfGroup,
+    });
+
+    return (
+      <div ref={ref} className={containerClass} aria-live="polite">
+        {isOwnMessage ? (
+          <div className={styles.avatarPlaceholder} aria-hidden="true" />
+        ) : isFirstOfGroup && avatarUrl ? (
+          <img src={avatarUrl} alt="" className={styles.avatar} aria-hidden="true" />
+        ) : (
+          <div className={styles.avatarPlaceholder} aria-hidden="true" />
+        )}
+        <div className={styles.bubble}>
+          {message.attachments?.map((attachment) => (
+            <img
+              key={attachment.id}
+              src={attachment.url}
+              alt={attachment.name}
+              className={styles.attachment}
+            />
+          ))}
+          {message.type === "image" && !message.attachments?.length && (
+            <img
+              src={message.content}
+              alt="Imagem enviada"
+              className={styles.attachment}
+            />
+          )}
+          {message.content && (
+            <p className={styles.text}>{message.content}</p>
+          )}
+          <div className={styles.meta}>
+            <time dateTime={message.timestamp}>{formatTime(message.timestamp)}</time>
+            {isOwnMessage && (
+              <span className={styles.statusIcon} aria-label={`Status: ${message.status}`}>
+                <CheckCheck size={16} aria-hidden="true" />
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+
+MessageBubble.displayName = "MessageBubble";

--- a/frontend/src/features/chat/components/MessageViewport.module.css
+++ b/frontend/src/features/chat/components/MessageViewport.module.css
@@ -1,0 +1,25 @@
+.container {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.spacer {
+  position: relative;
+  display: block;
+}
+
+.loading {
+  text-align: center;
+  color: hsl(var(--muted-foreground));
+  padding: 0.5rem 0;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 900px) {
+  .container {
+    padding: 1rem;
+  }
+}

--- a/frontend/src/features/chat/components/MessageViewport.tsx
+++ b/frontend/src/features/chat/components/MessageViewport.tsx
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { Message } from "../types";
+import { MessageBubble } from "./MessageBubble";
+import styles from "./MessageViewport.module.css";
+
+interface MessageViewportProps {
+  messages: Message[];
+  avatarUrl?: string;
+  containerRef: React.RefObject<HTMLDivElement>;
+  hasMore: boolean;
+  isLoadingMore: boolean;
+  onLoadMore: () => Promise<Message[]>;
+  onStickToBottomChange?: (isNearBottom: boolean) => void;
+}
+
+// Mantemos uma janela de mensagens limitada para simular virtualização sem depender de bibliotecas externas.
+const WINDOW_COUNT = 40;
+const OVERSCAN_PX = 320;
+
+const estimateHeight = (message: Message) => {
+  let base = 72;
+  if (message.content) {
+    base += Math.min(160, Math.ceil(message.content.length / 38) * 18);
+  }
+  if (message.attachments && message.attachments.length > 0) {
+    base += 220;
+  }
+  return base;
+};
+
+export const MessageViewport = ({
+  messages,
+  avatarUrl,
+  containerRef,
+  hasMore,
+  isLoadingMore,
+  onLoadMore,
+  onStickToBottomChange,
+}: MessageViewportProps) => {
+  const heightsRef = useRef<Map<string, number>>(new Map());
+  const [heightsVersion, setHeightsVersion] = useState(0);
+  const [visibleRange, setVisibleRange] = useState({ start: 0, end: Math.min(messages.length, WINDOW_COUNT) });
+  const previousLengthRef = useRef(0);
+  const lastStickStateRef = useRef<boolean | null>(null);
+
+  const registerHeight = useCallback((id: string, height: number) => {
+    const current = heightsRef.current.get(id);
+    if (!current || Math.abs(current - height) > 2) {
+      heightsRef.current.set(id, height);
+      setHeightsVersion((value) => value + 1);
+    }
+  }, []);
+
+  const prefixSums = useMemo(() => {
+    // 'heightsVersion' garante o recálculo quando uma bolha muda de tamanho.
+    const version = heightsVersion;
+    void version;
+    const sums: number[] = [0];
+    for (const message of messages) {
+      const height = heightsRef.current.get(message.id) ?? estimateHeight(message);
+      sums.push(sums[sums.length - 1] + height);
+    }
+    return sums;
+  }, [messages, heightsVersion]);
+
+  const getIndexForOffset = useCallback(
+    (offset: number) => {
+      let low = 0;
+      let high = prefixSums.length - 1;
+      while (low < high) {
+        const mid = Math.floor((low + high) / 2);
+        if (prefixSums[mid] <= offset) {
+          low = mid + 1;
+        } else {
+          high = mid;
+        }
+      }
+      return Math.max(0, low - 1);
+    },
+    [prefixSums],
+  );
+
+  const loadMore = useCallback(async () => {
+    if (!hasMore || isLoadingMore) return;
+    const container = containerRef.current;
+    if (!container) return;
+    const previousHeight = container.scrollHeight;
+    const previousTop = container.scrollTop;
+    const loaded = await onLoadMore();
+    if (!loaded.length) return;
+    requestAnimationFrame(() => {
+      const node = containerRef.current;
+      if (node) {
+        const heightDiff = node.scrollHeight - previousHeight;
+        node.scrollTop = previousTop + heightDiff;
+      }
+    });
+  }, [containerRef, hasMore, isLoadingMore, onLoadMore]);
+
+  const updateRange = useCallback(
+    (scrollTop: number, clientHeight: number, scrollHeight: number) => {
+      const isNearBottom = scrollHeight - (scrollTop + clientHeight) < 120;
+      if (lastStickStateRef.current !== isNearBottom) {
+        lastStickStateRef.current = isNearBottom;
+        onStickToBottomChange?.(isNearBottom);
+      }
+      const startOffset = Math.max(0, scrollTop - OVERSCAN_PX);
+      const endOffset = Math.min(scrollHeight, scrollTop + clientHeight + OVERSCAN_PX);
+      const startIndex = getIndexForOffset(startOffset);
+      const endIndex = Math.min(messages.length, getIndexForOffset(endOffset) + 1);
+      setVisibleRange((previous) => {
+        if (previous.start === startIndex && previous.end === endIndex) {
+          return previous;
+        }
+        return { start: startIndex, end: endIndex };
+      });
+    },
+    [getIndexForOffset, messages.length, onStickToBottomChange],
+  );
+
+  const handleScroll: React.UIEventHandler<HTMLDivElement> = (event) => {
+    const target = event.currentTarget;
+    const { scrollTop, clientHeight, scrollHeight } = target;
+    if (scrollTop < 120 && hasMore && !isLoadingMore) {
+      void loadMore();
+    }
+    updateRange(scrollTop, clientHeight, scrollHeight);
+  };
+
+  useEffect(() => {
+    if (previousLengthRef.current === 0 && messages.length > 0) {
+      const end = messages.length;
+      const start = Math.max(0, end - WINDOW_COUNT);
+      setVisibleRange({ start, end });
+    }
+    previousLengthRef.current = messages.length;
+  }, [messages.length]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    updateRange(container.scrollTop, container.clientHeight, container.scrollHeight);
+  }, [containerRef, updateRange, prefixSums]);
+
+  const paddingTop = prefixSums[visibleRange.start] ?? 0;
+  const paddingBottom = (prefixSums[prefixSums.length - 1] ?? 0) - (prefixSums[visibleRange.end] ?? 0);
+
+  const visibleMessages = messages.slice(visibleRange.start, visibleRange.end);
+
+  return (
+    <div ref={containerRef} className={styles.container} onScroll={handleScroll}>
+      {hasMore && isLoadingMore && <div className={styles.loading}>Carregando histórico...</div>}
+      <div className={styles.spacer} style={{ paddingTop, paddingBottom }}>
+        {visibleMessages.map((message, index) => {
+          const absoluteIndex = visibleRange.start + index;
+          const previous = messages[absoluteIndex - 1];
+          const isFirstOfGroup = !previous || previous.sender !== message.sender;
+          return (
+            <MeasuredBubble
+              key={message.id}
+              message={message}
+              isOwnMessage={message.sender === "me"}
+              isFirstOfGroup={isFirstOfGroup}
+              avatarUrl={avatarUrl}
+              onMeasure={registerHeight}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+interface MeasuredBubbleProps {
+  message: Message;
+  isOwnMessage: boolean;
+  isFirstOfGroup: boolean;
+  avatarUrl?: string;
+  onMeasure: (id: string, height: number) => void;
+}
+
+const MeasuredBubble = ({ message, isOwnMessage, isFirstOfGroup, avatarUrl, onMeasure }: MeasuredBubbleProps) => {
+  const bubbleRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const node = bubbleRef.current;
+    if (!node) return;
+    const update = () => {
+      onMeasure(message.id, node.getBoundingClientRect().height);
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [message.id, onMeasure, message.content, message.attachments]);
+
+  return (
+    <MessageBubble
+      ref={bubbleRef}
+      message={message}
+      isOwnMessage={isOwnMessage}
+      isFirstOfGroup={isFirstOfGroup}
+      avatarUrl={avatarUrl}
+    />
+  );
+};

--- a/frontend/src/features/chat/components/Modal.module.css
+++ b/frontend/src/features/chat/components/Modal.module.css
@@ -1,0 +1,31 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: hsl(var(--background) / 0.75);
+  backdrop-filter: blur(6px);
+  z-index: 50;
+  padding: 1.5rem;
+}
+
+.content {
+  background: hsl(var(--card));
+  color: hsl(var(--card-foreground));
+  border-radius: 1rem;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.16);
+  max-width: min(640px, 100%);
+  width: 100%;
+  outline: none;
+}
+
+@media (max-width: 768px) {
+  .overlay {
+    padding: 1rem;
+  }
+
+  .content {
+    border-radius: 0.75rem;
+  }
+}

--- a/frontend/src/features/chat/components/Modal.tsx
+++ b/frontend/src/features/chat/components/Modal.tsx
@@ -1,0 +1,93 @@
+import type { MouseEvent, PropsWithChildren } from "react";
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import styles from "./Modal.module.css";
+
+interface ModalProps {
+  open: boolean;
+  ariaLabel: string;
+  onClose: () => void;
+}
+
+const focusableSelectors = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "textarea:not([disabled])",
+  "select:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+export const Modal = ({ open, ariaLabel, onClose, children }: PropsWithChildren<ModalProps>) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    lastFocusedElementRef.current = document.activeElement as HTMLElement | null;
+    const firstFocusable = containerRef.current?.querySelector<HTMLElement>(
+      focusableSelectors,
+    );
+    firstFocusable?.focus();
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      lastFocusedElementRef.current?.focus();
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key === "Tab") {
+        const focusable = containerRef.current?.querySelectorAll<HTMLElement>(
+          focusableSelectors,
+        );
+        if (!focusable || focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey) {
+          if (document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          }
+        } else if (document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  return createPortal(
+    <div className={styles.overlay} role="presentation" onMouseDown={handleBackdropClick}>
+      <div
+        ref={containerRef}
+        className={styles.content}
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabel}
+        tabIndex={-1}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+};

--- a/frontend/src/features/chat/components/NewConversationModal.module.css
+++ b/frontend/src/features/chat/components/NewConversationModal.module.css
@@ -1,0 +1,132 @@
+.wrapper {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.header h2 {
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.header p {
+  color: hsl(var(--muted-foreground));
+}
+
+.search {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.search input {
+  flex: 1;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--input));
+  color: inherit;
+  padding: 0.7rem 1rem;
+  border-radius: 0.75rem;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease;
+}
+
+.search input:focus {
+  outline: 2px solid hsl(var(--primary));
+  outline-offset: 1px;
+  border-color: hsl(var(--primary));
+}
+
+.createButton {
+  border: none;
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  padding: 0.7rem 1.15rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.createButton[disabled] {
+  cursor: not-allowed;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+}
+
+.createButton:not([disabled]):hover,
+.createButton:not([disabled]):focus-visible {
+  background: hsl(var(--primary-hover));
+}
+
+.list {
+  max-height: 320px;
+  overflow-y: auto;
+  border: 1px solid hsl(var(--border));
+  border-radius: 1rem;
+  padding: 0.5rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.item:hover,
+.item:focus-visible {
+  background: hsl(var(--accent));
+}
+
+.itemAvatar {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  object-fit: cover;
+}
+
+.itemName {
+  font-weight: 600;
+}
+
+.itemDescription {
+  font-size: 0.85rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.empty {
+  text-align: center;
+  padding: 1.5rem 0.5rem;
+  color: hsl(var(--muted-foreground));
+}
+
+@media (max-width: 720px) {
+  .wrapper {
+    padding: 1.5rem;
+  }
+
+  .search {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .createButton {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/frontend/src/features/chat/components/NewConversationModal.tsx
+++ b/frontend/src/features/chat/components/NewConversationModal.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useMemo, useState } from "react";
+import { UserPlus, Sparkles } from "lucide-react";
+import type { ConversationSummary } from "../types";
+import { Modal } from "./Modal";
+import styles from "./NewConversationModal.module.css";
+import { normalizeText } from "../utils/format";
+
+interface NewConversationModalProps {
+  open: boolean;
+  suggestions: ConversationSummary[];
+  onClose: () => void;
+  onSelectConversation: (conversationId: string) => void;
+  onCreateConversation: (name: string) => Promise<string | null>;
+}
+
+export const NewConversationModal = ({
+  open,
+  suggestions,
+  onClose,
+  onSelectConversation,
+  onCreateConversation,
+}: NewConversationModalProps) => {
+  const [search, setSearch] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setSearch("");
+      setIsCreating(false);
+    }
+  }, [open]);
+
+  const normalizedQuery = normalizeText(search);
+  const filtered = useMemo(() => {
+    if (!normalizedQuery) return suggestions;
+    return suggestions.filter((conversation) => {
+      const normalizedName = normalizeText(conversation.name);
+      const normalizedDescription = normalizeText(conversation.description ?? "");
+      return (
+        normalizedName.includes(normalizedQuery) ||
+        (normalizedDescription && normalizedDescription.includes(normalizedQuery))
+      );
+    });
+  }, [normalizedQuery, suggestions]);
+
+  const exactMatch = useMemo(() => {
+    if (!normalizedQuery) return false;
+    return suggestions.some((conversation) => normalizeText(conversation.name) === normalizedQuery);
+  }, [normalizedQuery, suggestions]);
+
+  const canCreate = normalizedQuery.length > 0 && !exactMatch && !isCreating;
+
+  const handleCreate = async () => {
+    if (!canCreate) return;
+    setIsCreating(true);
+    try {
+      const createdId = await onCreateConversation(search.trim());
+      if (createdId) {
+        onSelectConversation(createdId);
+        onClose();
+      }
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (event) => {
+    if (event.key === "Enter" && canCreate) {
+      event.preventDefault();
+      void handleCreate();
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} ariaLabel="Iniciar nova conversa">
+      <div className={styles.wrapper}>
+        <header className={styles.header}>
+          <h2>Nova conversa</h2>
+          <p>Pesquise um contato existente ou crie um novo canal de atendimento instantaneamente.</p>
+        </header>
+        <div className={styles.search}>
+          <input
+            type="text"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Pesquisar cliente, processo ou etiqueta"
+            aria-label="Pesquisar contato"
+            autoFocus
+          />
+          <button
+            type="button"
+            className={styles.createButton}
+            onClick={handleCreate}
+            disabled={!canCreate}
+          >
+            <UserPlus size={18} aria-hidden="true" />
+            {isCreating ? "Criando..." : "Criar contato"}
+          </button>
+        </div>
+        <section aria-live="polite">
+          {filtered.length === 0 ? (
+            <div className={styles.empty}>
+              <Sparkles size={18} aria-hidden="true" /> Nenhum resultado. Pressione Enter para criar "{search.trim()}".
+            </div>
+          ) : (
+            <ul className={styles.list} role="listbox" aria-label="Contatos sugeridos">
+              {filtered.map((conversation) => (
+                <li key={conversation.id}>
+                  <button
+                    type="button"
+                    className={styles.item}
+                    onClick={() => {
+                      onSelectConversation(conversation.id);
+                      onClose();
+                    }}
+                    aria-label={`Abrir conversa com ${conversation.name}`}
+                  >
+                    <img
+                      src={conversation.avatar}
+                      alt=""
+                      className={styles.itemAvatar}
+                      aria-hidden="true"
+                    />
+                    <div>
+                      <div className={styles.itemName}>{conversation.name}</div>
+                      {conversation.description && (
+                        <div className={styles.itemDescription}>{conversation.description}</div>
+                      )}
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </Modal>
+  );
+};

--- a/frontend/src/features/chat/data/chatData.json
+++ b/frontend/src/features/chat/data/chatData.json
@@ -1,0 +1,491 @@
+{
+  "conversations": [
+    {
+      "id": "conv-joana",
+      "name": "Joana Prado",
+      "avatar": "https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=facearea&w=80&h=80&q=80",
+      "shortStatus": "online",
+      "description": "Acordo de honorários • Proc. 2023.451",
+      "unreadCount": 2,
+      "pinned": true
+    },
+    {
+      "id": "conv-financeiro",
+      "name": "Equipe Financeira",
+      "avatar": "https://images.unsplash.com/photo-1483478550801-ceba5fe50e8e?auto=format&fit=facearea&w=80&h=80&q=80",
+      "shortStatus": "responde normalmente em 1h",
+      "description": "Dúvidas sobre faturamento",
+      "unreadCount": 0,
+      "pinned": true
+    },
+    {
+      "id": "conv-carlos",
+      "name": "Carlos Mendes",
+      "avatar": "https://images.unsplash.com/photo-1599566150163-29194dcaad36?auto=format&fit=facearea&w=80&h=80&q=80",
+      "shortStatus": "visto às 08:10",
+      "description": "Contrato de consultoria",
+      "unreadCount": 0
+    },
+    {
+      "id": "conv-tribunal",
+      "name": "Secretaria do TJ-SP",
+      "avatar": "https://images.unsplash.com/photo-1528747008803-1f5c1cbd6c24?auto=format&fit=facearea&w=80&h=80&q=80",
+      "shortStatus": "expediente até 19h",
+      "description": "Avisos do tribunal",
+      "unreadCount": 5
+    },
+    {
+      "id": "conv-marketing",
+      "name": "Marketing InCompany",
+      "avatar": "https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=facearea&w=80&h=80&q=80",
+      "shortStatus": "online",
+      "description": "Campanha institucional",
+      "unreadCount": 0
+    },
+    {
+      "id": "conv-diligence",
+      "name": "Grupo Due Diligence",
+      "avatar": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=facearea&w=80&h=80&q=80",
+      "shortStatus": "último acesso às 22:15",
+      "description": "Auditoria Tech&Law",
+      "unreadCount": 3
+    },
+    {
+      "id": "conv-ana",
+      "name": "Cliente • Ana Luz",
+      "avatar": "https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=facearea&w=80&h=80&q=80",
+      "shortStatus": "aguardando retorno",
+      "description": "Revisão de cláusulas",
+      "unreadCount": 0
+    },
+    {
+      "id": "conv-paula",
+      "name": "Carlos & Paula",
+      "avatar": "https://images.unsplash.com/photo-1544005313-94ddf0286df2?auto=format&fit=facearea&w=80&h=80&q=80",
+      "shortStatus": "online",
+      "description": "Atualização audiência",
+      "unreadCount": 1
+    }
+  ],
+  "messages": {
+    "conv-joana": [
+      {
+        "id": "m-joana-001",
+        "conversationId": "conv-joana",
+        "sender": "contact",
+        "content": "Bom dia, doutor! Conseguiu revisar a minuta atualizada?",
+        "timestamp": "2024-11-05T08:05:00.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-002",
+        "conversationId": "conv-joana",
+        "sender": "me",
+        "content": "Bom dia, Joana! Estou finalizando agora, já te envio na sequência.",
+        "timestamp": "2024-11-05T08:06:30.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-003",
+        "conversationId": "conv-joana",
+        "sender": "contact",
+        "content": "Perfeito. Preciso apresentar ao conselho ainda hoje, então qualquer ajuste que ache pertinente pode sinalizar.",
+        "timestamp": "2024-11-05T08:12:00.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-004",
+        "conversationId": "conv-joana",
+        "sender": "me",
+        "content": "Incluí cláusula de reajuste atrelada ao IPCA e limitei a multa rescisória a 30%. Faz sentido para vocês?",
+        "timestamp": "2024-11-05T08:18:00.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-005",
+        "conversationId": "conv-joana",
+        "sender": "contact",
+        "content": "Excelente. O conselho pediu apenas para deixar explícita a possibilidade de revisão trimestral.",
+        "timestamp": "2024-11-05T08:21:40.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-006",
+        "conversationId": "conv-joana",
+        "sender": "me",
+        "content": "Acabo de anexar a nova versão com essa previsão. Segue aqui o trecho destacado.",
+        "timestamp": "2024-11-05T08:23:10.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-007",
+        "conversationId": "conv-joana",
+        "sender": "me",
+        "content": "Também inclui uma nota explicando o racional para facilitar a apresentação.",
+        "timestamp": "2024-11-05T08:23:30.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-008",
+        "conversationId": "conv-joana",
+        "sender": "contact",
+        "content": "Ficou ótimo! Você consegue preparar um slide resumindo os indicadores jurídicos que monitoramos?",
+        "timestamp": "2024-11-05T08:31:00.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-009",
+        "conversationId": "conv-joana",
+        "sender": "me",
+        "content": "Sim, mando em PDF ainda pela manhã.",
+        "timestamp": "2024-11-05T08:32:20.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-010",
+        "conversationId": "conv-joana",
+        "sender": "contact",
+        "content": "Obrigada! Lembrei de anexar as minutas assinadas do aditivo passado para você comparar.",
+        "timestamp": "2024-11-05T08:40:10.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-011",
+        "conversationId": "conv-joana",
+        "sender": "contact",
+        "content": "Segue o PDF com a assinatura digital consolidada.",
+        "timestamp": "2024-11-05T08:40:40.000Z",
+        "status": "read",
+        "type": "image",
+        "attachments": [
+          {
+            "id": "att-joana-001",
+            "type": "image",
+            "url": "https://images.unsplash.com/photo-1521791136064-7986c2920216?auto=format&fit=crop&w=640&q=80",
+            "name": "assinatura-aditivo.png"
+          }
+        ]
+      },
+      {
+        "id": "m-joana-012",
+        "conversationId": "conv-joana",
+        "sender": "me",
+        "content": "Recebido. Vou comparar com a nova redação e te aviso se notar algum conflito.",
+        "timestamp": "2024-11-05T08:45:10.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-013",
+        "conversationId": "conv-joana",
+        "sender": "contact",
+        "content": "Combinado. O conselho se reúne às 14h, então te ligo depois para alinharmos a assinatura.",
+        "timestamp": "2024-11-05T09:00:00.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-014",
+        "conversationId": "conv-joana",
+        "sender": "me",
+        "content": "Perfeito. Estarei disponível a partir das 13h30 para qualquer ajuste final.",
+        "timestamp": "2024-11-05T09:01:15.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-015",
+        "conversationId": "conv-joana",
+        "sender": "contact",
+        "content": "Ótimo. Aliás, conseguimos revisar o indicador de performance do time externo?",
+        "timestamp": "2024-11-05T09:05:45.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-016",
+        "conversationId": "conv-joana",
+        "sender": "me",
+        "content": "Atualizei para 92% considerando o fechamento do último trimestre.",
+        "timestamp": "2024-11-05T09:07:12.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-017",
+        "conversationId": "conv-joana",
+        "sender": "contact",
+        "content": "Excelente. Vou usar esse número na apresentação.",
+        "timestamp": "2024-11-05T09:08:54.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-018",
+        "conversationId": "conv-joana",
+        "sender": "contact",
+        "content": "Te aviso qualquer novidade antes da reunião.",
+        "timestamp": "2024-11-05T09:15:10.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-019",
+        "conversationId": "conv-joana",
+        "sender": "me",
+        "content": "Obrigado, Joana. Boa reunião!",
+        "timestamp": "2024-11-05T09:16:50.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-020",
+        "conversationId": "conv-joana",
+        "sender": "contact",
+        "content": "Retorno às 14h30 com o parecer final.",
+        "timestamp": "2024-11-05T09:17:05.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-021",
+        "conversationId": "conv-joana",
+        "sender": "contact",
+        "content": "Obrigada pelo suporte rápido!",
+        "timestamp": "2024-11-05T09:17:45.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-022",
+        "conversationId": "conv-joana",
+        "sender": "me",
+        "content": "Sempre à disposição. Até mais tarde!",
+        "timestamp": "2024-11-05T09:18:20.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-023",
+        "conversationId": "conv-joana",
+        "sender": "contact",
+        "content": "Antes que eu esqueça: pode incluir uma observação sobre reajuste extraordinário em caso de mudança regulatória?",
+        "timestamp": "2024-11-05T11:02:10.000Z",
+        "status": "delivered",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-024",
+        "conversationId": "conv-joana",
+        "sender": "me",
+        "content": "Claro, acrescento agora e envio nova versão até o meio-dia.",
+        "timestamp": "2024-11-05T11:04:00.000Z",
+        "status": "sent",
+        "type": "text"
+      },
+      {
+        "id": "m-joana-025",
+        "conversationId": "conv-joana",
+        "sender": "contact",
+        "content": "Perfeito. Obrigada!",
+        "timestamp": "2024-11-05T11:05:15.000Z",
+        "status": "delivered",
+        "type": "text"
+      }
+    ],
+    "conv-financeiro": [
+      {
+        "id": "m-fin-001",
+        "conversationId": "conv-financeiro",
+        "sender": "me",
+        "content": "Pessoal, segue o relatório consolidado das notas fiscais emitidas em outubro.",
+        "timestamp": "2024-11-04T14:20:00.000Z",
+        "status": "read",
+        "type": "text"
+      },
+      {
+        "id": "m-fin-002",
+        "conversationId": "conv-financeiro",
+        "sender": "contact",
+        "content": "Obrigada! Vamos validar e retorno ainda hoje com eventuais ajustes.",
+        "timestamp": "2024-11-04T14:28:00.000Z",
+        "status": "read",
+        "type": "text"
+      }
+    ],
+    "conv-carlos": [
+      {
+        "id": "m-carlos-001",
+        "conversationId": "conv-carlos",
+        "sender": "contact",
+        "content": "Bom dia! Preciso alterar a cláusula de confidencialidade para incluir a subsidiária da holding.",
+        "timestamp": "2024-11-05T07:45:00.000Z",
+        "status": "delivered",
+        "type": "text"
+      },
+      {
+        "id": "m-carlos-002",
+        "conversationId": "conv-carlos",
+        "sender": "me",
+        "content": "Sem problemas, Carlos. Posso enviar uma versão revisada até o fim do dia.",
+        "timestamp": "2024-11-05T07:46:30.000Z",
+        "status": "sent",
+        "type": "text"
+      }
+    ],
+    "conv-tribunal": [
+      {
+        "id": "m-tribunal-001",
+        "conversationId": "conv-tribunal",
+        "sender": "contact",
+        "content": "Publicada nova movimentação no processo 1045537-89.2021.8.26.0100.",
+        "timestamp": "2024-11-04T22:30:00.000Z",
+        "status": "delivered",
+        "type": "text"
+      },
+      {
+        "id": "m-tribunal-002",
+        "conversationId": "conv-tribunal",
+        "sender": "contact",
+        "content": "Prazo de manifestação: 5 dias úteis a contar de 05/11.",
+        "timestamp": "2024-11-04T22:30:25.000Z",
+        "status": "delivered",
+        "type": "text"
+      },
+      {
+        "id": "m-tribunal-003",
+        "conversationId": "conv-tribunal",
+        "sender": "contact",
+        "content": "Envio da intimação digitalizado em anexo.",
+        "timestamp": "2024-11-04T22:31:00.000Z",
+        "status": "delivered",
+        "type": "image",
+        "attachments": [
+          {
+            "id": "att-tribunal-001",
+            "type": "image",
+            "url": "https://images.unsplash.com/photo-1509023464722-18d996393ca8?auto=format&fit=crop&w=640&q=80",
+            "name": "intimacao-1045537.png"
+          }
+        ]
+      }
+    ],
+    "conv-marketing": [
+      {
+        "id": "m-marketing-001",
+        "conversationId": "conv-marketing",
+        "sender": "contact",
+        "content": "Segue rascunho dos posts da próxima semana.",
+        "timestamp": "2024-11-03T17:10:00.000Z",
+        "status": "delivered",
+        "type": "text"
+      },
+      {
+        "id": "m-marketing-002",
+        "conversationId": "conv-marketing",
+        "sender": "me",
+        "content": "Gostei das variações 1 e 3. Só ajustaria a cor do banner para ficar em linha com o guia da marca.",
+        "timestamp": "2024-11-03T17:18:10.000Z",
+        "status": "sent",
+        "type": "text"
+      },
+      {
+        "id": "m-marketing-003",
+        "conversationId": "conv-marketing",
+        "sender": "contact",
+        "content": "Perfeito! Atualizo ainda hoje e mando para aprovação final.",
+        "timestamp": "2024-11-03T17:20:33.000Z",
+        "status": "delivered",
+        "type": "text"
+      }
+    ],
+    "conv-diligence": [
+      {
+        "id": "m-dili-001",
+        "conversationId": "conv-diligence",
+        "sender": "contact",
+        "content": "Atualização do checklist: 14 itens pendentes para validação jurídica.",
+        "timestamp": "2024-11-04T23:10:00.000Z",
+        "status": "delivered",
+        "type": "text"
+      },
+      {
+        "id": "m-dili-002",
+        "conversationId": "conv-diligence",
+        "sender": "contact",
+        "content": "Precisamos priorizar os contratos de fornecedores estratégicos.",
+        "timestamp": "2024-11-04T23:12:05.000Z",
+        "status": "delivered",
+        "type": "text"
+      },
+      {
+        "id": "m-dili-003",
+        "conversationId": "conv-diligence",
+        "sender": "me",
+        "content": "Organizo um mutirão às 9h com o time societário para revisar os pendentes.",
+        "timestamp": "2024-11-05T07:30:00.000Z",
+        "status": "sent",
+        "type": "text"
+      }
+    ],
+    "conv-ana": [
+      {
+        "id": "m-ana-001",
+        "conversationId": "conv-ana",
+        "sender": "contact",
+        "content": "Doutor, consegue revisar a cláusula 5? Acho que está muito extensa para o cliente entender.",
+        "timestamp": "2024-11-04T19:25:00.000Z",
+        "status": "delivered",
+        "type": "text"
+      },
+      {
+        "id": "m-ana-002",
+        "conversationId": "conv-ana",
+        "sender": "me",
+        "content": "Claro, Ana. Posso te mandar um áudio explicando a redação e as alternativas?",
+        "timestamp": "2024-11-04T19:30:40.000Z",
+        "status": "sent",
+        "type": "text"
+      }
+    ],
+    "conv-paula": [
+      {
+        "id": "m-paula-001",
+        "conversationId": "conv-paula",
+        "sender": "contact",
+        "content": "O juiz converteu a audiência em virtual na próxima terça às 10h.",
+        "timestamp": "2024-11-05T10:22:00.000Z",
+        "status": "delivered",
+        "type": "text"
+      },
+      {
+        "id": "m-paula-002",
+        "conversationId": "conv-paula",
+        "sender": "contact",
+        "content": "Preciso confirmar com vocês a estratégia de sustentação.",
+        "timestamp": "2024-11-05T10:22:45.000Z",
+        "status": "delivered",
+        "type": "text"
+      },
+      {
+        "id": "m-paula-003",
+        "conversationId": "conv-paula",
+        "sender": "me",
+        "content": "Vamos alinhar às 18h ainda hoje e te envio o roteiro atualizado.",
+        "timestamp": "2024-11-05T10:40:00.000Z",
+        "status": "sent",
+        "type": "text"
+      }
+    ]
+  }
+}

--- a/frontend/src/features/chat/hooks/useChatMessages.ts
+++ b/frontend/src/features/chat/hooks/useChatMessages.ts
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  fetchConversationMessages,
+  sendConversationMessage,
+} from "../services/chatApi";
+import type { Message, MessagePage, SendMessageInput } from "../types";
+
+interface UseChatMessagesResult {
+  messages: Message[];
+  hasMore: boolean;
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  loadOlder: () => Promise<Message[]>;
+  reload: () => Promise<void>;
+  sendMessage: (payload: SendMessageInput) => Promise<Message | null>;
+  reset: () => void;
+}
+
+// Carregamos blocos pequenos para combinar com a janela virtualizada da área de mensagens.
+const DEFAULT_PAGE_SIZE = 24;
+
+export const useChatMessages = (
+  conversationId?: string,
+  pageSize = DEFAULT_PAGE_SIZE,
+): UseChatMessagesResult => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [hasMore, setHasMore] = useState(false);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const activeConversationRef = useRef<string | undefined>(conversationId);
+
+  useEffect(() => {
+    activeConversationRef.current = conversationId;
+  }, [conversationId]);
+
+  const applyPage = useCallback(
+    (page: MessagePage, resetList = false) => {
+      setMessages((current) =>
+        resetList ? page.messages : [...page.messages, ...current],
+      );
+      setCursor(page.nextCursor ?? null);
+      setHasMore(Boolean(page.nextCursor));
+    },
+    [],
+  );
+
+  const reload = useCallback(async () => {
+    if (!conversationId) return;
+    setIsLoading(true);
+    try {
+      const page = await fetchConversationMessages(conversationId, null, pageSize);
+      if (activeConversationRef.current !== conversationId) return;
+      applyPage(page, true);
+    } finally {
+      if (activeConversationRef.current === conversationId) {
+        setIsLoading(false);
+      }
+    }
+  }, [applyPage, conversationId, pageSize]);
+
+  const loadOlder = useCallback(async () => {
+    if (!conversationId || !cursor || isLoadingMore) return [];
+    setIsLoadingMore(true);
+    try {
+      const page = await fetchConversationMessages(conversationId, cursor, pageSize);
+      if (activeConversationRef.current !== conversationId) return [];
+      applyPage(page, false);
+      return page.messages;
+    } finally {
+      if (activeConversationRef.current === conversationId) {
+        setIsLoadingMore(false);
+      }
+    }
+  }, [applyPage, conversationId, cursor, isLoadingMore, pageSize]);
+
+  const sendMessage = useCallback(
+    async (payload: SendMessageInput) => {
+      if (!conversationId) return null;
+      const message = await sendConversationMessage(conversationId, payload);
+      if (activeConversationRef.current !== conversationId) return null;
+      setMessages((current) => [...current, message]);
+      setHasMore((currentHasMore) => currentHasMore);
+      return message;
+    },
+    [conversationId],
+  );
+
+  const reset = useCallback(() => {
+    setMessages([]);
+    setCursor(null);
+    setHasMore(false);
+    setIsLoading(false);
+    setIsLoadingMore(false);
+  }, []);
+
+  useEffect(() => {
+    if (!conversationId) {
+      reset();
+      return;
+    }
+    reset();
+    void reload();
+  }, [conversationId, reload, reset]);
+
+  return {
+    messages,
+    hasMore,
+    isLoading,
+    isLoadingMore,
+    loadOlder,
+    reload,
+    sendMessage,
+    reset,
+  };
+};

--- a/frontend/src/features/chat/services/chatApi.ts
+++ b/frontend/src/features/chat/services/chatApi.ts
@@ -1,0 +1,67 @@
+import type {
+  ConversationSummary,
+  Message,
+  MessagePage,
+  NewConversationInput,
+  SendMessageInput,
+} from "../types";
+
+const parseJson = async <T>(response: Response): Promise<T> => {
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || `Erro de rede (${response.status})`);
+  }
+  if (response.status === 204) {
+    return {} as T;
+  }
+  return (await response.json()) as T;
+};
+
+export const fetchConversations = async (): Promise<ConversationSummary[]> => {
+  const response = await fetch("/api/conversations");
+  return parseJson<ConversationSummary[]>(response);
+};
+
+export const fetchConversationMessages = async (
+  conversationId: string,
+  cursor?: string | null,
+  limit = 20,
+): Promise<MessagePage> => {
+  const url = new URL(`/api/conversations/${conversationId}/messages`, window.location.origin);
+  if (cursor) {
+    url.searchParams.set("cursor", cursor);
+  }
+  url.searchParams.set("limit", String(limit));
+  const response = await fetch(url.toString());
+  return parseJson<MessagePage>(response);
+};
+
+export const sendConversationMessage = async (
+  conversationId: string,
+  payload: SendMessageInput,
+): Promise<Message> => {
+  const response = await fetch(`/api/conversations/${conversationId}/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return parseJson<Message>(response);
+};
+
+export const markConversationRead = async (conversationId: string) => {
+  const response = await fetch(`/api/conversations/${conversationId}/read`, {
+    method: "POST",
+  });
+  await parseJson(response);
+};
+
+export const createConversation = async (
+  payload: NewConversationInput,
+): Promise<ConversationSummary> => {
+  const response = await fetch(`/api/conversations`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return parseJson<ConversationSummary>(response);
+};

--- a/frontend/src/features/chat/services/mockServer.ts
+++ b/frontend/src/features/chat/services/mockServer.ts
@@ -1,0 +1,263 @@
+import chatData from "../data/chatData.json";
+import type {
+  ChatDataset,
+  ConversationDatasetEntry,
+  ConversationLastMessage,
+  ConversationSummary,
+  Message,
+  MessagePage,
+  NewConversationInput,
+  SendMessageInput,
+} from "../types";
+import { getMessagePreview } from "../utils/format";
+
+const NETWORK_DELAY = 220;
+
+type Dataset = ChatDataset & {
+  conversations: (ConversationDatasetEntry & { lastActivity?: string })[];
+};
+
+const dataset: Dataset = (() => {
+  // Clonamos o JSON para permitir mutações locais sem afetar o arquivo original.
+  const clone: Dataset = JSON.parse(JSON.stringify(chatData));
+  Object.keys(clone.messages).forEach((key) => {
+    clone.messages[key]?.sort(
+      (a: Message, b: Message) =>
+        new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+    );
+  });
+  clone.conversations = clone.conversations.map((entry) => ({
+    ...entry,
+    lastActivity: getLastActivityTimestamp(clone.messages[entry.id]),
+  }));
+  return clone;
+})();
+
+const originalFetch = typeof window !== "undefined" ? window.fetch.bind(window) : undefined;
+
+const withLatency = (body: unknown, init?: ResponseInit) =>
+  new Promise<Response>((resolve) => {
+    setTimeout(() => {
+      resolve(
+        new Response(body === undefined ? null : JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+          ...init,
+        }),
+      );
+    }, NETWORK_DELAY);
+  });
+
+const notFound = () =>
+  withLatency(
+    { message: "Recurso não encontrado" },
+    { status: 404, headers: { "Content-Type": "application/json" } },
+  );
+
+function getLastActivityTimestamp(messages: Message[] | undefined) {
+  if (!messages || messages.length === 0) {
+    return new Date(0).toISOString();
+  }
+  return messages[messages.length - 1]!.timestamp;
+}
+
+function buildLastMessage(message: Message | undefined): ConversationLastMessage | undefined {
+  if (!message) return undefined;
+  return {
+    id: message.id,
+    content: message.content,
+    preview: getMessagePreview(message.content, message.type),
+    timestamp: message.timestamp,
+    sender: message.sender,
+    type: message.type,
+    status: message.status,
+  };
+}
+
+function buildSummary(entry: ConversationDatasetEntry): ConversationSummary {
+  const messages = dataset.messages[entry.id] ?? [];
+  const lastMessage = buildLastMessage(messages[messages.length - 1]);
+  return {
+    ...entry,
+    lastMessage,
+  };
+}
+
+function listConversations() {
+  const conversations = dataset.conversations
+    .map((entry) => ({
+      ...entry,
+      lastActivity: getLastActivityTimestamp(dataset.messages[entry.id]),
+    }))
+    .sort((a, b) => {
+      const timeA = new Date(a.lastActivity ?? 0).getTime();
+      const timeB = new Date(b.lastActivity ?? 0).getTime();
+      return timeB - timeA;
+    })
+    .map((entry) => buildSummary(entry));
+  return conversations;
+}
+
+function getMessages(
+  conversationId: string,
+  cursor?: string | null,
+  limit = 20,
+): MessagePage {
+  const allMessages = dataset.messages[conversationId] ?? [];
+  if (allMessages.length === 0) {
+    return { messages: [], nextCursor: null };
+  }
+  const sorted = [...allMessages].sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+  );
+  if (!cursor) {
+    const slice = sorted.slice(-limit);
+    const nextCursor = sorted.length > slice.length ? sorted[sorted.length - slice.length - 1]!.id : null;
+    return { messages: slice, nextCursor };
+  }
+  const cursorIndex = sorted.findIndex((message) => message.id === cursor);
+  if (cursorIndex === -1) {
+    const slice = sorted.slice(-limit);
+    const nextCursor = sorted.length > slice.length ? sorted[sorted.length - slice.length - 1]!.id : null;
+    return { messages: slice, nextCursor };
+  }
+  const sliceStart = Math.max(0, cursorIndex - limit);
+  const slice = sorted.slice(sliceStart, cursorIndex);
+  const nextCursor = sliceStart > 0 ? sorted[sliceStart - 1]!.id : null;
+  return { messages: slice, nextCursor };
+}
+
+function createConversation(payload: NewConversationInput) {
+  const id = `conv-${Date.now()}`;
+  const newConversation: ConversationDatasetEntry & { lastActivity?: string } = {
+    id,
+    name: payload.name,
+    avatar:
+      payload.avatar ??
+      "https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=facearea&w=80&h=80&q=80",
+    shortStatus: "novo contato",
+    description: payload.description,
+    unreadCount: 0,
+    lastActivity: new Date().toISOString(),
+  };
+  dataset.conversations.push(newConversation);
+  dataset.messages[id] = [];
+  return buildSummary(newConversation);
+}
+
+function appendMessage(
+  conversationId: string,
+  body: SendMessageInput,
+  sender: "me" | "contact" = "me",
+): Message {
+  const id = `m-${conversationId}-${Date.now()}`;
+  const computedContent = body.content?.trim()
+    ? body.content
+    : body.attachments && body.attachments.length > 0
+      ? body.attachments[0]!.name
+      : "";
+  const message: Message = {
+    id,
+    conversationId,
+    sender,
+    content: computedContent,
+    timestamp: new Date().toISOString(),
+    status: sender === "me" ? "sent" : "delivered",
+    type: body.type ?? "text",
+    attachments: body.attachments,
+  };
+  if (!dataset.messages[conversationId]) {
+    dataset.messages[conversationId] = [];
+  }
+  dataset.messages[conversationId]!.push(message);
+  const conversation = dataset.conversations.find((item) => item.id === conversationId);
+  if (conversation) {
+    conversation.lastActivity = message.timestamp;
+    if (sender === "contact") {
+      conversation.unreadCount = (conversation.unreadCount ?? 0) + 1;
+    }
+  }
+  return message;
+}
+
+function markConversationAsRead(conversationId: string) {
+  const conversation = dataset.conversations.find((item) => item.id === conversationId);
+  if (conversation) {
+    conversation.unreadCount = 0;
+  }
+}
+
+function updateConversationAfterSend(conversationId: string) {
+  const conversation = dataset.conversations.find((item) => item.id === conversationId);
+  if (!conversation) return;
+  const summary = buildSummary(conversation);
+  conversation.lastActivity = summary.lastMessage?.timestamp ?? conversation.lastActivity;
+}
+
+export const setupMockChatServer = () => {
+  if (typeof window === "undefined" || !originalFetch) return;
+  const globalWindow = window as typeof window & { __chatMockServer?: boolean };
+  if (globalWindow.__chatMockServer) return;
+
+  globalWindow.__chatMockServer = true;
+
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : (input instanceof URL ? input.toString() : input.url);
+    const method = (init?.method ?? (typeof input === "object" && "method" in input ? (input as Request).method : "GET")).toUpperCase();
+    const requestUrl = new URL(url, window.location.origin);
+
+    if (!requestUrl.pathname.startsWith("/api/conversations")) {
+      return originalFetch(input, init);
+    }
+
+    try {
+      if (requestUrl.pathname === "/api/conversations" && method === "GET") {
+        const data = listConversations();
+        return withLatency(data);
+      }
+
+      if (requestUrl.pathname === "/api/conversations" && method === "POST") {
+        const payload = init?.body ? (JSON.parse(init.body.toString()) as NewConversationInput) : { name: "Novo contato" };
+        const conversation = createConversation(payload);
+        return withLatency(conversation, { status: 201 });
+      }
+
+      const match = requestUrl.pathname.match(/^\/api\/conversations\/([^/]+)(?:\/(messages|read))?$/);
+      if (!match) {
+        return notFound();
+      }
+      const conversationId = decodeURIComponent(match[1]);
+      const action = match[2];
+
+      if (method === "POST" && action === "messages") {
+        const payload = init?.body
+          ? (JSON.parse(init.body.toString()) as SendMessageInput)
+          : { content: "" };
+        const message = appendMessage(conversationId, payload, "me");
+        updateConversationAfterSend(conversationId);
+        return withLatency(message, { status: 201 });
+      }
+
+      if (method === "GET" && action === "messages") {
+        const cursor = requestUrl.searchParams.get("cursor");
+        const limitParam = requestUrl.searchParams.get("limit");
+        const limit = limitParam ? Number.parseInt(limitParam, 10) : 20;
+        const page = getMessages(conversationId, cursor, Number.isNaN(limit) ? 20 : limit);
+        return withLatency(page);
+      }
+
+      if (method === "POST" && action === "read") {
+        markConversationAsRead(conversationId);
+        return withLatency({ ok: true });
+      }
+
+      return notFound();
+    } catch (error) {
+      console.error("Mock server error", error);
+      return withLatency(
+        { message: error instanceof Error ? error.message : "Erro interno" },
+        { status: 500 },
+      );
+    }
+  };
+};

--- a/frontend/src/features/chat/types.ts
+++ b/frontend/src/features/chat/types.ts
@@ -1,0 +1,73 @@
+export type MessageStatus = "sent" | "delivered" | "read";
+export type MessageType = "text" | "image";
+
+export interface MessageAttachment {
+  id: string;
+  type: "image";
+  url: string;
+  name: string;
+}
+
+export interface Message {
+  id: string;
+  conversationId: string;
+  sender: "me" | "contact";
+  content: string;
+  timestamp: string;
+  status: MessageStatus;
+  type: MessageType;
+  attachments?: MessageAttachment[];
+}
+
+export interface ConversationSummary {
+  id: string;
+  name: string;
+  avatar: string;
+  shortStatus: string;
+  description?: string;
+  unreadCount: number;
+  pinned?: boolean;
+  lastMessage?: ConversationLastMessage;
+}
+
+export interface ConversationLastMessage {
+  id: string;
+  content: string;
+  preview: string;
+  timestamp: string;
+  sender: "me" | "contact";
+  type: MessageType;
+  status: MessageStatus;
+}
+
+export interface ConversationDatasetEntry {
+  id: string;
+  name: string;
+  avatar: string;
+  shortStatus: string;
+  description?: string;
+  unreadCount: number;
+  pinned?: boolean;
+}
+
+export interface ChatDataset {
+  conversations: ConversationDatasetEntry[];
+  messages: Record<string, Message[]>;
+}
+
+export interface MessagePage {
+  messages: Message[];
+  nextCursor: string | null;
+}
+
+export interface NewConversationInput {
+  name: string;
+  description?: string;
+  avatar?: string;
+}
+
+export interface SendMessageInput {
+  content: string;
+  type?: MessageType;
+  attachments?: MessageAttachment[];
+}

--- a/frontend/src/features/chat/utils/format.ts
+++ b/frontend/src/features/chat/utils/format.ts
@@ -1,0 +1,58 @@
+const intlTime = new Intl.DateTimeFormat("pt-BR", {
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+const intlDay = new Intl.DateTimeFormat("pt-BR", {
+  day: "2-digit",
+  month: "2-digit",
+});
+
+const intlFull = new Intl.DateTimeFormat("pt-BR", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+});
+
+export const formatTime = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "--:--";
+  return intlTime.format(date);
+};
+
+export const formatConversationTimestamp = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const startOfYesterday = new Date(startOfToday.getTime() - 24 * 60 * 60 * 1000);
+  const startOfGivenDay = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const diffInDays = Math.floor(
+    (startOfToday.getTime() - startOfGivenDay.getTime()) / (24 * 60 * 60 * 1000),
+  );
+  if (date >= startOfToday) {
+    return formatTime(value);
+  }
+  if (date >= startOfYesterday) {
+    return "Ontem";
+  }
+  if (diffInDays < 7) {
+    return date.toLocaleDateString("pt-BR", { weekday: "short" });
+  }
+  if (date.getFullYear() === now.getFullYear()) {
+    return intlDay.format(date);
+  }
+  return intlFull.format(date);
+};
+
+export const getMessagePreview = (content: string, type: string) => {
+  if (type === "image") return "Imagem";
+  if (content.length <= 56) return content;
+  return `${content.slice(0, 56).trim()}…`;
+};
+
+export const normalizeText = (value: string) =>
+  value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[^\p{Letter}\p{Number}\s]/gu, "");

--- a/frontend/src/pages/Conversas.tsx
+++ b/frontend/src/pages/Conversas.tsx
@@ -1,0 +1,5 @@
+import { ChatPage } from "../features/chat/ChatPage";
+
+const Conversas = () => <ChatPage />;
+
+export default Conversas;


### PR DESCRIPTION
## Summary
- add chat data mocks and fetch interceptor to simulate conversations API
- build conversations workspace with sidebar, virtualized message viewport, and rich input
- expose new /conversas route in navigation and document usage in README

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c89b60d770832696d0f8698a8fc10d