### PR TITLE
Add module access management to profile settings

### DIFF
--- a/backend/sql/perfis.sql
+++ b/backend/sql/perfis.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS public.perfil_modulos (
+    perfil_id INTEGER NOT NULL REFERENCES public.perfis(id) ON DELETE CASCADE,
+    modulo TEXT NOT NULL,
+    PRIMARY KEY (perfil_id, modulo)
+);

--- a/backend/src/constants/modules.ts
+++ b/backend/src/constants/modules.ts
@@ -1,0 +1,95 @@
+export interface SystemModule {
+  id: string;
+  nome: string;
+  descricao?: string;
+  categoria?: string;
+}
+
+export const SYSTEM_MODULES: SystemModule[] = [
+  { id: 'dashboard', nome: 'Dashboard', categoria: 'Aplicação' },
+  { id: 'conversas', nome: 'Conversas', categoria: 'Aplicação' },
+  { id: 'clientes', nome: 'Clientes', categoria: 'Aplicação' },
+  { id: 'pipeline', nome: 'Pipeline', categoria: 'Aplicação' },
+  { id: 'agenda', nome: 'Agenda', categoria: 'Aplicação' },
+  { id: 'tarefas', nome: 'Tarefas', categoria: 'Aplicação' },
+  { id: 'processos', nome: 'Processos', categoria: 'Aplicação' },
+  { id: 'intimacoes', nome: 'Intimações', categoria: 'Aplicação' },
+  { id: 'documentos', nome: 'Documentos', categoria: 'Aplicação' },
+  { id: 'financeiro', nome: 'Financeiro', categoria: 'Aplicação' },
+  { id: 'relatorios', nome: 'Relatórios', categoria: 'Aplicação' },
+  { id: 'meu-plano', nome: 'Meu Plano', categoria: 'Aplicação' },
+  { id: 'suporte', nome: 'Suporte', categoria: 'Aplicação' },
+  { id: 'configuracoes', nome: 'Configurações', categoria: 'Configurações' },
+  { id: 'configuracoes-usuarios', nome: 'Configurações - Usuários', categoria: 'Configurações' },
+  { id: 'configuracoes-integracoes', nome: 'Configurações - Integrações', categoria: 'Configurações' },
+  { id: 'configuracoes-parametros', nome: 'Configurações - Parâmetros', categoria: 'Configurações' },
+  { id: 'configuracoes-parametros-perfis', nome: 'Configurações - Parâmetros - Perfis', categoria: 'Configurações' },
+  { id: 'configuracoes-parametros-escritorios', nome: 'Configurações - Parâmetros - Escritórios', categoria: 'Configurações' },
+  { id: 'configuracoes-parametros-area-atuacao', nome: 'Configurações - Parâmetros - Área de Atuação', categoria: 'Configurações' },
+  { id: 'configuracoes-parametros-situacao-processo', nome: 'Configurações - Parâmetros - Situação do Processo', categoria: 'Configurações' },
+  { id: 'configuracoes-parametros-tipo-processo', nome: 'Configurações - Parâmetros - Tipo de Processo', categoria: 'Configurações' },
+  { id: 'configuracoes-parametros-tipo-evento', nome: 'Configurações - Parâmetros - Tipo de Evento', categoria: 'Configurações' },
+  { id: 'configuracoes-parametros-situacao-cliente', nome: 'Configurações - Parâmetros - Situação do Cliente', categoria: 'Configurações' },
+  { id: 'configuracoes-parametros-etiquetas', nome: 'Configurações - Parâmetros - Etiquetas', categoria: 'Configurações' },
+  { id: 'configuracoes-parametros-tipos-documento', nome: 'Configurações - Parâmetros - Tipos de Documento', categoria: 'Configurações' },
+  { id: 'configuracoes-parametros-fluxo-trabalho', nome: 'Configurações - Parâmetros - Fluxo de Trabalho', categoria: 'Configurações' },
+];
+
+const SYSTEM_MODULE_INDEX = new Map<string, number>(
+  SYSTEM_MODULES.map((module, index) => [module.id, index])
+);
+
+export const SYSTEM_MODULE_SET = new Set<string>(
+  SYSTEM_MODULES.map((module) => module.id)
+);
+
+export function sanitizeModuleIds(values: unknown): string[] {
+  if (values == null) {
+    return [];
+  }
+
+  if (!Array.isArray(values)) {
+    throw new Error('modulos deve ser um array de strings');
+  }
+
+  const unique = new Set<string>();
+  const sanitized: string[] = [];
+
+  for (const value of values) {
+    if (typeof value !== 'string') {
+      throw new Error('modulos deve conter apenas strings válidas');
+    }
+
+    const trimmed = value.trim();
+    if (!SYSTEM_MODULE_SET.has(trimmed)) {
+      throw new Error(`Módulo desconhecido: ${value}`);
+    }
+
+    if (!unique.has(trimmed)) {
+      unique.add(trimmed);
+      sanitized.push(trimmed);
+    }
+  }
+
+  return sanitized;
+}
+
+export function sortModules(modules: string[]): string[] {
+  return [...modules].sort((a, b) => {
+    const indexA = SYSTEM_MODULE_INDEX.get(a);
+    const indexB = SYSTEM_MODULE_INDEX.get(b);
+
+    if (indexA == null && indexB == null) {
+      return a.localeCompare(b);
+    }
+
+    if (indexA == null) return 1;
+    if (indexB == null) return -1;
+
+    if (indexA === indexB) {
+      return a.localeCompare(b);
+    }
+
+    return indexA - indexB;
+  });
+}

