### PR TITLE
Update document editor routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -95,8 +95,8 @@ const App = () => (
             <Route path="/intimacoes" element={<Intimacoes />} />
             <Route path="/documentos">
               <Route index element={<LibraryPage />} />
-              <Route path="novo" element={<EditorPage />} />
-              <Route path=":id" element={<EditorPage />} />
+              <Route path="editor/novo" element={<EditorPage />} />
+              <Route path="editor/:id" element={<EditorPage />} />
             </Route>
             <Route path="/financeiro/lancamentos" element={<FinancialFlows />} />
             <Route path="/relatorios" element={<Relatorios />} />

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -27,10 +27,15 @@ export default function EditorPage() {
   const { data: tags } = useQuery({ queryKey: ['tags'], queryFn: fetchTags });
 
   const saveMut = useMutation({
-    mutationFn: () => (isNew ? createTemplate({ title, content }) : updateTemplate(Number(id), { title, content })),
-    onSuccess: () => {
+    mutationFn: () =>
+      isNew ? createTemplate({ title, content }) : updateTemplate(Number(id), { title, content }),
+    onSuccess: template => {
       queryClient.invalidateQueries({ queryKey: ['templates'] });
-      navigate('/documentos');
+      if (isNew) {
+        navigate(`/documentos/editor/${template.id}`);
+      } else {
+        navigate('/documentos');
+      }
     }
   });
 

--- a/frontend/src/pages/LibraryPage.tsx
+++ b/frontend/src/pages/LibraryPage.tsx
@@ -28,7 +28,7 @@ export default function LibraryPage() {
     <div className="p-6 space-y-4">
       <div className="flex justify-between items-center">
         <h1 className="text-3xl font-bold">Templates</h1>
-        <Button onClick={() => navigate('/documentos/novo')}>Novo Template</Button>
+        <Button onClick={() => navigate('/documentos/editor/novo')}>Novo Template</Button>
       </div>
       <Table>
         <TableHeader>
@@ -48,7 +48,7 @@ export default function LibraryPage() {
                 {t.content.slice(0, 60)}{t.content.length > 60 ? '...' : ''}
               </TableCell>
               <TableCell className="text-right space-x-2">
-                <Button variant="outline" size="sm" onClick={() => navigate(`/documentos/${t.id}`)}>Editar</Button>
+                <Button variant="outline" size="sm" onClick={() => navigate(`/documentos/editor/${t.id}`)}>Editar</Button>
                 <Button variant="outline" size="sm" onClick={() => duplicateMut.mutate(t)}>Duplicar</Button>
                 <Button variant="destructive" size="sm" onClick={() => deleteMut.mutate(t.id)}>Excluir</Button>
               </TableCell>


### PR DESCRIPTION
## Summary
- update template library navigation to point to the new `/documentos/editor` routes
- adjust the editor page save flow and router configuration to honor the new prefix

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68c8ec9712408326bdb6e107a1f91c57