### PR TITLE
fix: add missing icon import for integrations page

### DIFF
--- a/frontend/src/pages/configuracoes/Integracoes.tsx
+++ b/frontend/src/pages/configuracoes/Integracoes.tsx
@@ -6,6 +6,7 @@ import {
   ShieldCheck,
   Copy,
   Trash2,
+  RefreshCcw,
   Webhook as WebhookIcon,
 } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";


### PR DESCRIPTION
## Summary
- import the RefreshCcw icon used by the webhook secret button on the configurações/integracoes screen to prevent runtime errors when rendering the page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8b91380508326be84fe4f2fcb30bb