--- a/backend/src/controllers/perfilController.ts
+++ b/backend/src/controllers/perfilController.ts
@@ -1,63 +1,200 @@
 import { Request, Response } from 'express';
 import pool from '../services/db';
+import {
+  SYSTEM_MODULES,
+  sanitizeModuleIds,
+  sortModules,
+} from '../constants/modules';
+
+const formatPerfilRow = (row: {
+  id: number;
+  nome: string;
+  ativo: boolean;
+  datacriacao: Date;
+  modulos?: string[] | null;
+}) => ({
+  id: row.id,
+  nome: row.nome,
+  ativo: row.ativo,
+  datacriacao: row.datacriacao,
+  modulos: row.modulos ? sortModules(row.modulos) : [],
+});
+
+const parseModules = (value: unknown): { ok: true; modules: string[] } | { ok: false; error: string } => {
+  try {
+    const modules = sortModules(sanitizeModuleIds(value));
+    return { ok: true, modules };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Não foi possível processar os módulos informados';
+    return { ok: false, error: message };
+  }
+};
+
+const parsePerfilId = (value: string): number | null => {
+  const id = Number(value);
+  if (!Number.isInteger(id) || id <= 0) {
+    return null;
+  }
+  return id;
+};
 
 export const listPerfis = async (_req: Request, res: Response) => {
   try {
     const result = await pool.query(
-      'SELECT id, nome, ativo, datacriacao FROM public.perfis'
+      `SELECT p.id,
+              p.nome,
+              p.ativo,
+              p.datacriacao,
+              COALESCE(
+                array_agg(pm.modulo ORDER BY pm.modulo) FILTER (WHERE pm.modulo IS NOT NULL),
+                '{}'
+              ) AS modulos
+         FROM public.perfis p
+    LEFT JOIN public.perfil_modulos pm ON pm.perfil_id = p.id
+     GROUP BY p.id
+     ORDER BY p.nome`
     );
-    res.json(result.rows);
+    res.json(result.rows.map(formatPerfilRow));
   } catch (error) {
     console.error(error);
     res.status(500).json({ error: 'Internal server error' });
   }
 };
 
