### PR TITLE
feat: add notification providers and webhook routing

### DIFF
--- a/backend/src/routes/notificationRoutes.ts
+++ b/backend/src/routes/notificationRoutes.ts
@@ -11,6 +11,8 @@ import {
   getNotificationPreferencesHandler,
   updateNotificationPreferencesHandler,
 } from '../controllers/notificationController';
+import { getNotificationProvider } from '../services/notificationProviders/registry';
+import { NotificationProviderError } from '../services/notificationProviders/types';
 
 const router = Router();
 
@@ -19,6 +21,40 @@ router.get('/notifications/unread-count', getUnreadCountHandler);
 router.get('/notifications/preferences', getNotificationPreferencesHandler);
 router.get('/notifications/:id', getNotificationHandler);
 router.post('/notifications', createNotificationHandler);
+router.post('/notifications/webhooks/:providerId?', async (req, res) => {
+  const headerProvider =
+    req.header('x-notification-provider') ??
+    req.header('x-notification-source') ??
+    req.header('x-provider-id');
+
+  const providerId = (req.params.providerId || headerProvider)?.toLowerCase();
+
+  if (!providerId) {
+    return res.status(400).json({ error: 'Notification provider identifier is required' });
+  }
+
+  const provider = getNotificationProvider(providerId);
+
+  if (!provider) {
+    return res.status(404).json({ error: `Notification provider '${providerId}' not found` });
+  }
+
+  try {
+    const notifications = await provider.handleWebhook(req);
+    res.status(202).json({
+      provider: providerId,
+      received: notifications.length,
+      notifications,
+    });
+  } catch (error) {
+    if (error instanceof NotificationProviderError) {
+      return res.status(error.statusCode).json({ error: error.message });
+    }
+
+    console.error(`Failed to handle webhook from provider ${providerId}`, error);
+    res.status(500).json({ error: 'Failed to process notification webhook' });
+  }
+});
 router.post('/notifications/read-all', markAllNotificationsAsReadHandler);
 router.post('/notifications/:id/read', markNotificationAsReadHandler);
 router.post('/notifications/:id/unread', markNotificationAsUnreadHandler);

