### PR TITLE
Hide Meu Perfil from sidebar navigation

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -19,7 +19,6 @@ import {
   ChevronLeft,
   ChevronRight,
   LogOut,
-  UserCircle,
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -87,7 +86,6 @@ export function Sidebar() {
     { name: "Documentos", href: "/documentos", icon: FileText },
     { name: "Financeiro", href: "/financeiro/lancamentos", icon: DollarSign },
     { name: "Relatórios", href: "/relatorios", icon: BarChart3 },
-    { name: "Meu Perfil", href: "/meu-perfil", icon: UserCircle },
     { name: "Meu Plano", href: "/meu-plano", icon: CreditCard },
     { name: "Suporte", href: "/suporte", icon: LifeBuoy },
     {


### PR DESCRIPTION
## Summary
- remove the Meu Perfil entry from the sidebar navigation so the profile is accessed via the account dropdown

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8abe540e0832685d3099f7d8830e1