### PR TITLE
feat(chat): add assignment filters and conversation metadata

### DIFF
--- a/frontend/src/features/chat/components/ChatSidebar.module.css
+++ b/frontend/src/features/chat/components/ChatSidebar.module.css
@@ -68,6 +68,33 @@
   outline: none;
 }
 
+.filterControl {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.filterControl span {
+  font-weight: 600;
+}
+
+.filterSelect {
+  width: 100%;
+  border: 1px solid hsl(var(--sidebar-border));
+  border-radius: 0.75rem;
+  padding: 0.45rem 0.7rem;
+  font-size: 0.9rem;
+  background: hsl(var(--background));
+  color: inherit;
+}
+
+.filterSelect:focus {
+  outline: 2px solid hsl(var(--sidebar-ring));
+  outline-offset: 1px;
+}
+
 .listContainer {
   flex: 1;
   overflow-y: auto;
@@ -159,12 +186,74 @@
   opacity: 0.85;
 }
 
+.itemMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+  font-size: 0.78rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.metaResponsible {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: hsl(var(--sidebar-accent));
+  color: inherit;
+  font-weight: 500;
+}
+
+.itemButton[data-active="true"] .metaResponsible {
+  background: rgba(255, 255, 255, 0.2);
+  color: hsl(var(--sidebar-primary-foreground));
+}
+
+.metaTags {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.tagChip {
+  background: hsl(var(--sidebar-accent));
+  border-radius: 999px;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: inherit;
+}
+
+.itemButton[data-active="true"] .tagChip {
+  background: rgba(255, 255, 255, 0.22);
+  color: hsl(var(--sidebar-primary-foreground));
+}
+
 .timestamp {
   font-size: 0.8rem;
   color: hsl(var(--muted-foreground));
 }
 
 .itemButton[data-active="true"] .timestamp {
+  color: hsl(var(--sidebar-primary-foreground));
+}
+
+.privateBadge {
+  display: inline-block;
+  margin-top: 0.35rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+}
+
+.itemButton[data-active="true"] .privateBadge {
+  background: rgba(255, 255, 255, 0.2);
   color: hsl(var(--sidebar-primary-foreground));
 }
 

--- a/frontend/src/features/chat/components/ChatWindow.module.css
+++ b/frontend/src/features/chat/components/ChatWindow.module.css
@@ -7,11 +7,15 @@
   min-height: 0;
 }
 
+.wrapper[data-private="true"] {
+  background: linear-gradient(180deg, hsl(var(--background)), hsl(var(--muted) / 0.35));
+}
+
 .header {
   padding: 1rem 1.5rem;
   border-bottom: 1px solid hsl(var(--border));
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
 }
@@ -35,14 +39,43 @@
   gap: 0.3rem;
 }
 