--- a/backend/src/services/notificationProviders/pjeNotificationService.ts
+++ b/backend/src/services/notificationProviders/pjeNotificationService.ts
@@ -1,0 +1,229 @@
+import type { Request } from 'express';
+import {
+  createNotification,
+  type CreateNotificationInput,
+  type Notification,
+  type NotificationType,
+} from '../notificationService';
+import {
+  NotificationProviderError,
+  type INotificationProvider,
+  type NotificationPublisher,
+} from './types';
+
+type PjeEventType = 'deadline' | 'movement' | 'intimation' | 'publication';
+
+interface RawPjeWebhookEvent {
+  type?: string;
+  description?: string;
+  occurredAt?: string;
+  [key: string]: unknown;
+}
+
+interface PjeWebhookEvent {
+  type: PjeEventType;
+  description: string;
+  occurredAt?: string;
+  extra: Record<string, unknown>;
+}
+
+interface RawPjeWebhookPayload {
+  userId?: unknown;
+  processNumber?: unknown;
+  events?: unknown;
+  [key: string]: unknown;
+}
+
+interface PjeWebhookPayload {
+  userId: string;
+  processNumber: string;
+  events: PjeWebhookEvent[];
+}
+
+const VALID_EVENT_TYPES: readonly PjeEventType[] = [
+  'deadline',
+  'movement',
+  'intimation',
+  'publication',
+];
+
+function resolveEventType(value: unknown): PjeEventType {
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (VALID_EVENT_TYPES.includes(normalized as PjeEventType)) {
+      return normalized as PjeEventType;
+    }
+  }
+
+  return 'movement';
+}
+
+function buildPjeNotificationInput(payload: PjeWebhookPayload, event: PjeWebhookEvent): CreateNotificationInput {
+  const baseTitle = (() => {
+    switch (event.type) {
+      case 'deadline':
+        return `PJe: prazo atualizado no processo ${payload.processNumber}`;
+      case 'intimation':
+        return `PJe: nova intimação no processo ${payload.processNumber}`;
+      case 'publication':
+        return `PJe: publicação no processo ${payload.processNumber}`;
+      default:
+        return `PJe: movimentação no processo ${payload.processNumber}`;
+    }
+  })();
+
+  const details: string[] = [event.description];
+
+  if (event.occurredAt) {
+    details.push(`Ocorrido em ${event.occurredAt}`);
+  }
+
+  const message = `${details.join(' — ')} (Processo ${payload.processNumber})`;
+
+  const metadata: Record<string, unknown> = {
+    provider: 'pje',
+    processNumber: payload.processNumber,
+    eventType: event.type,
+    ...event.extra,
+  };
+
+  if (event.occurredAt) {
+    metadata.occurredAt = event.occurredAt;
+  }
+
+  return {
+    userId: payload.userId,
+    title: baseTitle,
+    message,
+    category: 'pje',
+    type: resolveNotificationType(event.type),
+    metadata,
+  };
+}
+
+function resolveNotificationType(eventType: PjeEventType): NotificationType {
+  switch (eventType) {
+    case 'deadline':
+      return 'warning';
+    case 'intimation':
+      return 'success';
+    default:
+      return 'info';
+  }
+}
+
+export class PjeNotificationProvider implements INotificationProvider {
+  public readonly id = 'pje';
+  private readonly publish: NotificationPublisher;
+  private pending: Notification[] = [];
+  private subscribed = false;
+
+  constructor(publish: NotificationPublisher = createNotification) {
+    this.publish = publish;
+  }
+
+  async subscribe(): Promise<void> {
+    this.subscribed = true;
+  }
+
+  async fetchUpdates(): Promise<Notification[]> {
+    const notifications = [...this.pending];
+    this.pending = [];
+    return notifications;
+  }
+
+  async handleWebhook(req: Request): Promise<Notification[]> {
+    const payloads = this.normalizePayload(req.body);
+
+    if (!this.subscribed) {
+      await this.subscribe();
+    }
+
+    const created: Notification[] = [];
+
+    for (const payload of payloads) {
+      for (const event of payload.events) {
+        const notification = this.publish(buildPjeNotificationInput(payload, event));
+        this.pending.push(notification);
+        created.push(notification);
+      }
+    }
+
+    return created;
+  }
+
+  private normalizePayload(body: unknown): PjeWebhookPayload[] {
+    if (body === null || body === undefined) {
+      throw new NotificationProviderError('PJe webhook payload cannot be empty');
+    }
+
+    const items: RawPjeWebhookPayload[] = Array.isArray(body) ? body : [body];
+
+    if (items.length === 0) {
+      throw new NotificationProviderError('PJe webhook payload cannot be empty');
+    }
+
+    return items.map((item, index) => this.normalizePayloadItem(item, index));
+  }
+
+  private normalizePayloadItem(raw: RawPjeWebhookPayload, index: number): PjeWebhookPayload {
+    if (!raw || typeof raw !== 'object') {
+      throw new NotificationProviderError(`PJe webhook payload at index ${index} must be an object`);
+    }
+
+    const { userId, processNumber, events } = raw;
+
+    if (typeof userId !== 'string' || userId.trim() === '') {
+      throw new NotificationProviderError('PJe webhook payload is missing a valid userId');
+    }
+
+    if (typeof processNumber !== 'string' || processNumber.trim() === '') {
+      throw new NotificationProviderError('PJe webhook payload is missing a valid processNumber');
+    }
+
+    if (!Array.isArray(events) || events.length === 0) {
+      throw new NotificationProviderError('PJe webhook payload must include at least one event');
+    }
+
+    const normalizedEvents = events.map((event, eventIndex) => this.normalizeEvent(event, eventIndex));
+
+    return {
+      userId,
+      processNumber,
+      events: normalizedEvents,
+    };
+  }
+
+  private normalizeEvent(raw: unknown, index: number): PjeWebhookEvent {
+    if (!raw || typeof raw !== 'object') {
+      throw new NotificationProviderError(`PJe event at index ${index} must be an object`);
+    }
+
+    const event = raw as RawPjeWebhookEvent;
+    const description = typeof event.description === 'string' ? event.description.trim() : '';
+
+    if (!description) {
+      throw new NotificationProviderError(`PJe event at index ${index} must include a description`);
+    }
+
+    const occurredAt = typeof event.occurredAt === 'string' ? event.occurredAt : undefined;
+    const type = resolveEventType(event.type);
+
+    const extra: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(event)) {
+      if (!['type', 'description', 'occurredAt'].includes(key)) {
+        extra[key] = value as unknown;
+      }
+    }
+
+    return {
+      type,
+      description,
+      occurredAt,
+      extra,
+    };
+  }
+}
+
+export const pjeNotificationProvider = new PjeNotificationProvider();

