### PR TITLE
Ensure chat input remains focused after sending messages

### DIFF
--- a/frontend/src/features/chat/components/ChatInput.tsx
+++ b/frontend/src/features/chat/components/ChatInput.tsx
@@ -60,6 +60,9 @@ export const ChatInput = ({ onSend, disabled = false }: ChatInputProps) => {
       setValue("");
     } finally {
       setIsSending(false);
+      requestAnimationFrame(() => {
+        textareaRef.current?.focus();
+      });
     }
   };
 
@@ -190,7 +193,7 @@ export const ChatInput = ({ onSend, disabled = false }: ChatInputProps) => {
           onPaste={handlePaste}
           placeholder="Escreva uma mensagem"
           aria-label="Campo para digitar mensagem"
-          disabled={disabled || isSending}
+          disabled={disabled}
         />
         <button
           type="button"


### PR DESCRIPTION
## Summary
- restore focus to the chat textarea after sending a message
- keep the textarea enabled while a send request is in flight so the user can continue typing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8cfa4e74c8326ab730f8c72ff31b4