-.headerText h2 {
+.headerTitleRow {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.headerTitleRow h2 {
   font-size: 1.25rem;
   font-weight: 700;
+  margin: 0;
 }
 
 .status {
   font-size: 0.9rem;
   color: hsl(var(--muted-foreground));
+}
+
+.phoneNumber {
+  font-size: 0.85rem;
+  color: hsl(var(--accent-foreground));
+}
+
+.privateIndicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.75rem;
+  border-radius: 999px;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.wrapper[data-private="true"] .privateIndicator {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
 }
 
 .actions {
@@ -108,6 +141,322 @@
   background: hsl(var(--muted));
 }
 
+.metadataPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid hsl(var(--border));
+  background: hsl(var(--background));
+}
+
+.wrapper[data-private="true"] .metadataPanel {
+  background: hsl(var(--muted) / 0.25);
+}
+
+.metadataRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.metadataGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  flex: 1 1 260px;
+}
+
+.metadataLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: hsl(var(--muted-foreground));
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.metadataSelect {
+  width: 100%;
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.75rem;
+  padding: 0.55rem 0.75rem;
+  background: hsl(var(--background));
+  color: inherit;
+  font-size: 0.95rem;
+}
+
+.metadataSelect:focus {
+  outline: 2px solid hsl(var(--accent));
+  outline-offset: 2px;
+}
+
+.metadataActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+  font-size: 0.9rem;
+}
+
+.secondaryButton {
+  border: 1px solid hsl(var(--border));
+  background: transparent;
+  color: inherit;
+  border-radius: 0.75rem;
+  padding: 0.35rem 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.secondaryButton:hover,
+.secondaryButton:focus-visible {
+  background: hsl(var(--muted));
+}
+
+.tagsEditor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.tagsList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tagPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.tagPill button {
+  border: none;
+  background: transparent;
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.tagPill button:hover,
+.tagPill button:focus-visible {
+  color: hsl(var(--accent-foreground));
+}
+
+.emptyHint {
+  color: hsl(var(--muted-foreground));
+  font-size: 0.85rem;
+}
+
+.inlineForm {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.inlineForm input {
+  flex: 1 1 180px;
+  min-width: 160px;
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: hsl(var(--background));
+  color: inherit;
+}
+
+.inlineForm button {
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.5rem 1rem;
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  font-weight: 600;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.inlineForm button:disabled {
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  cursor: not-allowed;
+}
+
+.inlineForm button:not(:disabled):hover,
+.inlineForm button:not(:disabled):focus-visible {
+  background: hsl(var(--primary-hover));
+}
+
+.detailsGrid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.detailsColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.attributeList,
+.noteList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.attributeList li,
+.noteList li {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+}
+
+.attributeList li div,
+.noteContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  flex: 1;
+}
+
+.attributeList li strong {
+  font-size: 0.9rem;
+  color: hsl(var(--foreground));
+}
+
+.attributeList li span {
+  font-size: 0.85rem;
+}
+
+.attributeList li button,
+.noteList li button {
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.attributeList li button:hover,
+.attributeList li button:focus-visible,
+.noteList li button:hover,
+.noteList li button:focus-visible {
+  color: hsl(var(--accent-foreground));
+}
+
+.attributeForm {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.attributeForm input {
+  flex: 1 1 160px;
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: hsl(var(--background));
+  color: inherit;
+}
+
+.attributeForm button {
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.5rem 1rem;
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  font-weight: 600;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.attributeForm button:disabled {
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  cursor: not-allowed;
+}
+
+.attributeForm button:not(:disabled):hover,
+.attributeForm button:not(:disabled):focus-visible {
+  background: hsl(var(--primary-hover));
+}
+
+.noteMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+}
+
+.noteMeta time {
+  color: hsl(var(--muted-foreground));
+}
+
+.noteForm {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.noteForm textarea {
+  min-height: 80px;
+  resize: vertical;
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  font-family: inherit;
+  background: hsl(var(--background));
+  color: inherit;
+}
+
+.noteForm button {
+  align-self: flex-start;
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.5rem 1rem;
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  font-weight: 600;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.noteForm button:disabled {
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  cursor: not-allowed;
+}
+
+.noteForm button:not(:disabled):hover,
+.noteForm button:not(:disabled):focus-visible {
+  background: hsl(var(--primary-hover));
+}
+
 .placeholder {
   flex: 1;
   display: grid;
@@ -149,5 +498,13 @@
   .headerInfo img {
     width: 2.5rem;
     height: 2.5rem;
+  }
+
+  .metadataPanel {
+    padding: 1rem;
+  }
+
+  .detailsGrid {
+    grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -1,10 +1,50 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { Phone, Video, MoreVertical, Search, Archive, Monitor } from "lucide-react";
-import type { ConversationSummary, Message, SendMessageInput } from "../types";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEventHandler,
+  type FormEventHandler,
+} from "react";
+import {
+  CalendarPlus,
+  CheckSquare,
+  MoreVertical,
+  Search,
+  Archive,
+  Monitor,
+  Shield,
+  UserRound,
+  X,
+} from "lucide-react";
+import { teamMembers } from "../data/teamMembers";
+import type {
+  ConversationInternalNote,
+  ConversationSummary,
+  Message,
+  SendMessageInput,
+  UpdateConversationPayload,
+} from "../types";
 import { ChatInput } from "./ChatInput";
 import { MessageViewport } from "./MessageViewport";
 import { DeviceLinkModal } from "./DeviceLinkModal";
 import styles from "./ChatWindow.module.css";
+
+const CLIENT_SUGGESTIONS = [
+  "Prado & Cia Consultoria",
+  "Inovatech Brasil",
+  "Tribunal de Justiça SP",
+  "Tech&Law Holding",
+  "Luz Arquitetura",
+  "Paula & Carlos Empreendimentos",
+  "FinanceX Serviços",
+  "Grupo Aurora",
+];
+
+const createId = () =>
+  typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+    ? crypto.randomUUID()
+    : `tmp-${Math.random().toString(36).slice(2, 10)}`;
 
 interface ChatWindowProps {
   conversation?: ConversationSummary;
@@ -14,6 +54,8 @@ interface ChatWindowProps {
   isLoadingMore: boolean;
   onSendMessage: (payload: SendMessageInput) => Promise<void>;
   onLoadOlder: () => Promise<Message[]>;
+  onUpdateConversation: (conversationId: string, changes: UpdateConversationPayload) => Promise<void>;
+  isUpdatingConversation?: boolean;
 }
 
 export const ChatWindow = ({
@@ -24,14 +66,34 @@ export const ChatWindow = ({
   isLoadingMore,
   onSendMessage,
   onLoadOlder,
+  onUpdateConversation,
+  isUpdatingConversation = false,
 }: ChatWindowProps) => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [deviceModalOpen, setDeviceModalOpen] = useState(false);
   const [stickToBottom, setStickToBottom] = useState(true);
+  const [newTag, setNewTag] = useState("");
+  const [clientInput, setClientInput] = useState("");
+  const [newAttributeLabel, setNewAttributeLabel] = useState("");
+  const [newAttributeValue, setNewAttributeValue] = useState("");
+  const [internalNoteContent, setInternalNoteContent] = useState("");
   const scrollRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const previousConversationRef = useRef<string | undefined>(undefined);
   const previousLengthRef = useRef(0);
+  const noteFormatter = useMemo(
+    () => new Intl.DateTimeFormat("pt-BR", { dateStyle: "short", timeStyle: "short" }),
+    [],
+  );
+
+  useEffect(() => {
+    if (!conversation) return;
+    setNewTag("");
+    setClientInput(conversation.clientName ?? "");
+    setNewAttributeLabel("");
+    setNewAttributeValue("");
+    setInternalNoteContent("");
+  }, [conversation]);
 
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {
@@ -53,7 +115,6 @@ export const ChatWindow = ({
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, []);
 
-  // Mantemos o foco no final da conversa sempre que o usuário estiver no final do histórico.
   useEffect(() => {
     const container = scrollRef.current;
     if (!container) return;
@@ -68,44 +129,160 @@ export const ChatWindow = ({
     previousLengthRef.current = messages.length;
   }, [conversation?.id, messages, stickToBottom]);
 
+  const runUpdate = async (changes: UpdateConversationPayload) => {
+    if (!conversation) return;
+    try {
+      await onUpdateConversation(conversation.id, changes);
+    } catch (error) {
+      console.error("Falha ao atualizar conversa", error);
+    }
+  };
+
   const handleSend = async (payload: SendMessageInput) => {
     if (!conversation) return;
     await onSendMessage(payload);
     setStickToBottom(true);
   };
 
-  const placeholder = useMemo(() => (
-    <div className={styles.placeholder}>
-      <div>
-        <h3>Selecione uma conversa</h3>
-        <p>
-          Utilize a barra lateral para escolher um contato, iniciar um novo chat ou pesquisar processos.
-          Os atalhos Ctrl+K e Ctrl+N aceleram sua navegação.
-        </p>
+  const handleAssignResponsible: ChangeEventHandler<HTMLSelectElement> = async (event) => {
+    await runUpdate({ responsibleId: event.target.value === "" ? null : event.target.value });
+  };
+
+  const handleTagSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    if (!conversation) return;
+    const trimmed = newTag.trim();
+    if (!trimmed) return;
+    const exists = conversation.tags.some((tag) => tag.toLowerCase() === trimmed.toLowerCase());
+    if (exists) {
+      setNewTag("");
+      return;
+    }
+    await runUpdate({ tags: [...conversation.tags, trimmed] });
+    setNewTag("");
+  };
+
+  const handleRemoveTag = async (tagToRemove: string) => {
+    if (!conversation) return;
+    await runUpdate({ tags: conversation.tags.filter((tag) => tag !== tagToRemove) });
+  };
+
+  const handleClientSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    if (!conversation) return;
+    const trimmed = clientInput.trim();
+    await runUpdate({
+      clientName: trimmed.length > 0 ? trimmed : null,
+      isLinkedToClient: trimmed.length > 0,
+    });
+  };
+
+  const handleUnlinkClient = async () => {
+    if (!conversation) return;
+    setClientInput("");
+    await runUpdate({ clientName: null, isLinkedToClient: false });
+  };
+
+  const handleAttributeSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    if (!conversation) return;
+    const label = newAttributeLabel.trim();
+    const value = newAttributeValue.trim();
+    if (!label || !value) return;
+    const nextAttributes = [
+      ...conversation.customAttributes,
+      { id: createId(), label, value },
+    ];
+    await runUpdate({ customAttributes: nextAttributes });
+    setNewAttributeLabel("");
+    setNewAttributeValue("");
+  };
+
+  const handleRemoveAttribute = async (attributeId: string) => {
+    if (!conversation) return;
+    await runUpdate({
+      customAttributes: conversation.customAttributes.filter((attribute) => attribute.id !== attributeId),
+    });
+  };
+
+  const handleTogglePrivate = async () => {
+    if (!conversation) return;
+    await runUpdate({ isPrivate: !conversation.isPrivate });
+  };
+
+  const handleInternalNoteSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    if (!conversation) return;
+    const trimmed = internalNoteContent.trim();
+    if (!trimmed) return;
+    const newNote: ConversationInternalNote = {
+      id: createId(),
+      author: "Você",
+      content: trimmed,
+      createdAt: new Date().toISOString(),
+    };
+    const payload: UpdateConversationPayload = {
+      internalNotes: [...conversation.internalNotes, newNote],
+    };
+    if (!conversation.isPrivate) {
+      payload.isPrivate = true;
+    }
+    await runUpdate(payload);
+    setInternalNoteContent("");
+  };
+
+  const handleRemoveInternalNote = async (noteId: string) => {
+    if (!conversation) return;
+    await runUpdate({
+      internalNotes: conversation.internalNotes.filter((note) => note.id !== noteId),
+    });
+  };
+
+  const placeholder = useMemo(
+    () => (
+      <div className={styles.placeholder}>
+        <div>
+          <h3>Selecione uma conversa</h3>
+          <p>
+            Utilize a barra lateral para escolher um contato, iniciar um novo chat ou pesquisar processos.
+            Os atalhos Ctrl+K e Ctrl+N aceleram sua navegação.
+          </p>
+        </div>
       </div>
-    </div>
-  ), []);
+    ),
+    [],
+  );
 
   if (!conversation) {
     return <div className={styles.wrapper}>{placeholder}</div>;
   }
 
+  const isClientLinked = Boolean(conversation.isLinkedToClient && conversation.clientName);
+
   return (
-    <div className={styles.wrapper}>
+    <div className={styles.wrapper} data-private={conversation.isPrivate ? "true" : undefined}>
       <header className={styles.header}>
         <div className={styles.headerInfo}>
           <img src={conversation.avatar} alt="" aria-hidden="true" />
           <div className={styles.headerText}>
-            <h2>{conversation.name}</h2>
+            <div className={styles.headerTitleRow}>
+              <h2>{conversation.name}</h2>
+              {conversation.isPrivate && (
+                <span className={styles.privateIndicator}>
+                  <Shield size={14} aria-hidden="true" /> Privada
+                </span>
+              )}
+            </div>
             <span className={styles.status}>{conversation.shortStatus}</span>
+            <span className={styles.phoneNumber}>{conversation.phoneNumber ?? "Telefone não informado"}</span>
           </div>
         </div>
         <div className={styles.actions} ref={menuRef}>
-          <button type="button" className={styles.actionButton} aria-label="Iniciar ligação">
-            <Phone size={18} aria-hidden="true" />
+          <button type="button" className={styles.actionButton} aria-label="Criar tarefa">
+            <CheckSquare size={18} aria-hidden="true" />
           </button>
-          <button type="button" className={styles.actionButton} aria-label="Iniciar chamada de vídeo">
-            <Video size={18} aria-hidden="true" />
+          <button type="button" className={styles.actionButton} aria-label="Criar agendamento">
+            <CalendarPlus size={18} aria-hidden="true" />
           </button>
           <div className={styles.menu}>
             <button
@@ -141,6 +318,215 @@ export const ChatWindow = ({
           </div>
         </div>
       </header>
+
+      <section className={styles.metadataPanel} aria-label="Detalhes da conversa">
+        <div className={styles.metadataRow}>
+          <div className={styles.metadataGroup}>
+            <span className={styles.metadataLabel}>
+              <UserRound size={14} aria-hidden="true" /> Responsável
+            </span>
+            <select
+              className={styles.metadataSelect}
+              value={conversation.responsible?.id ?? ""}
+              onChange={handleAssignResponsible}
+              disabled={isUpdatingConversation}
+            >
+              <option value="">Sem responsável</option>
+              {teamMembers.map((member) => (
+                <option key={member.id} value={member.id}>
+                  {member.name} — {member.role}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className={styles.metadataGroup}>
+            <span className={styles.metadataLabel}>
+              <Shield size={14} aria-hidden="true" /> Privacidade
+            </span>
+            <div className={styles.metadataActions}>
+              <span>{conversation.isPrivate ? "Visível apenas para a equipe" : "Visível para toda a equipe"}</span>
+              <button
+                type="button"
+                className={styles.secondaryButton}
+                onClick={handleTogglePrivate}
+                disabled={isUpdatingConversation}
+              >
+                {conversation.isPrivate ? "Tornar pública" : "Marcar como privada"}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.metadataGroup}>
+          <span className={styles.metadataLabel}>Etiquetas</span>
+          <div className={styles.tagsEditor}>
+            <div className={styles.tagsList}>
+              {conversation.tags.map((tag) => (
+                <span key={tag} className={styles.tagPill}>
+                  {tag}
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveTag(tag)}
+                    aria-label={`Remover etiqueta ${tag}`}
+                    disabled={isUpdatingConversation}
+                  >
+                    <X size={12} aria-hidden="true" />
+                  </button>
+                </span>
+              ))}
+              {conversation.tags.length === 0 && <span className={styles.emptyHint}>Nenhuma etiqueta cadastrada</span>}
+            </div>
+            <form onSubmit={handleTagSubmit} className={styles.inlineForm}>
+              <input
+                type="text"
+                value={newTag}
+                onChange={(event) => setNewTag(event.target.value)}
+                placeholder="Adicionar etiqueta"
+                aria-label="Adicionar etiqueta"
+                disabled={isUpdatingConversation}
+              />
+              <button type="submit" disabled={isUpdatingConversation || newTag.trim().length === 0}>
+                Adicionar
+              </button>
+            </form>
+          </div>
+        </div>
+
+        <div className={styles.metadataGroup}>
+          <span className={styles.metadataLabel}>Cliente vinculado</span>
+          <form onSubmit={handleClientSubmit} className={styles.inlineForm}>
+            <input
+              type="text"
+              value={clientInput}
+              onChange={(event) => setClientInput(event.target.value)}
+              list="client-suggestions"
+              placeholder="Nome do cliente"
+              aria-label="Nome do cliente"
+              disabled={isUpdatingConversation}
+            />
+            <datalist id="client-suggestions">
+              {CLIENT_SUGGESTIONS.map((client) => (
+                <option key={client} value={client} />
+              ))}
+            </datalist>
+            <button type="submit" disabled={isUpdatingConversation}>
+              {isClientLinked ? "Atualizar vínculo" : "Vincular cliente"}
+            </button>
+            {isClientLinked && (
+              <button
+                type="button"
+                className={styles.secondaryButton}
+                onClick={handleUnlinkClient}
+                disabled={isUpdatingConversation}
+              >
+                Remover vínculo
+              </button>
+            )}
+          </form>
+        </div>
+
+        <div className={styles.detailsGrid}>
+          <div className={styles.detailsColumn}>
+            <div className={styles.metadataGroup}>
+              <span className={styles.metadataLabel}>Atributos personalizados</span>
+              {conversation.customAttributes.length === 0 ? (
+                <p className={styles.emptyHint}>Nenhum atributo cadastrado.</p>
+              ) : (
+                <ul className={styles.attributeList}>
+                  {conversation.customAttributes.map((attribute) => (
+                    <li key={attribute.id}>
+                      <div>
+                        <strong>{attribute.label}</strong>
+                        <span>{attribute.value}</span>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveAttribute(attribute.id)}
+                        aria-label={`Remover atributo ${attribute.label}`}
+                        disabled={isUpdatingConversation}
+                      >
+                        <X size={12} aria-hidden="true" />
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <form onSubmit={handleAttributeSubmit} className={styles.attributeForm}>
+                <input
+                  type="text"
+                  value={newAttributeLabel}
+                  onChange={(event) => setNewAttributeLabel(event.target.value)}
+                  placeholder="Nome do atributo"
+                  aria-label="Nome do atributo"
+                  disabled={isUpdatingConversation}
+                />
+                <input
+                  type="text"
+                  value={newAttributeValue}
+                  onChange={(event) => setNewAttributeValue(event.target.value)}
+                  placeholder="Valor"
+                  aria-label="Valor do atributo"
+                  disabled={isUpdatingConversation}
+                />
+                <button
+                  type="submit"
+                  disabled={
+                    isUpdatingConversation ||
+                    newAttributeLabel.trim().length === 0 ||
+                    newAttributeValue.trim().length === 0
+                  }
+                >
+                  Adicionar atributo
+                </button>
+              </form>
+            </div>
+          </div>
+          <div className={styles.detailsColumn}>
+            <div className={styles.metadataGroup}>
+              <span className={styles.metadataLabel}>Notas internas</span>
+              {conversation.internalNotes.length === 0 ? (
+                <p className={styles.emptyHint}>Nenhuma nota registrada. Utilize este espaço para histórico interno.</p>
+              ) : (
+                <ul className={styles.noteList}>
+                  {conversation.internalNotes.map((note) => (
+                    <li key={note.id}>
+                      <div className={styles.noteContent}>{note.content}</div>
+                      <div className={styles.noteMeta}>
+                        <span>{note.author}</span>
+                        <time dateTime={note.createdAt}>{noteFormatter.format(new Date(note.createdAt))}</time>
+                        <button
+                          type="button"
+                          onClick={() => handleRemoveInternalNote(note.id)}
+                          aria-label="Excluir nota"
+                          disabled={isUpdatingConversation}
+                        >
+                          <X size={12} aria-hidden="true" />
+                        </button>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <form onSubmit={handleInternalNoteSubmit} className={styles.noteForm}>
+                <textarea
+                  value={internalNoteContent}
+                  onChange={(event) => setInternalNoteContent(event.target.value)}
+                  placeholder="Registrar nota interna"
+                  aria-label="Registrar nota interna"
+                  disabled={isUpdatingConversation}
+                />
+                <button
+                  type="submit"
+                  disabled={isUpdatingConversation || internalNoteContent.trim().length === 0}
+                >
+                  Adicionar nota
+                </button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <div className={styles.viewportWrapper}>
         {isLoading && <div className={styles.loadingOverlay}>Carregando conversa...</div>}
         <MessageViewport

--- a/frontend/src/features/chat/data/chatData.json
+++ b/frontend/src/features/chat/data/chatData.json
@@ -7,7 +7,25 @@
       "shortStatus": "online",
       "description": "Acordo de honorários • Proc. 2023.451",
       "unreadCount": 2,
-      "pinned": true
+      "pinned": true,
+      "phoneNumber": "+55 11 99123-4567",
+      "responsibleId": "tm-lucas",
+      "tags": ["prioridade alta", "honorários"],
+      "isLinkedToClient": true,
+      "clientName": "Prado & Cia Consultoria",
+      "customAttributes": [
+        { "id": "attr-joana-1", "label": "Origem", "value": "Recomendação" },
+        { "id": "attr-joana-2", "label": "Etapa", "value": "Aprovação do conselho" }
+      ],
+      "isPrivate": false,
+      "internalNotes": [
+        {
+          "id": "note-joana-1",
+          "author": "Lucas Prado",
+          "content": "Registrar follow-up após reunião com o conselho.",
+          "createdAt": "2024-11-04T11:10:00.000Z"
+        }
+      ]
     },
     {
       "id": "conv-financeiro",
@@ -16,7 +34,31 @@
       "shortStatus": "responde normalmente em 1h",
       "description": "Dúvidas sobre faturamento",
       "unreadCount": 0,
-      "pinned": true
+      "pinned": true,
+      "phoneNumber": "+55 11 4002-8922",
+      "responsibleId": "tm-ana",
+      "tags": ["financeiro", "interno"],
+      "isLinkedToClient": false,
+      "clientName": null,
+      "customAttributes": [
+        { "id": "attr-fin-1", "label": "Canal", "value": "Slack" },
+        { "id": "attr-fin-2", "label": "Frequência", "value": "Semanal" }
+      ],
+      "isPrivate": true,
+      "internalNotes": [
+        {
+          "id": "note-fin-1",
+          "author": "Ana Bezerra",
+          "content": "Registrar ajustes de boleto antes do fechamento do mês.",
+          "createdAt": "2024-11-02T14:05:00.000Z"
+        },
+        {
+          "id": "note-fin-2",
+          "author": "Ana Bezerra",
+          "content": "Conversa convertida em privada para alinhar fluxo interno de aprovações.",
+          "createdAt": "2024-11-03T09:25:00.000Z"
+        }
+      ]
     },
     {
       "id": "conv-carlos",
@@ -24,7 +66,18 @@
       "avatar": "https://images.unsplash.com/photo-1599566150163-29194dcaad36?auto=format&fit=facearea&w=80&h=80&q=80",
       "shortStatus": "visto às 08:10",
       "description": "Contrato de consultoria",
-      "unreadCount": 0
+      "unreadCount": 0,
+      "phoneNumber": "+55 21 99876-1122",
+      "responsibleId": "tm-marina",
+      "tags": ["consultoria", "andamento"],
+      "isLinkedToClient": true,
+      "clientName": "Inovatech Brasil",
+      "customAttributes": [
+        { "id": "attr-carlos-1", "label": "Segmento", "value": "Tecnologia" },
+        { "id": "attr-carlos-2", "label": "Ticket", "value": "R$ 35.000" }
+      ],
+      "isPrivate": false,
+      "internalNotes": []
     },
     {
       "id": "conv-tribunal",
@@ -32,7 +85,25 @@
       "avatar": "https://images.unsplash.com/photo-1528747008803-1f5c1cbd6c24?auto=format&fit=facearea&w=80&h=80&q=80",
       "shortStatus": "expediente até 19h",
       "description": "Avisos do tribunal",
-      "unreadCount": 5
+      "unreadCount": 5,
+      "phoneNumber": "+55 11 3300-4455",
+      "responsibleId": "tm-lucas",
+      "tags": ["processual", "andamento"],
+      "isLinkedToClient": true,
+      "clientName": "Tribunal de Justiça SP",
+      "customAttributes": [
+        { "id": "attr-tribunal-1", "label": "Classe", "value": "Processo cível" },
+        { "id": "attr-tribunal-2", "label": "Prazo", "value": "07/11/2024" }
+      ],
+      "isPrivate": false,
+      "internalNotes": [
+        {
+          "id": "note-tribunal-1",
+          "author": "Lucas Prado",
+          "content": "Agendar conferência de intimações para equipe de contencioso.",
+          "createdAt": "2024-11-01T18:40:00.000Z"
+        }
+      ]
     },
     {
       "id": "conv-marketing",
@@ -40,7 +111,18 @@
       "avatar": "https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=facearea&w=80&h=80&q=80",
       "shortStatus": "online",
       "description": "Campanha institucional",
-      "unreadCount": 0
+      "unreadCount": 0,
+      "phoneNumber": "+55 11 95555-2211",
+      "responsibleId": "tm-ana",
+      "tags": ["marketing", "campanhas"],
+      "isLinkedToClient": false,
+      "clientName": null,
+      "customAttributes": [
+        { "id": "attr-marketing-1", "label": "Status", "value": "Produção" },
+        { "id": "attr-marketing-2", "label": "Canal", "value": "LinkedIn" }
+      ],
+      "isPrivate": false,
+      "internalNotes": []
     },
     {
       "id": "conv-diligence",
@@ -48,7 +130,25 @@
       "avatar": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=facearea&w=80&h=80&q=80",
       "shortStatus": "último acesso às 22:15",
       "description": "Auditoria Tech&Law",
-      "unreadCount": 3
+      "unreadCount": 3,
+      "phoneNumber": "+55 11 94433-1000",
+      "responsibleId": "tm-ricardo",
+      "tags": ["due diligence", "prioridade média"],
+      "isLinkedToClient": true,
+      "clientName": "Tech&Law Holding",
+      "customAttributes": [
+        { "id": "attr-diligence-1", "label": "Fase", "value": "Coleta de documentos" },
+        { "id": "attr-diligence-2", "label": "Equipe", "value": "3 analistas" }
+      ],
+      "isPrivate": true,
+      "internalNotes": [
+        {
+          "id": "note-diligence-1",
+          "author": "Ricardo Luz",
+          "content": "Reunião interna agendada para revisar checklist de compliance.",
+          "createdAt": "2024-11-04T20:15:00.000Z"
+        }
+      ]
     },
     {
       "id": "conv-ana",
@@ -56,7 +156,18 @@
       "avatar": "https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=facearea&w=80&h=80&q=80",
       "shortStatus": "aguardando retorno",
       "description": "Revisão de cláusulas",
-      "unreadCount": 0
+      "unreadCount": 0,
+      "phoneNumber": "+55 31 98888-7722",
+      "responsibleId": "tm-marina",
+      "tags": ["contrato", "cliente premium"],
+      "isLinkedToClient": true,
+      "clientName": "Luz Arquitetura",
+      "customAttributes": [
+        { "id": "attr-ana-1", "label": "Prazo", "value": "09/11/2024" },
+        { "id": "attr-ana-2", "label": "Plano", "value": "Consultivo" }
+      ],
+      "isPrivate": false,
+      "internalNotes": []
     },
     {
       "id": "conv-paula",
@@ -64,7 +175,17 @@
       "avatar": "https://images.unsplash.com/photo-1544005313-94ddf0286df2?auto=format&fit=facearea&w=80&h=80&q=80",
       "shortStatus": "online",
       "description": "Atualização audiência",
-      "unreadCount": 1
+      "unreadCount": 1,
+      "phoneNumber": "+55 41 97766-5544",
+      "responsibleId": null,
+      "tags": ["audiência", "andamento"],
+      "isLinkedToClient": true,
+      "clientName": "Paula & Carlos Empreendimentos",
+      "customAttributes": [
+        { "id": "attr-paula-1", "label": "Audiência", "value": "12/11/2024" }
+      ],
+      "isPrivate": false,
+      "internalNotes": []
     }
   ],
   "messages": {

--- a/frontend/src/features/chat/data/teamMembers.ts
+++ b/frontend/src/features/chat/data/teamMembers.ts
@@ -1,0 +1,28 @@
+import type { TeamMember } from "../types";
+
+export const teamMembers: TeamMember[] = [
+  {
+    id: "tm-ana",
+    name: "Ana Bezerra",
+    avatar: "https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=facearea&w=80&h=80&q=80",
+    role: "Advogada Associada",
+  },
+  {
+    id: "tm-lucas",
+    name: "Lucas Prado",
+    avatar: "https://images.unsplash.com/photo-1599566150163-29194dcaad36?auto=format&fit=facearea&w=80&h=80&q=80",
+    role: "Coordenador Jurídico",
+  },
+  {
+    id: "tm-marina",
+    name: "Marina Sato",
+    avatar: "https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=facearea&w=80&h=80&q=80",
+    role: "Especialista em Compliance",
+  },
+  {
+    id: "tm-ricardo",
+    name: "Ricardo Luz",
+    avatar: "https://images.unsplash.com/photo-1544005313-94ddf0286df2?auto=format&fit=facearea&w=80&h=80&q=80",
+    role: "Sócio Diretor",
+  },
+];

--- a/frontend/src/features/chat/services/chatApi.ts
+++ b/frontend/src/features/chat/services/chatApi.ts
@@ -4,6 +4,7 @@ import type {
   MessagePage,
   NewConversationInput,
   SendMessageInput,
+  UpdateConversationPayload,
 } from "../types";
 
 const parseJson = async <T>(response: Response): Promise<T> => {
@@ -60,6 +61,18 @@ export const createConversation = async (
 ): Promise<ConversationSummary> => {
   const response = await fetch(`/api/conversations`, {
     method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return parseJson<ConversationSummary>(response);
+};
+
+export const updateConversation = async (
+  conversationId: string,
+  payload: UpdateConversationPayload,
+): Promise<ConversationSummary> => {
+  const response = await fetch(`/api/conversations/${conversationId}`, {
+    method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
   });

--- a/frontend/src/features/chat/types.ts
+++ b/frontend/src/features/chat/types.ts
@@ -19,6 +19,28 @@ export interface Message {
   attachments?: MessageAttachment[];
 }
 
+export interface TeamMember {
+  id: string;
+  name: string;
+  avatar: string;
+  role: string;
+}
+
+export type ConversationResponsible = TeamMember;
+
+export interface ConversationCustomAttribute {
+  id: string;
+  label: string;
+  value: string;
+}
+
+export interface ConversationInternalNote {
+  id: string;
+  author: string;
+  content: string;
+  createdAt: string;
+}
+
 export interface ConversationSummary {
   id: string;
   name: string;
@@ -28,6 +50,14 @@ export interface ConversationSummary {
   unreadCount: number;
   pinned?: boolean;
   lastMessage?: ConversationLastMessage;
+  phoneNumber?: string;
+  responsible?: ConversationResponsible | null;
+  tags: string[];
+  isLinkedToClient?: boolean;
+  clientName?: string | null;
+  customAttributes: ConversationCustomAttribute[];
+  isPrivate?: boolean;
+  internalNotes: ConversationInternalNote[];
 }
 
 export interface ConversationLastMessage {
@@ -48,6 +78,14 @@ export interface ConversationDatasetEntry {
   description?: string;
   unreadCount: number;
   pinned?: boolean;
+  phoneNumber?: string;
+  responsibleId?: string | null;
+  tags?: string[];
+  isLinkedToClient?: boolean;
+  clientName?: string | null;
+  customAttributes?: ConversationCustomAttribute[];
+  isPrivate?: boolean;
+  internalNotes?: ConversationInternalNote[];
 }
 
 export interface ChatDataset {
@@ -64,10 +102,23 @@ export interface NewConversationInput {
   name: string;
   description?: string;
   avatar?: string;
+  phoneNumber?: string;
+  responsibleId?: string | null;
 }
 
 export interface SendMessageInput {
   content: string;
   type?: MessageType;
   attachments?: MessageAttachment[];
+}
+
+export interface UpdateConversationPayload {
+  responsibleId?: string | null;
+  tags?: string[];
+  phoneNumber?: string;
+  isLinkedToClient?: boolean;
+  clientName?: string | null;
+  customAttributes?: ConversationCustomAttribute[];
+  isPrivate?: boolean;
+  internalNotes?: ConversationInternalNote[];
 }


### PR DESCRIPTION
## Summary
- expand conversation types and mock dataset with responsibles, phone numbers, tags, client linkage and internal notes support
- expose a conversation update endpoint and React Query mutation to persist assignments, tags, attributes and privacy changes
- refresh sidebar filters and chat window UI with responsible picker, tag management, client linking and private note controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8c23ca3fc83269882628737fcac22