--- a/backend/src/services/notificationProviders/projudiNotificationService.ts
+++ b/backend/src/services/notificationProviders/projudiNotificationService.ts
@@ -1,0 +1,231 @@
+import type { Request } from 'express';
+import {
+  createNotification,
+  type Notification,
+  type NotificationType,
+} from '../notificationService';
+import {
+  NotificationProviderError,
+  type INotificationProvider,
+  type NotificationPublisher,
+} from './types';
+
+type ProjudiAlertType = 'deadline' | 'document' | 'task' | 'hearing' | 'movement';
+
+interface RawProjudiAlert {
+  kind?: string;
+  description?: string;
+  processNumber?: string;
+  dueDate?: string;
+  [key: string]: unknown;
+}
+
+interface ProjudiAlert {
+  kind: ProjudiAlertType;
+  description: string;
+  processNumber?: string;
+  dueDate?: string;
+  extra: Record<string, unknown>;
+}
+
+interface RawProjudiPayload {
+  userId?: unknown;
+  alerts?: unknown;
+  [key: string]: unknown;
+}
+
+interface ProjudiWebhookPayload {
+  userId: string;
+  alerts: ProjudiAlert[];
+}
+
+const VALID_ALERT_TYPES: readonly ProjudiAlertType[] = [
+  'deadline',
+  'document',
+  'task',
+  'hearing',
+  'movement',
+];
+
+function resolveAlertType(value: unknown): ProjudiAlertType {
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (VALID_ALERT_TYPES.includes(normalized as ProjudiAlertType)) {
+      return normalized as ProjudiAlertType;
+    }
+  }
+
+  return 'movement';
+}
+
+function resolveNotificationType(kind: ProjudiAlertType): NotificationType {
+  switch (kind) {
+    case 'deadline':
+      return 'warning';
+    case 'hearing':
+      return 'success';
+    default:
+      return 'info';
+  }
+}
+
+function buildNotificationTitle(alert: ProjudiAlert): string {
+  const processPart = alert.processNumber ? ` no processo ${alert.processNumber}` : '';
+
+  switch (alert.kind) {
+    case 'deadline':
+      return `Projudi: novo prazo${processPart}`;
+    case 'document':
+      return `Projudi: novo documento disponível${processPart}`;
+    case 'task':
+      return `Projudi: nova tarefa${processPart}`;
+    case 'hearing':
+      return `Projudi: audiência atualizada${processPart}`;
+    default:
+      return `Projudi: atualização${processPart}`;
+  }
+}
+
+function buildNotificationMessage(alert: ProjudiAlert): string {
+  const details: string[] = [alert.description];
+
+  if (alert.processNumber) {
+    details.push(`Processo ${alert.processNumber}`);
+  }
+
+  if (alert.dueDate) {
+    details.push(`Prazo em ${alert.dueDate}`);
+  }
+
+  return details.join(' — ');
+}
+
+export class ProjudiNotificationProvider implements INotificationProvider {
+  public readonly id = 'projudi';
+  private readonly publish: NotificationPublisher;
+  private pending: Notification[] = [];
+  private subscribed = false;
+
+  constructor(publish: NotificationPublisher = createNotification) {
+    this.publish = publish;
+  }
+
+  async subscribe(): Promise<void> {
+    this.subscribed = true;
+  }
+
+  async fetchUpdates(): Promise<Notification[]> {
+    const notifications = [...this.pending];
+    this.pending = [];
+    return notifications;
+  }
+
+  async handleWebhook(req: Request): Promise<Notification[]> {
+    const payloads = this.normalizePayload(req.body);
+
+    if (!this.subscribed) {
+      await this.subscribe();
+    }
+
+    const created: Notification[] = [];
+
+    for (const payload of payloads) {
+      for (const alert of payload.alerts) {
+        const notification = this.publish({
+          userId: payload.userId,
+          title: buildNotificationTitle(alert),
+          message: buildNotificationMessage(alert),
+          category: 'projudi',
+          type: resolveNotificationType(alert.kind),
+          metadata: {
+            provider: 'projudi',
+            alertType: alert.kind,
+            processNumber: alert.processNumber,
+            dueDate: alert.dueDate,
+            ...alert.extra,
+          },
+        });
+
+        this.pending.push(notification);
+        created.push(notification);
+      }
+    }
+
+    return created;
+  }
+
+  private normalizePayload(body: unknown): ProjudiWebhookPayload[] {
+    if (body === null || body === undefined) {
+      throw new NotificationProviderError('Projudi webhook payload cannot be empty');
+    }
+
+    const items: RawProjudiPayload[] = Array.isArray(body) ? body : [body];
+
+    if (items.length === 0) {
+      throw new NotificationProviderError('Projudi webhook payload cannot be empty');
+    }
+
+    return items.map((item, index) => this.normalizePayloadItem(item, index));
+  }
+
+  private normalizePayloadItem(raw: RawProjudiPayload, index: number): ProjudiWebhookPayload {
+    if (!raw || typeof raw !== 'object') {
+      throw new NotificationProviderError(`Projudi webhook payload at index ${index} must be an object`);
+    }
+
+    const { userId, alerts } = raw;
+
+    if (typeof userId !== 'string' || userId.trim() === '') {
+      throw new NotificationProviderError('Projudi webhook payload is missing a valid userId');
+    }
+
+    if (!Array.isArray(alerts) || alerts.length === 0) {
+      throw new NotificationProviderError('Projudi webhook payload must include at least one alert');
+    }
+
+    const normalizedAlerts = alerts.map((alert, alertIndex) => this.normalizeAlert(alert, alertIndex));
+
+    return {
+      userId,
+      alerts: normalizedAlerts,
+    };
+  }
+
+  private normalizeAlert(raw: unknown, index: number): ProjudiAlert {
+    if (!raw || typeof raw !== 'object') {
+      throw new NotificationProviderError(`Projudi alert at index ${index} must be an object`);
+    }
+
+    const alert = raw as RawProjudiAlert;
+    const description = typeof alert.description === 'string' ? alert.description.trim() : '';
+
+    if (!description) {
+      throw new NotificationProviderError(`Projudi alert at index ${index} must include a description`);
+    }
+
+    const processNumber = typeof alert.processNumber === 'string' && alert.processNumber.trim() !== ''
+      ? alert.processNumber
+      : undefined;
+
+    const dueDate = typeof alert.dueDate === 'string' && alert.dueDate.trim() !== '' ? alert.dueDate : undefined;
+    const kind = resolveAlertType(alert.kind);
+
+    const extra: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(alert)) {
+      if (!['kind', 'description', 'processNumber', 'dueDate'].includes(key)) {
+        extra[key] = value as unknown;
+      }
+    }
+
+    return {
+      kind,
+      description,
+      processNumber,
+      dueDate,
+      extra,
+    };
+  }
+}
+
+export const projudiNotificationProvider = new ProjudiNotificationProvider();