+export const listPerfilModules = async (_req: Request, res: Response) => {
+  res.json(SYSTEM_MODULES);
+};
+
 export const createPerfil = async (req: Request, res: Response) => {
-  const { nome, ativo } = req.body;
+  const nomeValue = typeof req.body?.nome === 'string' ? req.body.nome.trim() : '';
+  const ativoValue = typeof req.body?.ativo === 'boolean' ? req.body.ativo : true;
+  const parsedModules = parseModules(req.body?.modulos);
+
+  if (!nomeValue) {
+    return res.status(400).json({ error: 'O nome do perfil é obrigatório' });
+  }
+
+  if (!parsedModules.ok) {
+    return res.status(400).json({ error: parsedModules.error });
+  }
+
+  const client = await pool.connect();
   try {
-    const result = await pool.query(
+    await client.query('BEGIN');
+
+    const result = await client.query(
       'INSERT INTO public.perfis (nome, ativo, datacriacao) VALUES ($1, $2, NOW()) RETURNING id, nome, ativo, datacriacao',
-      [nome, ativo]
+      [nomeValue, ativoValue]
     );
-    res.status(201).json(result.rows[0]);
+
+    const perfil = result.rows[0];
+
+    if (parsedModules.modules.length > 0) {
+      await client.query(
+        'INSERT INTO public.perfil_modulos (perfil_id, modulo) SELECT $1, unnest($2::text[])',
+        [perfil.id, parsedModules.modules]
+      );
+    }
+
+    await client.query('COMMIT');
+
+    res.status(201).json({
+      ...perfil,
+      modulos: parsedModules.modules,
+    });
   } catch (error) {
+    await client.query('ROLLBACK');
     console.error(error);
     res.status(500).json({ error: 'Internal server error' });
+  } finally {
+    client.release();
   }
 };
 
 export const updatePerfil = async (req: Request, res: Response) => {
-  const { id } = req.params;
-  const { nome, ativo } = req.body;
+  const parsedId = parsePerfilId(req.params.id);
+  if (parsedId == null) {
+    return res.status(400).json({ error: 'ID de perfil inválido' });
+  }
+
+  const nomeValue = typeof req.body?.nome === 'string' ? req.body.nome.trim() : '';
+  const ativoValue = typeof req.body?.ativo === 'boolean' ? req.body.ativo : true;
+  const parsedModules = parseModules(req.body?.modulos);
+
+  if (!nomeValue) {
+    return res.status(400).json({ error: 'O nome do perfil é obrigatório' });
+  }
+
+  if (!parsedModules.ok) {
+    return res.status(400).json({ error: parsedModules.error });
+  }
+
+  const client = await pool.connect();
   try {
-    const result = await pool.query(
+    await client.query('BEGIN');
+
+    const result = await client.query(
       'UPDATE public.perfis SET nome = $1, ativo = $2 WHERE id = $3 RETURNING id, nome, ativo, datacriacao',
-      [nome, ativo, id]
+      [nomeValue, ativoValue, parsedId]
     );
+
     if (result.rowCount === 0) {
+      await client.query('ROLLBACK');
       return res.status(404).json({ error: 'Perfil não encontrado' });
     }
-    res.json(result.rows[0]);
+
+    await client.query('DELETE FROM public.perfil_modulos WHERE perfil_id = $1', [parsedId]);
+
+    if (parsedModules.modules.length > 0) {
+      await client.query(
+        'INSERT INTO public.perfil_modulos (perfil_id, modulo) SELECT $1, unnest($2::text[])',
+        [parsedId, parsedModules.modules]
+      );
+    }
+
+    await client.query('COMMIT');
+
+    res.json({
+      ...result.rows[0],
+      modulos: parsedModules.modules,
+    });
   } catch (error) {
+    await client.query('ROLLBACK');
     console.error(error);
     res.status(500).json({ error: 'Internal server error' });
+  } finally {
+    client.release();
   }
 };
 
 export const deletePerfil = async (req: Request, res: Response) => {
-  const { id } = req.params;
+  const parsedId = parsePerfilId(req.params.id);
+  if (parsedId == null) {
+    return res.status(400).json({ error: 'ID de perfil inválido' });
+  }
+
+  const client = await pool.connect();
   try {
-    const result = await pool.query(
-      'DELETE FROM public.perfis WHERE id = $1',
-      [id]
-    );
-    if (result.rowCount === 0) {
+    await client.query('BEGIN');
+
+    const exists = await client.query('SELECT 1 FROM public.perfis WHERE id = $1', [parsedId]);
+    if (exists.rowCount === 0) {
+      await client.query('ROLLBACK');
       return res.status(404).json({ error: 'Perfil não encontrado' });
     }
+
+    await client.query('DELETE FROM public.perfil_modulos WHERE perfil_id = $1', [parsedId]);
+    await client.query('DELETE FROM public.perfis WHERE id = $1', [parsedId]);
+
+    await client.query('COMMIT');
+
     res.status(204).send();
   } catch (error) {
+    await client.query('ROLLBACK');
     console.error(error);
     res.status(500).json({ error: 'Internal server error' });
+  } finally {
+    client.release();
   }
 };

--- a/backend/src/routes/perfilRoutes.ts
+++ b/backend/src/routes/perfilRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import {
   listPerfis,
+  listPerfilModules,
   createPerfil,
   updatePerfil,
   deletePerfil,
@@ -27,7 +28,38 @@ const router = Router();
  *         datacriacao:
  *           type: string
  *           format: date-time
+ *         modulos:
+ *           type: array
+ *           items:
+ *             type: string
  */
+
+/**
+ * @swagger
+ * /api/perfis/modulos:
+ *   get:
+ *     summary: Lista todos os módulos disponíveis para perfis
+ *     tags: [Perfis]
+ *     responses:
+ *       200:
+ *         description: Lista de módulos do sistema
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *                   nome:
+ *                     type: string
+ *                   descricao:
+ *                     type: string
+ *                   categoria:
+ *                     type: string
+ */
+router.get('/perfis/modulos', listPerfilModules);
 
 /**
  * @swagger
@@ -64,6 +96,10 @@ router.get('/perfis', listPerfis);
  *                 type: string
  *               ativo:
  *                 type: boolean
+ *               modulos:
+ *                 type: array
+ *                 items:
+ *                   type: string
  *     responses:
  *       201:
  *         description: Perfil criado
@@ -97,6 +133,10 @@ router.post('/perfis', createPerfil);
  *                 type: string
  *               ativo:
  *                 type: boolean
+ *               modulos:
+ *                 type: array
+ *                 items:
+ *                   type: string
  *     responses:
  *       200:
  *         description: Perfil atualizado

--- a/frontend/src/pages/configuracoes/parametros/Perfis.tsx
+++ b/frontend/src/pages/configuracoes/parametros/Perfis.tsx
@@ -1,14 +1,489 @@
-import ParameterPage from "./ParameterPage";
+import { useEffect, useMemo, useState } from "react";
+import { Plus, Pencil, Trash2, Check, X, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { getApiBaseUrl } from "@/lib/api";
 
-export default function Perfis() {
-  return (
-    <ParameterPage
-      title="Perfis"
-      description="Gerencie os perfis do sistema"
-      placeholder="Novo perfil"
-      emptyMessage="Nenhum perfil cadastrado"
-      endpoint="/api/perfis"
-    />
-  );
+interface ModuleInfo {
+  id: string;
+  nome: string;
+  descricao?: string;
+  categoria?: string;
 }
 
+interface PerfilItem {
+  id: number;
+  nome: string;
+  modulos: string[];
+}
+
+const extractCollection = (data: unknown): unknown[] => {
+  if (Array.isArray(data)) return data;
+  if (data && typeof data === "object") {
+    const record = data as Record<string, unknown>;
+    if (Array.isArray(record.rows)) return record.rows;
+    if (Array.isArray(record.data)) return record.data;
+    if (record.data && typeof record.data === "object") {
+      const inner = record.data as Record<string, unknown>;
+      if (Array.isArray(inner.rows)) return inner.rows;
+    }
+  }
+  return [];
+};
+
+const normalizeModuleIds = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return [];
+  const unique: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string") continue;
+    const trimmed = entry.trim();
+    if (!trimmed || unique.includes(trimmed)) continue;
+    unique.push(trimmed);
+  }
+  return unique;
+};
+
+const orderModules = (modules: string[], available: ModuleInfo[]): string[] => {
+  if (modules.length <= 1 || available.length === 0) return [...modules];
+  const index = new Map<string, number>();
+  available.forEach((module, position) => {
+    index.set(module.id, position);
+  });
+  return [...modules].sort((a, b) => {
+    const indexA = index.get(a);
+    const indexB = index.get(b);
+    if (indexA == null && indexB == null) return a.localeCompare(b);
+    if (indexA == null) return 1;
+    if (indexB == null) return -1;
+    if (indexA === indexB) return a.localeCompare(b);
+    return indexA - indexB;
+  });
+};
+
+const sortProfilesByName = (profiles: PerfilItem[]): PerfilItem[] =>
+  [...profiles].sort((a, b) => a.nome.localeCompare(b.nome, "pt-BR"));
+
+const parseNumberId = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+};
+
+export default function Perfis() {
+  const apiUrl = getApiBaseUrl();
+
+  const [availableModules, setAvailableModules] = useState<ModuleInfo[]>([]);
+  const [profiles, setProfiles] = useState<PerfilItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [newName, setNewName] = useState("");
+  const [newModules, setNewModules] = useState<string[]>([]);
+  const [savingNew, setSavingNew] = useState(false);
+
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editingName, setEditingName] = useState("");
+  const [editingModules, setEditingModules] = useState<string[]>([]);
+  const [savingEdit, setSavingEdit] = useState(false);
+
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+
+  const moduleLabelMap = useMemo(() => {
+    const map = new Map<string, string>();
+    availableModules.forEach((module) => {
+      map.set(module.id, module.nome);
+    });
+    return map;
+  }, [availableModules]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const [modulesRes, profilesRes] = await Promise.all([
+          fetch(`${apiUrl}/api/perfis/modulos`, { headers: { Accept: "application/json" } }),
+          fetch(`${apiUrl}/api/perfis`, { headers: { Accept: "application/json" } }),
+        ]);
+
+        if (!modulesRes.ok) {
+          throw new Error(`HTTP ${modulesRes.status}: ${await modulesRes.text()}`);
+        }
+        if (!profilesRes.ok) {
+          throw new Error(`HTTP ${profilesRes.status}: ${await profilesRes.text()}`);
+        }
+
+        const rawModules = extractCollection(await modulesRes.json());
+        const parsedModules = rawModules
+          .map((entry) => {
+            if (!entry || typeof entry !== "object") return null;
+            const data = entry as Record<string, unknown>;
+            const id = typeof data.id === "string" ? data.id : null;
+            const nome = typeof data.nome === "string" ? data.nome : null;
+            if (!id || !nome) return null;
+            return {
+              id,
+              nome,
+              descricao: typeof data.descricao === "string" ? data.descricao : undefined,
+              categoria: typeof data.categoria === "string" ? data.categoria : undefined,
+            } satisfies ModuleInfo;
+          })
+          .filter((item): item is ModuleInfo => item !== null);
+
+        setAvailableModules(parsedModules);
+
+        const rawProfiles = extractCollection(await profilesRes.json());
+        const parsedProfiles = rawProfiles
+          .map((entry) => {
+            if (!entry || typeof entry !== "object") return null;
+            const data = entry as Record<string, unknown>;
+            const id = parseNumberId(data.id);
+            if (id == null) return null;
+            const nome =
+              typeof data.nome === "string"
+                ? data.nome
+                : typeof data.descricao === "string"
+                  ? data.descricao
+                  : typeof data.name === "string"
+                    ? data.name
+                    : "";
+            const modulos = orderModules(normalizeModuleIds(data.modulos), parsedModules);
+            return { id, nome, modulos } satisfies PerfilItem;
+          })
+          .filter((item): item is PerfilItem => item !== null);
+
+        setProfiles(sortProfilesByName(parsedProfiles));
+      } catch (err) {
+        console.error(err);
+        setError("Não foi possível carregar os dados de perfis.");
+        setProfiles([]);
+        setAvailableModules([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [apiUrl]);
+
+  useEffect(() => {
+    if (availableModules.length === 0) {
+      setNewModules([]);
+      setEditingModules([]);
+      return;
+    }
+
+    setNewModules((prev) => orderModules(prev.filter((id) => moduleLabelMap.has(id)), availableModules));
+    if (editingId != null) {
+      setEditingModules((prev) =>
+        orderModules(prev.filter((id) => moduleLabelMap.has(id)), availableModules)
+      );
+    }
+  }, [availableModules, moduleLabelMap, editingId]);
+
+  const updateSelection = (current: string[], moduleId: string, checked: boolean) => {
+    const next = new Set(current);
+    if (checked) {
+      next.add(moduleId);
+    } else {
+      next.delete(moduleId);
+    }
+    return orderModules(Array.from(next), availableModules);
+  };
+
+  const handleCreateProfile = async () => {
+    const nome = newName.trim();
+    if (!nome || savingNew) return;
+
+    setSavingNew(true);
+    setError(null);
+
+    const payload = {
+      nome,
+      ativo: true,
+      modulos: orderModules(newModules, availableModules),
+    };
+
+    try {
+      const response = await fetch(`${apiUrl}/api/perfis`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+      }
+
+      const data = await response.json();
+      const createdModules = orderModules(normalizeModuleIds((data as Record<string, unknown>)?.modulos), availableModules);
+      const parsedId = parseNumberId((data as Record<string, unknown>)?.id);
+      const created: PerfilItem = {
+        id: parsedId ?? Date.now(),
+        nome: typeof data?.nome === "string" ? data.nome : nome,
+        modulos: createdModules,
+      };
+
+      setProfiles((prev) => sortProfilesByName([...prev, created]));
+      setNewName("");
+      setNewModules([]);
+    } catch (err) {
+      console.error(err);
+      setError("Não foi possível criar o perfil.");
+    } finally {
+      setSavingNew(false);
+    }
+  };
+
+  const startEdit = (profile: PerfilItem) => {
+    setError(null);
+    setEditingId(profile.id);
+    setEditingName(profile.nome);
+    setEditingModules(orderModules(profile.modulos, availableModules));
+  };
+
+  const cancelEdit = () => {
+    if (savingEdit) return;
+    setEditingId(null);
+    setEditingName("");
+    setEditingModules([]);
+  };
+
+  const handleSaveEdit = async () => {
+    if (editingId == null || savingEdit) return;
+    const nome = editingName.trim();
+    if (!nome) return;
+
+    setSavingEdit(true);
+    setError(null);
+
+    const payload = {
+      nome,
+      ativo: true,
+      modulos: orderModules(editingModules, availableModules),
+    };
+
+    try {
+      const response = await fetch(`${apiUrl}/api/perfis/${editingId}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+      }
+
+      const data = await response.json();
+      const updatedModules = orderModules(normalizeModuleIds((data as Record<string, unknown>)?.modulos), availableModules);
+
+      setProfiles((prev) =>
+        sortProfilesByName(
+          prev.map((item) =>
+            item.id === editingId
+              ? {
+                  ...item,
+                  nome: typeof data?.nome === "string" ? data.nome : nome,
+                  modulos: updatedModules,
+                }
+              : item
+          )
+        )
+      );
+
+      setEditingId(null);
+      setEditingName("");
+      setEditingModules([]);
+    } catch (err) {
+      console.error(err);
+      setError("Não foi possível salvar as alterações do perfil.");
+    } finally {
+      setSavingEdit(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    if (deletingId != null) return;
+    setError(null);
+    setDeletingId(id);
+    try {
+      const response = await fetch(`${apiUrl}/api/perfis/${id}`, { method: "DELETE" });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+      }
+      setProfiles((prev) => prev.filter((item) => item.id !== id));
+      if (editingId === id) {
+        cancelEdit();
+      }
+    } catch (err) {
+      console.error(err);
+      setError("Não foi possível remover o perfil.");
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const renderModuleBadges = (modules: string[]) => {
+    if (modules.length === 0) {
+      return <span className="text-sm text-muted-foreground">Nenhum módulo</span>;
+    }
+
+    return (
+      <div className="flex flex-wrap gap-2">
+        {modules.map((moduleId) => (
+          <Badge key={moduleId} variant="secondary">
+            {moduleLabelMap.get(moduleId) ?? moduleId}
+          </Badge>
+        ))}
+      </div>
+    );
+  };
+
+  const renderModuleCheckboxes = (
+    selected: string[],
+    onChange: (moduleId: string, checked: boolean) => void,
+    idPrefix: string
+  ) => {
+    if (availableModules.length === 0) {
+      return <span className="text-sm text-muted-foreground">Nenhum módulo disponível</span>;
+    }
+
+    return (
+      <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+        {availableModules.map((module) => (
+          <label key={module.id} className="flex items-center gap-2 text-sm font-medium">
+            <Checkbox
+              id={`${idPrefix}-${module.id}`}
+              checked={selected.includes(module.id)}
+              onCheckedChange={(value) => onChange(module.id, value === true)}
+            />
+            <span>{module.nome}</span>
+          </label>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-foreground">Perfis</h1>
+        <p className="text-muted-foreground">Gerencie os perfis do sistema e seus módulos de acesso.</p>
+      </div>
+
+      <div className="space-y-4">
+        <div className="flex flex-col gap-3 md:flex-row md:items-end">
+          <div className="flex-1 space-y-2">
+            <Input
+              placeholder="Nome do novo perfil"
+              value={newName}
+              onChange={(event) => setNewName(event.target.value)}
+              className="max-w-sm"
+            />
+          </div>
+          <Button onClick={handleCreateProfile} disabled={!newName.trim() || savingNew}>
+            {savingNew ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Plus className="mr-2 h-4 w-4" />}
+            Adicionar
+          </Button>
+        </div>
+        {renderModuleCheckboxes(newModules, (moduleId, checked) => {
+          setNewModules((prev) => updateSelection(prev, moduleId, checked));
+        }, 'new')}
+      </div>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      {loading && <p className="text-sm text-muted-foreground">Carregando…</p>}
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-56">Nome</TableHead>
+            <TableHead>Módulos</TableHead>
+            <TableHead className="w-32">Ações</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {profiles.map((profile) => (
+            <TableRow key={profile.id}>
+              <TableCell>
+                {editingId === profile.id ? (
+                  <Input value={editingName} onChange={(event) => setEditingName(event.target.value)} />
+                ) : (
+                  profile.nome
+                )}
+              </TableCell>
+              <TableCell>
+                {editingId === profile.id
+                  ? renderModuleCheckboxes(editingModules, (moduleId, checked) => {
+                      setEditingModules((prev) => updateSelection(prev, moduleId, checked));
+                    }, `edit-${profile.id}`)
+                  : renderModuleBadges(profile.modulos)}
+              </TableCell>
+              <TableCell className="flex gap-2">
+                {editingId === profile.id ? (
+                  <>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      onClick={handleSaveEdit}
+                      disabled={savingEdit || !editingName.trim()}
+                    >
+                      {savingEdit ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
+                    </Button>
+                    <Button size="icon" variant="ghost" onClick={cancelEdit} disabled={savingEdit}>
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <Button size="icon" variant="ghost" onClick={() => startEdit(profile)}>
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      onClick={() => handleDelete(profile.id)}
+                      disabled={deletingId === profile.id}
+                    >
+                      {deletingId === profile.id ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Trash2 className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+          {!loading && profiles.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={3} className="text-center text-muted-foreground">
+                Nenhum perfil cadastrado
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a catalog of system modules and utilities to validate profile permissions
- extend profile CRUD endpoints to persist module assignments and expose the catalog to clients
- rebuild the profiles parameter page to let administrators assign module access visually

## Testing
- npm run build (backend)
- npm run build (frontend)
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8da97985883269f433f0a1dab57cc