### PR TITLE
Add WAHA API key provider option

### DIFF
--- a/backend/sql/integration_api_keys.sql
+++ b/backend/sql/integration_api_keys.sql
@@ -1,7 +1,7 @@
 -- Estrutura para armazenamento de chaves de API das integrações
 CREATE TABLE IF NOT EXISTS integration_api_keys (
   id BIGSERIAL PRIMARY KEY,
-  provider TEXT NOT NULL CHECK (provider IN ('gemini', 'openai')),
+  provider TEXT NOT NULL CHECK (provider IN ('gemini', 'openai', 'waha')),
   key_value TEXT NOT NULL,
   environment TEXT NOT NULL CHECK (environment IN ('producao', 'homologacao')),
   active BOOLEAN NOT NULL DEFAULT TRUE,

--- a/backend/src/routes/integrationApiKeyRoutes.ts
+++ b/backend/src/routes/integrationApiKeyRoutes.ts
@@ -46,7 +46,7 @@ router.get('/integrations/api-keys', listIntegrationApiKeys);
  *             properties:
  *               provider:
  *                 type: string
- *                 enum: [gemini, openai]
+ *                 enum: [gemini, openai, waha]
  *               key:
  *                 type: string
  *               environment:
@@ -84,7 +84,7 @@ router.post('/integrations/api-keys', createIntegrationApiKey);
  *             properties:
  *               provider:
  *                 type: string
- *                 enum: [gemini, openai]
+ *                 enum: [gemini, openai, waha]
  *               key:
  *                 type: string
  *               environment:

--- a/backend/src/services/integrationApiKeyService.ts
+++ b/backend/src/services/integrationApiKeyService.ts
@@ -1,7 +1,7 @@
 import { QueryResultRow } from 'pg';
 import pool from './db';
 
-export const API_KEY_PROVIDERS = ['gemini', 'openai'] as const;
+export const API_KEY_PROVIDERS = ['gemini', 'openai', 'waha'] as const;
 export type ApiKeyProvider = (typeof API_KEY_PROVIDERS)[number];
 
 export const API_KEY_ENVIRONMENTS = ['producao', 'homologacao'] as const;
@@ -65,7 +65,7 @@ function normalizeProvider(value: string | undefined): ApiKeyProvider {
     throw new ValidationError('Provider is required');
   }
   if (!API_KEY_PROVIDERS.includes(normalized as ApiKeyProvider)) {
-    throw new ValidationError('Provider must be either Gemini or OpenAI');
+    throw new ValidationError('Provider must be Gemini, OpenAI or WAHA');
   }
   return normalized as ApiKeyProvider;
 }

--- a/backend/tests/integrationApiKeyService.test.ts
+++ b/backend/tests/integrationApiKeyService.test.ts
@@ -27,7 +27,7 @@ class FakePool {
 test('IntegrationApiKeyService.create normalizes payload and persists values', async () => {
   const insertedRow = {
     id: 1,
-    provider: 'gemini',
+    provider: 'waha',
     key_value: 'sk_live_abc123',
     environment: 'producao',
     active: true,
@@ -43,7 +43,7 @@ test('IntegrationApiKeyService.create normalizes payload and persists values', a
   const service = new IntegrationApiKeyService(pool as any);
 
   const payload: CreateIntegrationApiKeyInput = {
-    provider: '  GEMINI  ',
+    provider: '  WAHA  ',
     key: '  sk_live_abc123  ',
     environment: ' Producao ',
   };
@@ -53,11 +53,11 @@ test('IntegrationApiKeyService.create normalizes payload and persists values', a
   assert.equal(pool.calls.length, 1);
   const call = pool.calls[0];
   assert.match(call.text, /INSERT INTO integration_api_keys/i);
-  assert.deepEqual(call.values, ['gemini', 'sk_live_abc123', 'producao', true, null]);
+  assert.deepEqual(call.values, ['waha', 'sk_live_abc123', 'producao', true, null]);
 
   const expected: IntegrationApiKey = {
     id: 1,
-    provider: 'gemini',
+    provider: 'waha',
     key: 'sk_live_abc123',
     environment: 'producao',
     active: true,

--- a/frontend/src/lib/integrationApiKeys.ts
+++ b/frontend/src/lib/integrationApiKeys.ts
@@ -1,11 +1,12 @@
 import { getApiUrl } from './api';
 
-export const API_KEY_PROVIDERS = ['gemini', 'openai'] as const;
+export const API_KEY_PROVIDERS = ['gemini', 'openai', 'waha'] as const;
 export type ApiKeyProvider = (typeof API_KEY_PROVIDERS)[number];
 
 export const API_KEY_PROVIDER_LABELS: Record<ApiKeyProvider, string> = {
   gemini: 'Gemini',
   openai: 'OpenAI',
+  waha: 'WAHA',
 };
 
 export const API_KEY_ENVIRONMENTS = ['producao', 'homologacao'] as const;


### PR DESCRIPTION
## Summary
- add WAHA to the allowed API key providers and update validation messaging
- expand database constraints, Swagger docs, and service tests to cover the new provider
- expose the WAHA option and label on the API key dropdown in the frontend

## Testing
- npm test (backend)
- npm run lint (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68c8bd3c91ac8326919016cd869d16f1