--- a/backend/src/services/notificationProviders/registry.ts
+++ b/backend/src/services/notificationProviders/registry.ts
@@ -1,0 +1,35 @@
+import type { INotificationProvider } from './types';
+import { pjeNotificationProvider } from './pjeNotificationService';
+import { projudiNotificationProvider } from './projudiNotificationService';
+
+const registry = new Map<string, INotificationProvider>();
+
+export function registerNotificationProvider(
+  provider: INotificationProvider,
+  identifier?: string,
+): void {
+  const derivedId = identifier ?? (provider as { id?: string }).id;
+
+  if (!derivedId || typeof derivedId !== 'string') {
+    throw new Error('Notification provider must define an identifier');
+  }
+
+  registry.set(derivedId.toLowerCase(), provider);
+}
+
+export function getNotificationProvider(identifier?: string | null): INotificationProvider | undefined {
+  if (!identifier) {
+    return undefined;
+  }
+
+  return registry.get(identifier.toLowerCase());
+}
+
+export function listNotificationProviders(): INotificationProvider[] {
+  return Array.from(registry.values());
+}
+
+registerNotificationProvider(pjeNotificationProvider, 'pje');
+registerNotificationProvider(projudiNotificationProvider, 'projudi');
+
+export const notificationProviderRegistry = registry;

