### PR TITLE
feat: integrate sidebar with global layout

### DIFF
--- a/frontend/src/components/layout/CRMLayout.tsx
+++ b/frontend/src/components/layout/CRMLayout.tsx
@@ -1,17 +1,20 @@
 import { Outlet } from "react-router-dom";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
+import { SidebarProvider } from "@/components/ui/sidebar";
 
 export function CRMLayout() {
   return (
-    <div className="min-h-screen bg-background flex w-full">
-      <Sidebar />
-      <div className="flex-1 flex flex-col">
-        <Header />
-        <main className="flex-1 overflow-auto">
-          <Outlet />
-        </main>
+    <SidebarProvider>
+      <div className="min-h-screen bg-background flex w-full">
+        <Sidebar />
+        <div className="flex-1 flex flex-col">
+          <Header />
+          <main className="flex-1 overflow-auto bg-background">
+            <Outlet />
+          </main>
+        </div>
       </div>
-    </div>
+    </SidebarProvider>
   );
 }

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ModeToggle } from "@/components/ui/mode-toggle";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -18,15 +19,18 @@ export function Header() {
   const navigate = useNavigate();
 
   return (
-    <header className="h-16 bg-card border-b border-border px-6 flex items-center justify-between">
+    <header className="h-16 bg-card border-b border-border px-6 flex items-center justify-between gap-4">
       {/* Search */}
-      <div className="flex-1 max-w-md">
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Pesquisar clientes, processos..."
-            className="pl-9 bg-muted/50"
-          />
+      <div className="flex flex-1 items-center gap-3">
+        <SidebarTrigger className="text-muted-foreground" />
+        <div className="flex-1 max-w-md">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Pesquisar clientes, processos..."
+              className="pl-9 bg-muted/50"
+            />
+          </div>
         </div>
       </div>
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
-import { useState, useEffect } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 import {
   LayoutDashboard,
   Users,
@@ -16,13 +16,29 @@ import {
   LifeBuoy,
   Scale,
   Settings,
-  ChevronDown,
-  ChevronLeft,
-  ChevronRight,
   LogOut,
+  ChevronRight,
   type LucideIcon,
 } from "lucide-react";
-import { cn } from "@/lib/utils";
+import {
+  Sidebar as SidebarUI,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarRail,
+  useSidebar,
+} from "@/components/ui/sidebar";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { getApiBaseUrl } from "@/lib/api";
 
 interface NavItem {
@@ -35,7 +51,7 @@ interface NavItem {
 export function Sidebar() {
   const location = useLocation();
   const navigate = useNavigate();
-  const [collapsed, setCollapsed] = useState(false);
+  const { isMobile, setOpenMobile } = useSidebar();
   const [pipelineMenus, setPipelineMenus] = useState<NavItem[]>([]);
 
   useEffect(() => {
@@ -76,227 +92,251 @@ export function Sidebar() {
     fetchMenus();
   }, []);
 
-  const navigation: NavItem[] = [
-    { name: "Dashboard", href: "/", icon: LayoutDashboard },
-    { name: "Conversas", href: "/conversas", icon: MessageCircle },
-    { name: "Clientes", href: "/clientes", icon: Users },
-    { name: "Pipeline", href: "/pipeline", icon: Target, children: pipelineMenus },
-    { name: "Agenda", href: "/agenda", icon: Calendar },
-    { name: "Tarefas", href: "/tarefas", icon: CheckSquare },
-    { name: "Processos", href: "/processos", icon: Gavel },
-    { name: "Intimações", href: "/intimacoes", icon: BellRing },
-    { name: "Documentos", href: "/documentos", icon: FileText },
-    { name: "Financeiro", href: "/financeiro/lancamentos", icon: DollarSign },
-    { name: "Relatórios", href: "/relatorios", icon: BarChart3 },
-    { name: "Meu Plano", href: "/meu-plano", icon: CreditCard },
-    { name: "Suporte", href: "/suporte", icon: LifeBuoy },
-    {
-      name: "Configurações",
-      href: "/configuracoes",
-      icon: Settings,
-      children: [
-        {
-          name: "Usuários",
-          href: "/configuracoes/usuarios",
-        },
-        {
-          name: "Integrações",
-          href: "/configuracoes/integracoes",
-        },
-        {
-          name: "Parâmetros",
-          children: [
-            {
-              name: "Perfis",
-              href: "/configuracoes/parametros/perfis",
-            },
-            {
-              name: "Setores",
-              href: "/configuracoes/parametros/setores",
-            },
-            {
-              name: "Área de Atuação",
-              href: "/configuracoes/parametros/area-de-atuacao",
-            },
-            {
-              name: "Situação do Processo",
-              href: "/configuracoes/parametros/situacao-processo",
-            },
-            {
-              name: "Tipo de Processo",
-              href: "/configuracoes/parametros/tipo-processo",
-            },
-            {
-              name: "Tipo de Evento",
-              href: "/configuracoes/parametros/tipo-evento",
-            },
-            {
-              name: "Situação da Proposta",
-              href: "/configuracoes/parametros/situacao-proposta",
-            },
-            {
-              name: "Etiquetas",
-              href: "/configuracoes/parametros/etiquetas",
-            },
-            {
-              name: "Tipos de Documento",
-              href: "/configuracoes/parametros/tipo-documento",
-            },
-            {
-              name: "Fluxo de Trabalho",
-              href: "/configuracoes/parametros/fluxo-de-trabalho",
-            },
-          ],
-        },
-      ],
-    },
-  ];
+  const navigation = useMemo<NavItem[]>(
+    () => [
+      { name: "Dashboard", href: "/", icon: LayoutDashboard },
+      { name: "Conversas", href: "/conversas", icon: MessageCircle },
+      { name: "Clientes", href: "/clientes", icon: Users },
+      { name: "Pipeline", href: "/pipeline", icon: Target, children: pipelineMenus },
+      { name: "Agenda", href: "/agenda", icon: Calendar },
+      { name: "Tarefas", href: "/tarefas", icon: CheckSquare },
+      { name: "Processos", href: "/processos", icon: Gavel },
+      { name: "Intimações", href: "/intimacoes", icon: BellRing },
+      { name: "Documentos Padrões", href: "/documentos", icon: FileText },
+      { name: "Financeiro", href: "/financeiro/lancamentos", icon: DollarSign },
+      { name: "Relatórios", href: "/relatorios", icon: BarChart3 },
+      { name: "Meu Plano", href: "/meu-plano", icon: CreditCard },
+      { name: "Suporte", href: "/suporte", icon: LifeBuoy },
+      {
+        name: "Configurações",
+        href: "/configuracoes",
+        icon: Settings,
+        children: [
+          {
+            name: "Usuários",
+            href: "/configuracoes/usuarios",
+          },
+          {
+            name: "Integrações",
+            href: "/configuracoes/integracoes",
+          },
+          {
+            name: "Parâmetros",
+            children: [
+              {
+                name: "Perfis",
+                href: "/configuracoes/parametros/perfis",
+              },
+              {
+                name: "Setores",
+                href: "/configuracoes/parametros/setores",
+              },
+              {
+                name: "Área de Atuação",
+                href: "/configuracoes/parametros/area-de-atuacao",
+              },
+              {
+                name: "Situação do Processo",
+                href: "/configuracoes/parametros/situacao-processo",
+              },
+              {
+                name: "Tipo de Processo",
+                href: "/configuracoes/parametros/tipo-processo",
+              },
+              {
+                name: "Tipo de Evento",
+                href: "/configuracoes/parametros/tipo-evento",
+              },
+              {
+                name: "Situação da Proposta",
+                href: "/configuracoes/parametros/situacao-proposta",
+              },
+              {
+                name: "Etiquetas",
+                href: "/configuracoes/parametros/etiquetas",
+              },
+              {
+                name: "Tipos de Documento",
+                href: "/configuracoes/parametros/tipo-documento",
+              },
+              {
+                name: "Fluxo de Trabalho",
+                href: "/configuracoes/parametros/fluxo-de-trabalho",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    [pipelineMenus],
+  );
+
+  const isPathActive = (href?: string) => {
+    if (!href) return false;
+    if (href === "/") return location.pathname === "/";
+    return location.pathname === href || location.pathname.startsWith(`${href}/`);
+  };
 
   const isItemActive = (item: NavItem): boolean => {
-    if (item.href && location.pathname === item.href) return true;
+    if (isPathActive(item.href)) return true;
     return item.children ? item.children.some(isItemActive) : false;
   };
 
-  const NavItemComponent = ({ item }: { item: NavItem }) => {
-    const active = isItemActive(item);
-    const [open, setOpen] = useState(active);
-    const hasChildren = item.children && item.children.length > 0;
-    useEffect(() => {
-      if (active) setOpen(true);
-    }, [active]);
-    const classes = cn(
-      "flex items-center px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200",
-      collapsed ? "justify-center" : "gap-3",
-      active
-        ? "bg-primary text-primary-foreground shadow-md"
-        : "text-muted-foreground hover:text-foreground hover:bg-accent",
-    );
-
-    const handleClick = () => {
-      if (hasChildren) {
-        setOpen((prev) => !prev);
-      }
-    };
-
-    const content = !hasChildren && item.href ? (
-      <NavLink to={item.href} className={classes}>
-        {item.icon && <item.icon className="h-5 w-5" />}
-        {!collapsed && item.name}
-      </NavLink>
-    ) : (
-      <button
-        type="button"
-        onClick={handleClick}
-        className={cn(classes, !collapsed && "w-full justify-between")}
-      >
-        <span
-          className={cn(
-            "flex items-center",
-            collapsed ? "justify-center" : "gap-3",
-          )}
-        >
-          {item.icon && <item.icon className="h-5 w-5" />}
-          {!collapsed && item.name}
-        </span>
-        {!collapsed && hasChildren && (
-          <ChevronDown
-            className={cn(
-              "h-4 w-4 transition-transform",
-              open && "rotate-180",
-            )}
-          />
-        )}
-      </button>
-    );
-
-    return (
-      <div className="space-y-1">
-        {content}
-        {hasChildren && open && !collapsed && (
-          <div className="ml-6 space-y-1">
-            {item.children!.map((child) => (
-              <NavItemComponent key={child.name} item={child} />
-            ))}
-          </div>
-        )}
-      </div>
-    );
+  const handleNavigate = (item: NavItem) => {
+    if (item.href && isMobile) {
+      setOpenMobile(false);
+    }
   };
+
+  const renderNavItems = (items: NavItem[], depth = 0): ReactNode[] =>
+    items.map((navItem) => {
+      const key = `${depth}-${navItem.href ?? navItem.name}`;
+      const content = (
+        <NavItemContent
+          item={navItem}
+          depth={depth}
+          isItemActive={isItemActive}
+          onNavigate={handleNavigate}
+          renderChildren={renderNavItems}
+        />
+      );
+
+      return depth === 0 ? (
+        <SidebarMenuItem key={key}>{content}</SidebarMenuItem>
+      ) : (
+        <SidebarMenuSubItem key={key}>{content}</SidebarMenuSubItem>
+      );
+    });
 
   const handleLogout = () => {
     navigate("/login");
+    if (isMobile) {
+      setOpenMobile(false);
+    }
   };
 
   return (
-    <div
-      className={cn(
-        "bg-card border-r border-border flex flex-col transition-all duration-300",
-        collapsed ? "w-16" : "w-64",
-      )}
-    >
-      {/* Logo */}
-      <div
-        className={cn(
-          "border-b border-border flex items-center",
-          collapsed ? "p-2 justify-center" : "p-6 justify-between",
-        )}
-      >
-        <div className="flex items-center gap-2">
-          <div className="p-2 bg-primary rounded-lg">
-            <Scale className="h-6 w-6 text-primary-foreground" />
+    <SidebarUI>
+      <SidebarHeader className="border-b border-sidebar-border px-4 py-4">
+        <div className="flex items-center gap-3 px-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
+            <Scale className="h-5 w-5" />
           </div>
-          {!collapsed && (
-            <div>
-              <h1 className="text-lg font-bold text-foreground">CRM Jurídico</h1>
-              <p className="text-xs text-muted-foreground">Gestão Advocacia</p>
-            </div>
-          )}
+          <div className="space-y-1 group-data-[collapsible=icon]:hidden">
+            <p className="text-base font-semibold leading-none text-sidebar-foreground">
+              CRM Jurídico
+            </p>
+            <p className="text-xs text-sidebar-foreground/70">Gestão Advocacia</p>
+          </div>
         </div>
-        <button
-          type="button"
-          onClick={() => setCollapsed((prev) => !prev)}
-          className="p-2 rounded-md hover:bg-accent"
-        >
-          {collapsed ? (
-            <ChevronRight className="h-4 w-4" />
-          ) : (
-            <ChevronLeft className="h-4 w-4" />
-          )}
-        </button>
-      </div>
+      </SidebarHeader>
+      <SidebarContent className="px-2">
+        <SidebarMenu>{renderNavItems(navigation)}</SidebarMenu>
+      </SidebarContent>
+      <SidebarFooter className="border-t border-sidebar-border px-2 py-4">
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton onClick={handleLogout} className="justify-start gap-2">
+              <LogOut className="h-4 w-4" />
+              <span className="truncate group-data-[collapsible=icon]:hidden">Sair</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+        <p className="px-2 text-xs text-sidebar-foreground/60 group-data-[collapsible=icon]:hidden">
+          © 2024 CRM Jurídico
+        </p>
+      </SidebarFooter>
+      <SidebarRail />
+    </SidebarUI>
+  );
+}
 
-      {/* Navigation */}
-      <nav className={cn("flex-1 space-y-2", collapsed ? "p-2" : "p-4")}>
-        {navigation.map((item) => (
-          <NavItemComponent key={item.name} item={item} />
-        ))}
-      </nav>
+type NavItemContentProps = {
+  item: NavItem;
+  depth: number;
+  isItemActive: (item: NavItem) => boolean;
+  onNavigate: (item: NavItem) => void;
+  renderChildren: (items: NavItem[], depth: number) => ReactNode[];
+};
 
-      {/* Footer */}
-      <div
-        className={cn(
-          "border-t border-border space-y-2",
-          collapsed ? "p-2" : "p-4",
-        )}
-      >
-        <button
-          type="button"
-          onClick={handleLogout}
-          className={cn(
-            "flex items-center w-full px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200",
-            collapsed ? "justify-center" : "gap-3",
-            "text-muted-foreground hover:text-foreground hover:bg-accent",
-          )}
-        >
-          <LogOut className="h-5 w-5" />
-          {!collapsed && "Sair"}
-        </button>
-        {!collapsed && (
-          <div className="text-xs text-muted-foreground text-center">
-            © 2024 CRM Jurídico
-          </div>
-        )}
-      </div>
-    </div>
+function NavItemContent({
+  item,
+  depth,
+  isItemActive,
+  onNavigate,
+  renderChildren,
+}: NavItemContentProps) {
+  const hasChildren = Boolean(item.children && item.children.length > 0);
+  const active = isItemActive(item);
+  const [open, setOpen] = useState(active);
+
+  useEffect(() => {
+    if (hasChildren && active) {
+      setOpen(true);
+    }
+  }, [active, hasChildren]);
+
+  const Icon = item.icon;
+  const handleClick = () => {
+    if (item.href) {
+      onNavigate(item);
+    }
+  };
+
+  if (hasChildren) {
+    if (depth === 0) {
+      return (
+        <Collapsible open={open} onOpenChange={setOpen} className="group/collapsible">
+          <CollapsibleTrigger asChild>
+            <SidebarMenuButton isActive={active} className="justify-between">
+              <span className="flex items-center gap-2">
+                {Icon && <Icon className="h-4 w-4" />}
+                <span className="truncate">{item.name}</span>
+              </span>
+              <ChevronRight className="h-4 w-4 transition-transform group-data-[state=open]/collapsible:rotate-90 group-data-[collapsible=icon]:hidden" />
+            </SidebarMenuButton>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <SidebarMenuSub>{renderChildren(item.children ?? [], depth + 1)}</SidebarMenuSub>
+          </CollapsibleContent>
+        </Collapsible>
+      );
+    }
+
+    return (
+      <Collapsible open={open} onOpenChange={setOpen} className="group/collapsible">
+        <CollapsibleTrigger asChild>
+          <SidebarMenuSubButton isActive={active} size="sm" className="justify-between">
+            <span className="truncate">{item.name}</span>
+            <ChevronRight className="h-4 w-4 transition-transform group-data-[state=open]/collapsible:rotate-90" />
+          </SidebarMenuSubButton>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <SidebarMenuSub className="ml-3 border-l border-sidebar-border/40">
+            {renderChildren(item.children ?? [], depth + 1)}
+          </SidebarMenuSub>
+        </CollapsibleContent>
+      </Collapsible>
+    );
+  }
+
+  if (depth === 0) {
+    return (
+      <SidebarMenuButton asChild isActive={active}>
+        <NavLink to={item.href ?? "#"} className="flex w-full items-center gap-2" onClick={handleClick}>
+          {Icon && <Icon className="h-4 w-4" />}
+          <span className="truncate">{item.name}</span>
+        </NavLink>
+      </SidebarMenuButton>
+    );
+  }
+
+  return (
+    <SidebarMenuSubButton asChild isActive={active} size="sm">
+      <NavLink to={item.href ?? "#"} className="flex w-full items-center gap-2" onClick={handleClick}>
+        {Icon && <Icon className="h-4 w-4" />}
+        <span className="truncate">{item.name}</span>
+      </NavLink>
+    </SidebarMenuSubButton>
   );
 }


### PR DESCRIPTION
## Summary
- rebuild the CRM sidebar using the shared sidebar UI primitives, including collapsible groups and the "Documentos Padrões" link
- wrap the CRM layout with the sidebar provider and expose the sidebar trigger in the header for consistent toggling

## Testing
- npm run lint *(warnings present from existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e5c97e7483268afeee3715fe6e73