### PR TITLE
Add integration API key management

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -31,6 +31,8 @@ O arquivo `sql/templates.sql` contém a estrutura mínima para as tabelas `templ
 
 O script `sql/support.sql` cria a tabela `support_requests` utilizada pelo módulo de suporte.
 
+O script `sql/integration_api_keys.sql` define a tabela `integration_api_keys`, responsável por armazenar as chaves de API configuradas na tela de Integrações.
+
 ## CORS
 
 Por padrão o backend libera requisições vindas de `localhost` e do domínio `https://jusconnec.quantumtecnologia.com.br`. Caso precise habilitar outros hosts, defina a variável de ambiente `CORS_ALLOWED_ORIGINS` com uma lista de URLs separadas por vírgula:

--- a/backend/sql/integration_api_keys.sql
+++ b/backend/sql/integration_api_keys.sql
@@ -1,0 +1,33 @@
+-- Estrutura para armazenamento de chaves de API das integrações
+CREATE TABLE IF NOT EXISTS integration_api_keys (
+  id BIGSERIAL PRIMARY KEY,
+  provider TEXT NOT NULL CHECK (provider IN ('gemini', 'openai')),
+  key_value TEXT NOT NULL,
+  environment TEXT NOT NULL CHECK (environment IN ('producao', 'homologacao')),
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  last_used TIMESTAMPTZ NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_integration_api_keys_provider
+  ON integration_api_keys (provider);
+
+CREATE INDEX IF NOT EXISTS idx_integration_api_keys_active
+  ON integration_api_keys (active)
+  WHERE active IS TRUE;
+
+-- Atualiza automaticamente o campo updated_at a cada modificação
+CREATE OR REPLACE FUNCTION set_integration_api_keys_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_integration_api_keys_updated_at ON integration_api_keys;
+CREATE TRIGGER trg_integration_api_keys_updated_at
+  BEFORE UPDATE ON integration_api_keys
+  FOR EACH ROW
+  EXECUTE FUNCTION set_integration_api_keys_updated_at();

--- a/backend/src/controllers/integrationApiKeyController.ts
+++ b/backend/src/controllers/integrationApiKeyController.ts
@@ -1,0 +1,160 @@
+import { Request, Response } from 'express';
+import IntegrationApiKeyService, {
+  CreateIntegrationApiKeyInput,
+  UpdateIntegrationApiKeyInput,
+  ValidationError,
+} from '../services/integrationApiKeyService';
+
+const service = new IntegrationApiKeyService();
+
+function parseIdParam(param: string): number | null {
+  const value = Number(param);
+  if (!Number.isInteger(value) || value <= 0) {
+    return null;
+  }
+  return value;
+}
+
+function toOptionalBoolean(value: unknown, field: string): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true') {
+      return true;
+    }
+    if (normalized === 'false') {
+      return false;
+    }
+  }
+  throw new ValidationError(`${field} must be a boolean value`);
+}
+
+function toOptionalDate(value: unknown, field: string): string | Date | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null || value instanceof Date || typeof value === 'string') {
+    return value;
+  }
+  throw new ValidationError(`${field} must be a string, Date or null`);
+}
+
+export async function listIntegrationApiKeys(_req: Request, res: Response) {
+  try {
+    const items = await service.list();
+    return res.json(items);
+  } catch (error) {
+    console.error('Failed to list integration API keys:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}
+
+export async function createIntegrationApiKey(req: Request, res: Response) {
+  const { provider, key, environment, active, lastUsed } = req.body as {
+    provider?: string;
+    key?: string;
+    environment?: string;
+    active?: unknown;
+    lastUsed?: unknown;
+  };
+
+  const input: CreateIntegrationApiKeyInput = {
+    provider: provider ?? '',
+    key: key ?? '',
+    environment: environment ?? '',
+  };
+
+  try {
+    const parsedActive = toOptionalBoolean(active, 'active');
+    if (parsedActive !== undefined) {
+      input.active = parsedActive;
+    }
+
+    const parsedLastUsed = toOptionalDate(lastUsed, 'lastUsed');
+    if (parsedLastUsed !== undefined) {
+      input.lastUsed = parsedLastUsed;
+    }
+
+    const created = await service.create(input);
+    return res.status(201).json(created);
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return res.status(400).json({ error: error.message });
+    }
+    console.error('Failed to create integration API key:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}
+
+export async function updateIntegrationApiKey(req: Request, res: Response) {
+  const apiKeyId = parseIdParam(req.params.id);
+
+  if (!apiKeyId) {
+    return res.status(400).json({ error: 'Invalid API key id' });
+  }
+
+  const { provider, key, environment, active, lastUsed } = req.body as UpdateIntegrationApiKeyInput & {
+    active?: unknown;
+    lastUsed?: unknown;
+  };
+
+  const updates: UpdateIntegrationApiKeyInput = {};
+
+  if (provider !== undefined) {
+    updates.provider = provider;
+  }
+  if (key !== undefined) {
+    updates.key = key;
+  }
+  if (environment !== undefined) {
+    updates.environment = environment;
+  }
+
+  try {
+    const parsedActive = toOptionalBoolean(active, 'active');
+    if (parsedActive !== undefined) {
+      updates.active = parsedActive;
+    }
+
+    const parsedLastUsed = toOptionalDate(lastUsed, 'lastUsed');
+    if (parsedLastUsed !== undefined) {
+      updates.lastUsed = parsedLastUsed;
+    }
+
+    const updated = await service.update(apiKeyId, updates);
+    if (!updated) {
+      return res.status(404).json({ error: 'API key not found' });
+    }
+    return res.json(updated);
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return res.status(400).json({ error: error.message });
+    }
+    console.error('Failed to update integration API key:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}
+
+export async function deleteIntegrationApiKey(req: Request, res: Response) {
+  const apiKeyId = parseIdParam(req.params.id);
+
+  if (!apiKeyId) {
+    return res.status(400).json({ error: 'Invalid API key id' });
+  }
+
+  try {
+    const deleted = await service.delete(apiKeyId);
+    if (!deleted) {
+      return res.status(404).json({ error: 'API key not found' });
+    }
+    return res.status(204).send();
+  } catch (error) {
+    console.error('Failed to delete integration API key:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -28,6 +28,7 @@ import tipoDocumentoRoutes from './routes/tipoDocumentoRoutes';
 import clienteDocumentoRoutes from './routes/clienteDocumentoRoutes';
 import supportRoutes from './routes/supportRoutes';
 import notificationRoutes from './routes/notificationRoutes';
+import integrationApiKeyRoutes from './routes/integrationApiKeyRoutes';
 import swaggerUi from 'swagger-ui-express';
 import swaggerJsdoc from 'swagger-jsdoc';
 import swaggerOptions from './swagger';
@@ -113,6 +114,7 @@ app.use('/api', tarefaResponsavelRoutes);
 app.use('/api', clienteDocumentoRoutes);
 app.use('/api', supportRoutes);
 app.use('/api', notificationRoutes);
+app.use('/api', integrationApiKeyRoutes);
 
 // Swagger
 const specs = swaggerJsdoc(swaggerOptions);

--- a/backend/src/routes/integrationApiKeyRoutes.ts
+++ b/backend/src/routes/integrationApiKeyRoutes.ts
@@ -1,0 +1,126 @@
+import { Router } from 'express';
+import {
+  createIntegrationApiKey,
+  deleteIntegrationApiKey,
+  listIntegrationApiKeys,
+  updateIntegrationApiKey,
+} from '../controllers/integrationApiKeyController';
+
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   - name: Integrações
+ *     description: Gerenciamento de chaves de API para integrações de IA
+ */
+
+/**
+ * @swagger
+ * /api/integrations/api-keys:
+ *   get:
+ *     summary: Lista as chaves de API configuradas
+ *     tags: [Integrações]
+ *     responses:
+ *       200:
+ *         description: Lista de chaves de API
+ */
+router.get('/integrations/api-keys', listIntegrationApiKeys);
+
+/**
+ * @swagger
+ * /api/integrations/api-keys:
+ *   post:
+ *     summary: Cadastra uma nova chave de API
+ *     tags: [Integrações]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - provider
+ *               - key
+ *               - environment
+ *             properties:
+ *               provider:
+ *                 type: string
+ *                 enum: [gemini, openai]
+ *               key:
+ *                 type: string
+ *               environment:
+ *                 type: string
+ *                 enum: [producao, homologacao]
+ *               active:
+ *                 type: boolean
+ *               lastUsed:
+ *                 type: string
+ *                 format: date-time
+ *     responses:
+ *       201:
+ *         description: Chave criada
+ */
+router.post('/integrations/api-keys', createIntegrationApiKey);
+
+/**
+ * @swagger
+ * /api/integrations/api-keys/{id}:
+ *   patch:
+ *     summary: Atualiza uma chave de API existente
+ *     tags: [Integrações]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               provider:
+ *                 type: string
+ *                 enum: [gemini, openai]
+ *               key:
+ *                 type: string
+ *               environment:
+ *                 type: string
+ *                 enum: [producao, homologacao]
+ *               active:
+ *                 type: boolean
+ *               lastUsed:
+ *                 type: string
+ *                 format: date-time
+ *     responses:
+ *       200:
+ *         description: Chave atualizada
+ *       404:
+ *         description: Chave não encontrada
+ */
+router.patch('/integrations/api-keys/:id', updateIntegrationApiKey);
+
+/**
+ * @swagger
+ * /api/integrations/api-keys/{id}:
+ *   delete:
+ *     summary: Remove uma chave de API
+ *     tags: [Integrações]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       204:
+ *         description: Chave removida com sucesso
+ *       404:
+ *         description: Chave não encontrada
+ */
+router.delete('/integrations/api-keys/:id', deleteIntegrationApiKey);
+
+export default router;

--- a/backend/src/services/integrationApiKeyService.ts
+++ b/backend/src/services/integrationApiKeyService.ts
@@ -1,0 +1,239 @@
+import { QueryResultRow } from 'pg';
+import pool from './db';
+
+export const API_KEY_PROVIDERS = ['gemini', 'openai'] as const;
+export type ApiKeyProvider = (typeof API_KEY_PROVIDERS)[number];
+
+export const API_KEY_ENVIRONMENTS = ['producao', 'homologacao'] as const;
+export type ApiKeyEnvironment = (typeof API_KEY_ENVIRONMENTS)[number];
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
+  }
+}
+
+type Queryable = {
+  query: (text: string, params?: unknown[]) => Promise<{ rows: QueryResultRow[]; rowCount: number }>;
+};
+
+export interface IntegrationApiKey {
+  id: number;
+  provider: ApiKeyProvider;
+  key: string;
+  environment: ApiKeyEnvironment;
+  active: boolean;
+  lastUsed: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateIntegrationApiKeyInput {
+  provider: string;
+  key: string;
+  environment: string;
+  active?: boolean;
+  lastUsed?: string | Date | null;
+}
+
+export interface UpdateIntegrationApiKeyInput {
+  provider?: string;
+  key?: string;
+  environment?: string;
+  active?: boolean;
+  lastUsed?: string | Date | null;
+}
+
+interface IntegrationApiKeyRow extends QueryResultRow {
+  id: number;
+  provider: string;
+  key_value: string;
+  environment: string;
+  active: boolean;
+  last_used: string | Date | null;
+  created_at: string | Date;
+  updated_at: string | Date;
+}
+
+function normalizeProvider(value: string | undefined): ApiKeyProvider {
+  if (typeof value !== 'string') {
+    throw new ValidationError('Provider is required');
+  }
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    throw new ValidationError('Provider is required');
+  }
+  if (!API_KEY_PROVIDERS.includes(normalized as ApiKeyProvider)) {
+    throw new ValidationError('Provider must be either Gemini or OpenAI');
+  }
+  return normalized as ApiKeyProvider;
+}
+
+function normalizeEnvironment(value: string | undefined): ApiKeyEnvironment {
+  if (typeof value !== 'string') {
+    throw new ValidationError('Environment is required');
+  }
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    throw new ValidationError('Environment is required');
+  }
+  if (!API_KEY_ENVIRONMENTS.includes(normalized as ApiKeyEnvironment)) {
+    throw new ValidationError('Environment must be produção or homologação');
+  }
+  return normalized as ApiKeyEnvironment;
+}
+
+function normalizeKey(value: string | undefined): string {
+  if (typeof value !== 'string') {
+    throw new ValidationError('API key value is required');
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new ValidationError('API key value is required');
+  }
+  return normalized;
+}
+
+function normalizeLastUsed(value: unknown): Date | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim();
+    if (!normalized) {
+      return null;
+    }
+    const parsed = new Date(normalized);
+    if (Number.isNaN(parsed.getTime())) {
+      throw new ValidationError('Invalid lastUsed datetime');
+    }
+    return parsed;
+  }
+  throw new ValidationError('Invalid lastUsed datetime');
+}
+
+function formatDate(value: string | Date): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  return new Date(value).toISOString();
+}
+
+function formatNullableDate(value: string | Date | null): string | null {
+  if (!value) {
+    return null;
+  }
+  return formatDate(value);
+}
+
+function mapRow(row: IntegrationApiKeyRow): IntegrationApiKey {
+  return {
+    id: row.id,
+    provider: normalizeProvider(row.provider),
+    key: row.key_value,
+    environment: normalizeEnvironment(row.environment),
+    active: row.active,
+    lastUsed: formatNullableDate(row.last_used),
+    createdAt: formatDate(row.created_at),
+    updatedAt: formatDate(row.updated_at),
+  };
+}
+
+export default class IntegrationApiKeyService {
+  constructor(private readonly db: Queryable = pool) {}
+
+  async list(): Promise<IntegrationApiKey[]> {
+    const result = await this.db.query(
+      `SELECT id, provider, key_value, environment, active, last_used, created_at, updated_at
+       FROM integration_api_keys
+       ORDER BY created_at DESC`
+    );
+
+    return (result.rows as IntegrationApiKeyRow[]).map(mapRow);
+  }
+
+  async create(input: CreateIntegrationApiKeyInput): Promise<IntegrationApiKey> {
+    const provider = normalizeProvider(input.provider);
+    const environment = normalizeEnvironment(input.environment);
+    const key = normalizeKey(input.key);
+    const active = input.active ?? true;
+    const lastUsed = normalizeLastUsed(input.lastUsed);
+
+    const result = await this.db.query(
+      `INSERT INTO integration_api_keys (provider, key_value, environment, active, last_used)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING id, provider, key_value, environment, active, last_used, created_at, updated_at`,
+      [provider, key, environment, active, lastUsed]
+    );
+
+    return mapRow(result.rows[0] as IntegrationApiKeyRow);
+  }
+
+  async update(id: number, updates: UpdateIntegrationApiKeyInput): Promise<IntegrationApiKey | null> {
+    const fields: string[] = [];
+    const values: unknown[] = [];
+    let index = 1;
+
+    if (updates.provider !== undefined) {
+      const provider = normalizeProvider(updates.provider);
+      fields.push(`provider = $${index}`);
+      values.push(provider);
+      index += 1;
+    }
+
+    if (updates.key !== undefined) {
+      const key = normalizeKey(updates.key);
+      fields.push(`key_value = $${index}`);
+      values.push(key);
+      index += 1;
+    }
+
+    if (updates.environment !== undefined) {
+      const environment = normalizeEnvironment(updates.environment);
+      fields.push(`environment = $${index}`);
+      values.push(environment);
+      index += 1;
+    }
+
+    if (updates.active !== undefined) {
+      fields.push(`active = $${index}`);
+      values.push(Boolean(updates.active));
+      index += 1;
+    }
+
+    if (updates.lastUsed !== undefined) {
+      const lastUsed = normalizeLastUsed(updates.lastUsed);
+      fields.push(`last_used = $${index}`);
+      values.push(lastUsed);
+      index += 1;
+    }
+
+    if (fields.length === 0) {
+      throw new ValidationError('No fields provided to update');
+    }
+
+    const query = `UPDATE integration_api_keys
+      SET ${fields.join(', ')}, updated_at = NOW()
+      WHERE id = $${index}
+      RETURNING id, provider, key_value, environment, active, last_used, created_at, updated_at`;
+
+    values.push(id);
+
+    const result = await this.db.query(query, values);
+
+    if (result.rowCount === 0) {
+      return null;
+    }
+
+    return mapRow(result.rows[0] as IntegrationApiKeyRow);
+  }
+
+  async delete(id: number): Promise<boolean> {
+    const result = await this.db.query('DELETE FROM integration_api_keys WHERE id = $1', [id]);
+    return result.rowCount > 0;
+  }
+}

--- a/backend/tests/integrationApiKeyService.test.ts
+++ b/backend/tests/integrationApiKeyService.test.ts
@@ -1,0 +1,186 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import IntegrationApiKeyService, {
+  CreateIntegrationApiKeyInput,
+  IntegrationApiKey,
+  UpdateIntegrationApiKeyInput,
+  ValidationError,
+} from '../src/services/integrationApiKeyService';
+
+type QueryCall = { text: string; values?: unknown[] };
+type QueryResponse = { rows: any[]; rowCount: number };
+
+class FakePool {
+  public readonly calls: QueryCall[] = [];
+
+  constructor(private readonly responses: QueryResponse[] = []) {}
+
+  async query(text: string, values?: unknown[]) {
+    this.calls.push({ text, values });
+    if (this.responses.length === 0) {
+      throw new Error('No response configured for query');
+    }
+    return this.responses.shift()!;
+  }
+}
+
+test('IntegrationApiKeyService.create normalizes payload and persists values', async () => {
+  const insertedRow = {
+    id: 1,
+    provider: 'gemini',
+    key_value: 'sk_live_abc123',
+    environment: 'producao',
+    active: true,
+    last_used: null,
+    created_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z',
+  };
+
+  const pool = new FakePool([
+    { rows: [insertedRow], rowCount: 1 },
+  ]);
+
+  const service = new IntegrationApiKeyService(pool as any);
+
+  const payload: CreateIntegrationApiKeyInput = {
+    provider: '  GEMINI  ',
+    key: '  sk_live_abc123  ',
+    environment: ' Producao ',
+  };
+
+  const result = await service.create(payload);
+
+  assert.equal(pool.calls.length, 1);
+  const call = pool.calls[0];
+  assert.match(call.text, /INSERT INTO integration_api_keys/i);
+  assert.deepEqual(call.values, ['gemini', 'sk_live_abc123', 'producao', true, null]);
+
+  const expected: IntegrationApiKey = {
+    id: 1,
+    provider: 'gemini',
+    key: 'sk_live_abc123',
+    environment: 'producao',
+    active: true,
+    lastUsed: null,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+  };
+
+  assert.deepEqual(result, expected);
+});
+
+test('IntegrationApiKeyService.create validates provider and key', async () => {
+  const pool = new FakePool([]);
+  const service = new IntegrationApiKeyService(pool as any);
+
+  await assert.rejects(
+    () => service.create({ provider: 'invalid', key: 'value', environment: 'producao' }),
+    ValidationError,
+  );
+
+  await assert.rejects(
+    () => service.create({ provider: 'gemini', key: '   ', environment: 'producao' }),
+    ValidationError,
+  );
+});
+
+test('IntegrationApiKeyService.list retrieves keys ordered by creation date', async () => {
+  const rows = [
+    {
+      id: 10,
+      provider: 'openai',
+      key_value: 'sk_test_123',
+      environment: 'homologacao',
+      active: false,
+      last_used: '2024-02-10T12:00:00.000Z',
+      created_at: '2024-02-11T12:00:00.000Z',
+      updated_at: '2024-02-11T12:30:00.000Z',
+    },
+  ];
+
+  const pool = new FakePool([
+    { rows, rowCount: rows.length },
+  ]);
+
+  const service = new IntegrationApiKeyService(pool as any);
+
+  const result = await service.list();
+
+  assert.equal(pool.calls.length, 1);
+  assert.match(pool.calls[0].text, /ORDER BY created_at DESC/);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, 10);
+  assert.equal(result[0].provider, 'openai');
+  assert.equal(result[0].lastUsed, '2024-02-10T12:00:00.000Z');
+});
+
+test('IntegrationApiKeyService.update builds dynamic query and handles not found', async () => {
+  const updatedRow = {
+    id: 7,
+    provider: 'openai',
+    key_value: 'sk_new_value',
+    environment: 'homologacao',
+    active: false,
+    last_used: '2024-03-01T08:30:00.000Z',
+    created_at: '2024-02-01T10:00:00.000Z',
+    updated_at: '2024-03-01T08:30:00.000Z',
+  };
+
+  const pool = new FakePool([
+    { rows: [updatedRow], rowCount: 1 },
+    { rows: [], rowCount: 0 },
+  ]);
+
+  const service = new IntegrationApiKeyService(pool as any);
+
+  const updates: UpdateIntegrationApiKeyInput = {
+    provider: 'OpenAI',
+    key: ' sk_new_value ',
+    environment: ' Homologacao ',
+    active: false,
+    lastUsed: '2024-03-01T08:30:00Z',
+  };
+
+  const result = await service.update(7, updates);
+
+  assert.ok(pool.calls[0].text.startsWith('UPDATE integration_api_keys'));
+  assert.deepEqual(pool.calls[0].values?.slice(0, 4), ['openai', 'sk_new_value', 'homologacao', false]);
+  const lastUsedValue = pool.calls[0].values?.[4];
+  assert.ok(lastUsedValue instanceof Date);
+  assert.equal((lastUsedValue as Date).toISOString(), '2024-03-01T08:30:00.000Z');
+  assert.equal(pool.calls[0].values?.[5], 7);
+
+  assert.equal(result?.id, 7);
+  assert.equal(result?.provider, 'openai');
+  assert.equal(result?.active, false);
+  assert.equal(result?.environment, 'homologacao');
+
+  const notFound = await service.update(99, { active: true });
+  assert.equal(pool.calls.length, 2);
+  assert.equal(pool.calls[1].values?.[1], 99);
+  assert.equal(notFound, null);
+});
+
+test('IntegrationApiKeyService.update requires at least one field', async () => {
+  const pool = new FakePool([]);
+  const service = new IntegrationApiKeyService(pool as any);
+
+  await assert.rejects(() => service.update(1, {}), ValidationError);
+});
+
+test('IntegrationApiKeyService.delete returns operation status', async () => {
+  const pool = new FakePool([
+    { rows: [], rowCount: 1 },
+    { rows: [], rowCount: 0 },
+  ]);
+
+  const service = new IntegrationApiKeyService(pool as any);
+
+  const deleted = await service.delete(3);
+  assert.equal(deleted, true);
+  assert.deepEqual(pool.calls[0].values, [3]);
+
+  const notDeleted = await service.delete(4);
+  assert.equal(notDeleted, false);
+  assert.deepEqual(pool.calls[1].values, [4]);
+});

--- a/frontend/src/lib/integrationApiKeys.ts
+++ b/frontend/src/lib/integrationApiKeys.ts
@@ -1,0 +1,116 @@
+import { getApiUrl } from './api';
+
+export const API_KEY_PROVIDERS = ['gemini', 'openai'] as const;
+export type ApiKeyProvider = (typeof API_KEY_PROVIDERS)[number];
+
+export const API_KEY_PROVIDER_LABELS: Record<ApiKeyProvider, string> = {
+  gemini: 'Gemini',
+  openai: 'OpenAI',
+};
+
+export const API_KEY_ENVIRONMENTS = ['producao', 'homologacao'] as const;
+export type ApiKeyEnvironment = (typeof API_KEY_ENVIRONMENTS)[number];
+
+export interface IntegrationApiKey {
+  id: number;
+  provider: ApiKeyProvider;
+  key: string;
+  environment: ApiKeyEnvironment;
+  active: boolean;
+  lastUsed: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateIntegrationApiKeyPayload {
+  provider: ApiKeyProvider;
+  key: string;
+  environment: ApiKeyEnvironment;
+  active?: boolean;
+  lastUsed?: string | null;
+}
+
+export interface UpdateIntegrationApiKeyPayload {
+  provider?: ApiKeyProvider;
+  key?: string;
+  environment?: ApiKeyEnvironment;
+  active?: boolean;
+  lastUsed?: string | null;
+}
+
+const API_KEYS_ENDPOINT = getApiUrl('integrations/api-keys');
+
+async function parseErrorMessage(response: Response): Promise<string> {
+  try {
+    const payload = await response.json();
+    if (payload && typeof payload === 'object' && 'error' in payload) {
+      const { error } = payload as { error?: unknown };
+      if (typeof error === 'string' && error.trim()) {
+        return error;
+      }
+    }
+  } catch (error) {
+    // ignore JSON parsing issues
+  }
+
+  return `Falha na requisição (status ${response.status})`;
+}
+
+export async function fetchIntegrationApiKeys(): Promise<IntegrationApiKey[]> {
+  const response = await fetch(API_KEYS_ENDPOINT, { headers: { Accept: 'application/json' } });
+  if (!response.ok) {
+    throw new Error(await parseErrorMessage(response));
+  }
+  const data = (await response.json()) as IntegrationApiKey[];
+  return data;
+}
+
+export async function createIntegrationApiKey(
+  payload: CreateIntegrationApiKeyPayload,
+): Promise<IntegrationApiKey> {
+  const response = await fetch(API_KEYS_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(await parseErrorMessage(response));
+  }
+
+  return (await response.json()) as IntegrationApiKey;
+}
+
+export async function updateIntegrationApiKey(
+  id: number,
+  updates: UpdateIntegrationApiKeyPayload,
+): Promise<IntegrationApiKey> {
+  const response = await fetch(`${API_KEYS_ENDPOINT}/${id}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(updates),
+  });
+
+  if (!response.ok) {
+    throw new Error(await parseErrorMessage(response));
+  }
+
+  return (await response.json()) as IntegrationApiKey;
+}
+
+export async function deleteIntegrationApiKey(id: number): Promise<void> {
+  const response = await fetch(`${API_KEYS_ENDPOINT}/${id}`, {
+    method: 'DELETE',
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(await parseErrorMessage(response));
+  }
+}


### PR DESCRIPTION
## Summary
- add database schema, service layer, controller and routes for managing integration API keys
- cover the new integration API key service with unit tests
- update the integrations UI to fetch, create, toggle and delete API keys via the backend using a provider dropdown and manual key entry

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8ab1cdcc483268a3b5a658fae62c9