--- a/backend/src/services/notificationProviders/types.ts
+++ b/backend/src/services/notificationProviders/types.ts
@@ -1,0 +1,17 @@
+import type { Request } from 'express';
+import type { CreateNotificationInput, Notification } from '../notificationService';
+
+export type NotificationPublisher = (input: CreateNotificationInput) => Notification;
+
+export interface INotificationProvider {
+  subscribe(): Promise<void>;
+  fetchUpdates(): Promise<Notification[]>;
+  handleWebhook(req: Request): Promise<Notification[]>;
+}
+
+export class NotificationProviderError extends Error {
+  constructor(message: string, public readonly statusCode = 400) {
+    super(message);
+    this.name = 'NotificationProviderError';
+  }
+}

--- a/backend/tests/notificationProviders.test.ts
+++ b/backend/tests/notificationProviders.test.ts
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { Request } from 'express';
+import { PjeNotificationProvider } from '../src/services/notificationProviders/pjeNotificationService';
+import { ProjudiNotificationProvider } from '../src/services/notificationProviders/projudiNotificationService';
+import { __resetNotificationState, listNotifications } from '../src/services/notificationService';
+
+function mockRequest<T>(body: T): Request {
+  return { body } as unknown as Request;
+}
+
+test.beforeEach(() => {
+  __resetNotificationState();
+});
+
+test('PjeNotificationProvider creates notifications for deadline and movement events', async () => {
+  const provider = new PjeNotificationProvider();
+
+  const request = mockRequest({
+    userId: 'adv-001',
+    processNumber: '5001234-89.2024.8.26.0100',
+    events: [
+      {
+        type: 'deadline',
+        description: 'Prazo para apresentação de defesa encerra em 5 dias.',
+        occurredAt: '2024-05-10T12:00:00Z',
+      },
+      {
+        type: 'movement',
+        description: 'Nova movimentação registrada no processo.',
+        occurredAt: '2024-05-10T15:45:00Z',
+      },
+    ],
+  });
+
+  const notifications = await provider.handleWebhook(request);
+
+  assert.equal(notifications.length, 2);
+  assert.equal(notifications[0].category, 'pje');
+  assert.equal(notifications[0].type, 'warning');
+  assert.match(notifications[0].title, /prazo/i);
+  assert.equal(notifications[0].metadata?.processNumber, '5001234-89.2024.8.26.0100');
+
+  assert.equal(notifications[1].type, 'info');
+  assert.match(notifications[1].title, /movimenta/);
+
+  const pending = await provider.fetchUpdates();
+  assert.equal(pending.length, 2);
+  assert.equal((await provider.fetchUpdates()).length, 0);
+
+  const stored = listNotifications('adv-001');
+  assert.equal(stored.length, 2);
+});
+
+test('ProjudiNotificationProvider creates notifications for deadline and document alerts', async () => {
+  const provider = new ProjudiNotificationProvider();
+
+  const request = mockRequest({
+    userId: 'adv-002',
+    alerts: [
+      {
+        kind: 'deadline',
+        description: 'Prazo para manifestação vence em 3 dias.',
+        processNumber: '8012345-55.2023.8.16.0010',
+        dueDate: '2024-06-20',
+      },
+      {
+        kind: 'document',
+        description: 'Novo laudo pericial disponível para download.',
+        processNumber: '8012345-55.2023.8.16.0010',
+      },
+    ],
+  });
+
+  const notifications = await provider.handleWebhook(request);
+
+  assert.equal(notifications.length, 2);
+  assert.equal(notifications[0].category, 'projudi');
+  assert.equal(notifications[0].type, 'warning');
+  assert.equal(notifications[0].metadata?.dueDate, '2024-06-20');
+
+  assert.equal(notifications[1].type, 'info');
+  assert.match(notifications[1].title, /documento/i);
+
+  const pending = await provider.fetchUpdates();
+  assert.equal(pending.length, 2);
+  assert.equal((await provider.fetchUpdates()).length, 0);
+
+  const stored = listNotifications('adv-002');
+  assert.equal(stored.length, 2);
+});


### PR DESCRIPTION
## Summary
- introduce the notification provider interface plus registry helpers
- implement PJe and Projudi providers that publish notifications from webhook payloads
- route webhook requests through the provider registry and cover providers with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8e83aa9f48326b3740ccbff8f73c8