### PR TITLE
Fix chat layout scrolling

### DIFF
--- a/frontend/src/features/chat/ChatPage.module.css
+++ b/frontend/src/features/chat/ChatPage.module.css
@@ -1,8 +1,12 @@
 .layout {
   display: flex;
-  min-height: calc(100vh - 4rem);
+  width: 100%;
+  height: calc(100vh - 4rem);
+  max-height: calc(100vh - 4rem);
   background: hsl(var(--background));
   color: hsl(var(--foreground));
+  overflow: hidden;
+  min-height: 0;
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/features/chat/components/ChatSidebar.module.css
+++ b/frontend/src/features/chat/components/ChatSidebar.module.css
@@ -7,6 +7,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-height: 0;
 }
 
 .header {
@@ -74,6 +75,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+  min-height: 0;
 }
 
 .list {

--- a/frontend/src/features/chat/components/ChatWindow.module.css
+++ b/frontend/src/features/chat/components/ChatWindow.module.css
@@ -3,6 +3,8 @@
   display: flex;
   flex-direction: column;
   background: hsl(var(--background));
+  height: 100%;
+  min-height: 0;
 }
 
 .header {

--- a/frontend/src/features/chat/components/MessageViewport.module.css
+++ b/frontend/src/features/chat/components/MessageViewport.module.css
@@ -4,6 +4,7 @@
   padding: 1.5rem 1.75rem;
   display: flex;
   flex-direction: column;
+  min-height: 0;
 }
 
 .spacer {


### PR DESCRIPTION
## Summary
- constrain the chat page container to the viewport height below the header so the page itself no longer scrolls
- allow the chat sidebar, window, and message viewport flex regions to shrink and manage their own scroll areas

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8a83e4a4c8326b297ae8cc33addd9