### PR TITLE
feat: redesign document editor and template library

### DIFF
--- a/frontend/src/features/document-editor/components/EditorToolbar.tsx
+++ b/frontend/src/features/document-editor/components/EditorToolbar.tsx
@@ -1,0 +1,241 @@
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Separator } from '@/components/ui/separator';
+import {
+  AlignCenter,
+  AlignJustify,
+  AlignLeft,
+  AlignRight,
+  Bold,
+  Highlighter,
+  Image as ImageIcon,
+  Italic,
+  List,
+  ListOrdered,
+  Minus,
+  Quote,
+  Redo2,
+  Strikethrough,
+  Table as TableIcon,
+  Underline,
+  Undo2,
+} from 'lucide-react';
+
+export type ToolbarBlock = 'paragraph' | 'h1' | 'h2' | 'h3';
+export type ToolbarAlignment = 'left' | 'center' | 'right' | 'justify';
+
+export interface ToolbarState {
+  block: ToolbarBlock;
+  fontSize: string;
+  align: ToolbarAlignment;
+  bold: boolean;
+  italic: boolean;
+  underline: boolean;
+  strike: boolean;
+  orderedList: boolean;
+  bulletList: boolean;
+  blockquote: boolean;
+  highlight: boolean;
+}
+
+interface EditorToolbarProps {
+  state: ToolbarState;
+  onBlockChange: (value: ToolbarBlock) => void;
+  onFontSizeChange: (value: string) => void;
+  onAlignmentChange: (value: ToolbarAlignment) => void;
+  onCommand: (command: string, value?: string) => void;
+  onHighlight: () => void;
+  onInsertImage: () => void;
+  onInsertTable: () => void;
+  onUndo: () => void;
+  onRedo: () => void;
+}
+
+const BLOCK_OPTIONS: { value: ToolbarBlock; label: string }[] = [
+  { value: 'paragraph', label: 'Texto normal' },
+  { value: 'h1', label: 'Título 1' },
+  { value: 'h2', label: 'Título 2' },
+  { value: 'h3', label: 'Título 3' },
+];
+
+const FONT_SIZE_OPTIONS = [
+  { value: 'default', label: 'Padrão' },
+  { value: '2', label: '12 pt' },
+  { value: '3', label: '14 pt' },
+  { value: '4', label: '16 pt' },
+  { value: '5', label: '18 pt' },
+  { value: '6', label: '24 pt' },
+  { value: '7', label: '32 pt' },
+];
+
+function ToolbarButton({
+  label,
+  isActive,
+  onClick,
+  children,
+  disabled,
+}: {
+  label: string;
+  isActive?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+  disabled?: boolean;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          size="sm"
+          variant={isActive ? 'secondary' : 'ghost'}
+          aria-pressed={isActive}
+          onClick={onClick}
+          disabled={disabled}
+          aria-label={label}
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function EditorToolbar({
+  state,
+  onBlockChange,
+  onFontSizeChange,
+  onAlignmentChange,
+  onCommand,
+  onHighlight,
+  onInsertImage,
+  onInsertTable,
+  onUndo,
+  onRedo,
+}: EditorToolbarProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-md border bg-card px-3 py-2 shadow-sm">
+      <Select value={state.block} onValueChange={value => onBlockChange(value as ToolbarBlock)}>
+        <SelectTrigger className="w-40">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {BLOCK_OPTIONS.map(option => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select value={state.fontSize} onValueChange={onFontSizeChange}>
+        <SelectTrigger className="w-28">
+          <SelectValue placeholder="Tamanho" />
+        </SelectTrigger>
+        <SelectContent>
+          {FONT_SIZE_OPTIONS.map(option => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Separator orientation="vertical" className="h-6" />
+      <div className="flex flex-wrap items-center gap-1">
+        <ToolbarButton label="Negrito" onClick={() => onCommand('bold')} isActive={state.bold}>
+          <Bold className="h-4 w-4" />
+        </ToolbarButton>
+        <ToolbarButton label="Itálico" onClick={() => onCommand('italic')} isActive={state.italic}>
+          <Italic className="h-4 w-4" />
+        </ToolbarButton>
+        <ToolbarButton label="Sublinhar" onClick={() => onCommand('underline')} isActive={state.underline}>
+          <Underline className="h-4 w-4" />
+        </ToolbarButton>
+        <ToolbarButton label="Tachar" onClick={() => onCommand('strikeThrough')} isActive={state.strike}>
+          <Strikethrough className="h-4 w-4" />
+        </ToolbarButton>
+        <ToolbarButton label="Marcador" onClick={onHighlight} isActive={state.highlight}>
+          <Highlighter className="h-4 w-4" />
+        </ToolbarButton>
+      </div>
+      <Separator orientation="vertical" className="h-6" />
+      <div className="flex flex-wrap items-center gap-1">
+        <ToolbarButton
+          label="Alinhar à esquerda"
+          onClick={() => onAlignmentChange('left')}
+          isActive={state.align === 'left'}
+        >
+          <AlignLeft className="h-4 w-4" />
+        </ToolbarButton>
+        <ToolbarButton
+          label="Centralizar"
+          onClick={() => onAlignmentChange('center')}
+          isActive={state.align === 'center'}
+        >
+          <AlignCenter className="h-4 w-4" />
+        </ToolbarButton>
+        <ToolbarButton
+          label="Alinhar à direita"
+          onClick={() => onAlignmentChange('right')}
+          isActive={state.align === 'right'}
+        >
+          <AlignRight className="h-4 w-4" />
+        </ToolbarButton>
+        <ToolbarButton
+          label="Justificar"
+          onClick={() => onAlignmentChange('justify')}
+          isActive={state.align === 'justify'}
+        >
+          <AlignJustify className="h-4 w-4" />
+        </ToolbarButton>
+      </div>
+      <Separator orientation="vertical" className="h-6" />
+      <div className="flex flex-wrap items-center gap-1">
+        <ToolbarButton
+          label="Lista não ordenada"
+          onClick={() => onCommand('insertUnorderedList')}
+          isActive={state.bulletList}
+        >
+          <List className="h-4 w-4" />
+        </ToolbarButton>
+        <ToolbarButton
+          label="Lista numerada"
+          onClick={() => onCommand('insertOrderedList')}
+          isActive={state.orderedList}
+        >
+          <ListOrdered className="h-4 w-4" />
+        </ToolbarButton>
+        <ToolbarButton
+          label="Citação"
+          onClick={() => onCommand('formatBlock', 'blockquote')}
+          isActive={state.blockquote}
+        >
+          <Quote className="h-4 w-4" />
+        </ToolbarButton>
+        <ToolbarButton label="Linha" onClick={() => onCommand('insertHorizontalRule')}>
+          <Minus className="h-4 w-4" />
+        </ToolbarButton>
+      </div>
+      <Separator orientation="vertical" className="h-6" />
+      <div className="flex items-center gap-1">
+        <ToolbarButton label="Inserir imagem" onClick={onInsertImage}>
+          <ImageIcon className="h-4 w-4" />
+        </ToolbarButton>
+        <ToolbarButton label="Inserir tabela" onClick={onInsertTable}>
+          <TableIcon className="h-4 w-4" />
+        </ToolbarButton>
+      </div>
+      <Separator orientation="vertical" className="h-6" />
+      <div className="flex items-center gap-1">
+        <ToolbarButton label="Desfazer" onClick={onUndo}>
+          <Undo2 className="h-4 w-4" />
+        </ToolbarButton>
+        <ToolbarButton label="Refazer" onClick={onRedo}>
+          <Redo2 className="h-4 w-4" />
+        </ToolbarButton>
+      </div>
+    </div>
+  );
+}
+
+export default EditorToolbar;

--- a/frontend/src/features/document-editor/components/InsertMenu.tsx
+++ b/frontend/src/features/document-editor/components/InsertMenu.tsx
@@ -1,0 +1,66 @@
+import { ListPlus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import type { VariableMenuItem } from '../data/variable-items';
+import { variableMenuTree } from '../data/variable-items';
+
+type InsertMenuProps = {
+  onSelect: (item: VariableMenuItem) => void;
+  disabled?: boolean;
+};
+
+function RenderMenuItems({ items, onSelect }: { items: VariableMenuItem[]; onSelect: (item: VariableMenuItem) => void }) {
+  return (
+    <>
+      {items.map(item => {
+        if (item.children && item.children.length > 0) {
+          return (
+            <DropdownMenuSub key={item.value}>
+              <DropdownMenuSubTrigger className="flex items-center justify-between gap-2">
+                <span>{item.label}</span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="max-h-80 overflow-y-auto" alignOffset={-4}>
+                <RenderMenuItems items={item.children} onSelect={onSelect} />
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          );
+        }
+
+        return (
+          <DropdownMenuItem key={item.value} onSelect={() => onSelect(item)}>
+            <div className="flex flex-col">
+              <span>{item.label}</span>
+              <span className="text-xs text-muted-foreground">{`{{${item.value}}}`}</span>
+            </div>
+          </DropdownMenuItem>
+        );
+      })}
+    </>
+  );
+}
+
+export function InsertMenu({ onSelect, disabled }: InsertMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild disabled={disabled}>
+        <Button type="button" variant="outline" className="gap-2" aria-haspopup="menu">
+          <ListPlus className="h-4 w-4" />
+          Inserir
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-56" sideOffset={8}>
+        <RenderMenuItems items={variableMenuTree} onSelect={onSelect} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export default InsertMenu;

--- a/frontend/src/features/document-editor/components/MetadataModal.tsx
+++ b/frontend/src/features/document-editor/components/MetadataModal.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import type { TemplateMetadata } from '@/types/templates';
+
+export interface MetadataFormValues extends TemplateMetadata {
+  title: string;
+}
+
+interface MetadataModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  defaultValues: MetadataFormValues;
+  onConfirm: (values: MetadataFormValues) => void;
+  isSaving?: boolean;
+}
+
+const TEMPLATE_TYPES = ['Documento', 'Petição', 'Contrato', 'Procuração', 'Relatório', 'Outro'];
+const COMPLEXITY_OPTIONS: TemplateMetadata['complexity'][] = ['Baixa', 'Média', 'Alta'];
+const VISIBILITY_OPTIONS: TemplateMetadata['visibility'][] = ['privado', 'equipe', 'publico'];
+
+export function MetadataModal({ open, onOpenChange, defaultValues, onConfirm, isSaving }: MetadataModalProps) {
+  const [values, setValues] = useState<MetadataFormValues>(defaultValues);
+
+  useEffect(() => {
+    if (open) {
+      setValues(defaultValues);
+    }
+  }, [defaultValues, open]);
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    onConfirm(values);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent aria-describedby="metadata-description" className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Salvar novo modelo</DialogTitle>
+          <DialogDescription id="metadata-description">
+            Preencha os metadados do modelo para facilitar a busca e o compartilhamento com o time.
+          </DialogDescription>
+        </DialogHeader>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <Label htmlFor="template-title">Título</Label>
+            <Input
+              id="template-title"
+              value={values.title}
+              onChange={event => setValues(prev => ({ ...prev, title: event.target.value }))}
+              placeholder="Título do modelo"
+              required
+            />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="template-type">Tipo</Label>
+              <Select
+                value={values.type}
+                onValueChange={value => setValues(prev => ({ ...prev, type: value }))}
+              >
+                <SelectTrigger id="template-type">
+                  <SelectValue placeholder="Selecione o tipo" />
+                </SelectTrigger>
+                <SelectContent>
+                  {TEMPLATE_TYPES.map(option => (
+                    <SelectItem key={option} value={option}>
+                      {option}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="template-area">Área</Label>
+              <Input
+                id="template-area"
+                value={values.area}
+                onChange={event => setValues(prev => ({ ...prev, area: event.target.value }))}
+                placeholder="Ex.: Cível, Trabalhista, Tributário"
+              />
+            </div>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="template-complexity">Complexidade</Label>
+              <Select
+                value={values.complexity}
+                onValueChange={value => setValues(prev => ({ ...prev, complexity: value as TemplateMetadata['complexity'] }))}
+              >
+                <SelectTrigger id="template-complexity">
+                  <SelectValue placeholder="Complexidade" />
+                </SelectTrigger>
+                <SelectContent>
+                  {COMPLEXITY_OPTIONS.map(option => (
+                    <SelectItem key={option} value={option}>
+                      {option}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="template-visibility">Visibilidade</Label>
+              <Select
+                value={values.visibility}
+                onValueChange={value => setValues(prev => ({ ...prev, visibility: value as TemplateMetadata['visibility'] }))}
+              >
+                <SelectTrigger id="template-visibility">
+                  <SelectValue placeholder="Visibilidade" />
+                </SelectTrigger>
+                <SelectContent>
+                  {VISIBILITY_OPTIONS.map(option => (
+                    <SelectItem key={option} value={option} className="capitalize">
+                      {option === 'publico' ? 'Público' : option.charAt(0).toUpperCase() + option.slice(1)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <div className="space-y-4 rounded-md border p-4">
+            <p className="text-sm font-medium">Ações automáticas</p>
+            <div className="flex items-start gap-3">
+              <Checkbox
+                id="template-auto-client"
+                checked={values.autoCreateClient}
+                onCheckedChange={checked =>
+                  setValues(prev => ({ ...prev, autoCreateClient: checked === true }))
+                }
+              />
+              <Label htmlFor="template-auto-client" className="text-sm font-normal">
+                Cadastrar cliente automaticamente ao utilizar o modelo
+              </Label>
+            </div>
+            <div className="flex items-start gap-3">
+              <Checkbox
+                id="template-auto-process"
+                checked={values.autoCreateProcess}
+                onCheckedChange={checked =>
+                  setValues(prev => ({ ...prev, autoCreateProcess: checked === true }))
+                }
+              />
+              <Label htmlFor="template-auto-process" className="text-sm font-normal">
+                Cadastrar processo automaticamente ao utilizar o modelo
+              </Label>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={isSaving}>
+              {isSaving ? 'Salvando...' : 'Salvar modelo'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default MetadataModal;

--- a/frontend/src/features/document-editor/components/SaveButton.tsx
+++ b/frontend/src/features/document-editor/components/SaveButton.tsx
@@ -1,0 +1,37 @@
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { Save } from 'lucide-react';
+
+interface SaveButtonProps {
+  onClick: () => void;
+  disabled?: boolean;
+  isDirty?: boolean;
+}
+
+export function SaveButton({ onClick, disabled, isDirty }: SaveButtonProps) {
+  return (
+    <div className="pointer-events-none fixed bottom-6 right-6 z-50 flex flex-col items-end gap-2">
+      <div
+        aria-hidden={!isDirty}
+        className={cn(
+          'rounded-full bg-primary px-3 py-1 text-xs font-medium text-primary-foreground shadow transition-opacity',
+          isDirty ? 'opacity-100' : 'opacity-0'
+        )}
+      >
+        Alterações não salvas
+      </div>
+      <Button
+        type="button"
+        size="lg"
+        onClick={onClick}
+        disabled={disabled}
+        className="pointer-events-auto gap-2 shadow-lg"
+      >
+        <Save className="h-4 w-4" />
+        Salvar novo modelo
+      </Button>
+    </div>
+  );
+}
+
+export default SaveButton;

--- a/frontend/src/features/document-editor/components/SidebarNavigation.tsx
+++ b/frontend/src/features/document-editor/components/SidebarNavigation.tsx
@@ -1,0 +1,122 @@
+import { Fragment } from 'react';
+import { ChevronLeft, ChevronRight, FileText, Info, ListTree } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { cn } from '@/lib/utils';
+import type { VariableMenuItem } from '../data/variable-items';
+import { variableMenuTree } from '../data/variable-items';
+
+interface SidebarNavigationProps {
+  collapsed: boolean;
+  onToggle: () => void;
+  activeSection: string;
+  onSelectSection: (section: string) => void;
+  onInsertVariable?: (item: VariableMenuItem) => void;
+  className?: string;
+}
+
+const NAV_ITEMS = [
+  { id: 'editor', label: 'Editor', icon: FileText },
+  { id: 'metadata', label: 'Metadados', icon: Info },
+  { id: 'placeholders', label: 'Campos', icon: ListTree },
+];
+
+function VariableTree({ items, depth, onSelect }: { items: VariableMenuItem[]; depth?: number; onSelect?: (item: VariableMenuItem) => void }) {
+  return (
+    <ul className="space-y-1">
+      {items.map(item => {
+        const IconWrapper = (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start gap-2 px-2 py-1 text-left text-sm"
+            onClick={() => onSelect?.(item)}
+            disabled={!onSelect}
+          >
+            <span className="font-medium">{item.label}</span>
+            <span className="ml-auto text-xs text-muted-foreground">{`{{${item.value}}}`}</span>
+          </Button>
+        );
+
+        return (
+          <li key={`${item.value}-${depth ?? 0}`} style={{ marginLeft: depth ? depth * 12 : 0 }}>
+            {onSelect ? IconWrapper : <span className="text-sm">{item.label}</span>}
+            {item.children && item.children.length > 0 && (
+              <VariableTree items={item.children} depth={(depth ?? 0) + 1} onSelect={onSelect} />
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export function SidebarNavigation({ collapsed, onToggle, activeSection, onSelectSection, onInsertVariable, className }: SidebarNavigationProps) {
+  return (
+    <aside
+      className={cn(
+        'flex h-full flex-col border-r bg-background transition-all duration-200 ease-in-out',
+        collapsed ? 'w-16' : 'w-64',
+        className
+      )}
+    >
+      <div className="flex items-center justify-between px-2 py-3">
+        {!collapsed && <p className="text-sm font-semibold">Biblioteca</p>}
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="h-8 w-8"
+          onClick={onToggle}
+          aria-label={collapsed ? 'Expandir barra lateral' : 'Recolher barra lateral'}
+        >
+          {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
+        </Button>
+      </div>
+      <nav className="space-y-1 px-1">
+        {NAV_ITEMS.map(item => {
+          const Icon = item.icon;
+          const isActive = activeSection === item.id;
+          const button = (
+            <Button
+              key={item.id}
+              type="button"
+              variant={isActive ? 'secondary' : 'ghost'}
+              className={cn(
+                'w-full justify-start gap-3 px-2 py-2 text-left text-sm',
+                collapsed && 'justify-center'
+              )}
+              onClick={() => onSelectSection(item.id)}
+            >
+              <Icon className="h-4 w-4" aria-hidden />
+              {!collapsed && <span>{item.label}</span>}
+            </Button>
+          );
+
+          if (collapsed) {
+            return (
+              <Tooltip key={item.id} delayDuration={0}>
+                <TooltipTrigger asChild>{button}</TooltipTrigger>
+                <TooltipContent side="right">{item.label}</TooltipContent>
+              </Tooltip>
+            );
+          }
+
+          return <Fragment key={item.id}>{button}</Fragment>;
+        })}
+      </nav>
+      {!collapsed && (
+        <div className="mt-6 flex-1 px-3 pb-6">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Campos disponíveis</h3>
+          <ScrollArea className="mt-3 h-[calc(100vh-260px)] pr-2">
+            <VariableTree items={variableMenuTree} depth={0} onSelect={onInsertVariable} />
+          </ScrollArea>
+        </div>
+      )}
+    </aside>
+  );
+}
+
+export default SidebarNavigation;

--- a/frontend/src/features/document-editor/data/variable-items.ts
+++ b/frontend/src/features/document-editor/data/variable-items.ts
@@ -1,0 +1,106 @@
+export interface VariableMenuItem {
+  label: string;
+  value: string;
+  description?: string;
+  children?: VariableMenuItem[];
+}
+
+export const variableMenuTree: VariableMenuItem[] = [
+  {
+    label: 'Cliente',
+    value: 'cliente',
+    children: [
+      { label: 'Primeiro nome', value: 'cliente.primeiro_nome' },
+      { label: 'Sobrenome', value: 'cliente.sobrenome' },
+      { label: 'Nome completo', value: 'cliente.nome_completo' },
+      {
+        label: 'Endereço',
+        value: 'cliente.endereco',
+        children: [
+          { label: 'Rua', value: 'cliente.endereco.rua' },
+          { label: 'Número', value: 'cliente.endereco.numero' },
+          { label: 'Bairro', value: 'cliente.endereco.bairro' },
+          { label: 'Cidade', value: 'cliente.endereco.cidade' },
+          { label: 'Estado', value: 'cliente.endereco.estado' },
+          { label: 'CEP', value: 'cliente.endereco.cep' },
+        ],
+      },
+      {
+        label: 'Contato',
+        value: 'cliente.contato',
+        children: [
+          { label: 'E-mail', value: 'cliente.contato.email' },
+          { label: 'Telefone', value: 'cliente.contato.telefone' },
+        ],
+      },
+      {
+        label: 'Documento',
+        value: 'cliente.documento',
+        children: [
+          { label: 'CPF', value: 'cliente.documento.cpf' },
+          { label: 'RG', value: 'cliente.documento.rg' },
+        ],
+      },
+    ],
+  },
+  {
+    label: 'Processo',
+    value: 'processo',
+    children: [
+      { label: 'Número', value: 'processo.numero' },
+      { label: 'Tipo de ação', value: 'processo.tipo_acao' },
+      { label: 'Vara', value: 'processo.vara' },
+      { label: 'Fase atual', value: 'processo.fase_atual' },
+      { label: 'Status', value: 'processo.status' },
+      {
+        label: 'Audiência',
+        value: 'processo.audiencia',
+        children: [
+          { label: 'Data', value: 'processo.audiencia.data' },
+          { label: 'Horário', value: 'processo.audiencia.horario' },
+          { label: 'Local', value: 'processo.audiencia.local' },
+        ],
+      },
+    ],
+  },
+  {
+    label: 'Escritório',
+    value: 'escritorio',
+    children: [
+      { label: 'Nome', value: 'escritorio.nome' },
+      { label: 'Razão social', value: 'escritorio.razao_social' },
+      { label: 'CNPJ', value: 'escritorio.cnpj' },
+      {
+        label: 'Endereço',
+        value: 'escritorio.endereco',
+        children: [
+          { label: 'Rua', value: 'escritorio.endereco.rua' },
+          { label: 'Número', value: 'escritorio.endereco.numero' },
+          { label: 'Bairro', value: 'escritorio.endereco.bairro' },
+          { label: 'Cidade', value: 'escritorio.endereco.cidade' },
+          { label: 'Estado', value: 'escritorio.endereco.estado' },
+        ],
+      },
+    ],
+  },
+  {
+    label: 'Usuário',
+    value: 'usuario',
+    children: [
+      { label: 'Nome completo', value: 'usuario.nome' },
+      { label: 'Cargo', value: 'usuario.cargo' },
+      { label: 'OAB', value: 'usuario.oab' },
+      { label: 'E-mail', value: 'usuario.email' },
+      { label: 'Telefone', value: 'usuario.telefone' },
+    ],
+  },
+  {
+    label: 'Data atual',
+    value: 'sistema',
+    children: [
+      { label: 'Data (DD/MM/AAAA)', value: 'sistema.data_atual' },
+      { label: 'Data por extenso', value: 'sistema.data_extenso' },
+      { label: 'Hora atual', value: 'sistema.hora_atual' },
+    ],
+  },
+];

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -142,3 +142,49 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer components {
+  .wysiwyg-editor {
+    min-height: 297mm;
+    font-size: 16px;
+    line-height: 1.6;
+    color: hsl(var(--foreground));
+  }
+
+  .wysiwyg-editor p {
+    margin-bottom: 0.75rem;
+  }
+
+  .wysiwyg-editor table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1rem 0;
+  }
+
+  .wysiwyg-editor table td,
+  .wysiwyg-editor table th {
+    border: 1px solid hsl(var(--border));
+    padding: 0.5rem;
+    min-width: 80px;
+  }
+
+  .variable-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.5rem;
+    border-radius: 9999px;
+    background-color: hsl(var(--primary) / 0.08);
+    color: hsl(var(--primary));
+    border: 1px solid hsl(var(--primary) / 0.2);
+    cursor: pointer;
+    font-size: 0.75rem;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  .variable-tag:focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+  }
+}

--- a/frontend/src/lib/templates.ts
+++ b/frontend/src/lib/templates.ts
@@ -1,45 +1,130 @@
 import { getApiUrl } from './api';
+import type {
+  EditorJsonContent,
+  Template,
+  TemplateDTO,
+  TemplateMetadata,
+  TemplatePayload,
+} from '@/types/templates';
+import { defaultTemplateMetadata } from '@/types/templates';
 
-export interface Template {
-  id: number;
-  title: string;
-  content: string;
+function normalizeMetadata(input: Partial<TemplateMetadata> | null | undefined): TemplateMetadata {
+  return {
+    type: input?.type ?? defaultTemplateMetadata.type,
+    area: input?.area ?? defaultTemplateMetadata.area,
+    complexity: (input?.complexity as TemplateMetadata['complexity']) ?? defaultTemplateMetadata.complexity,
+    autoCreateClient: Boolean(input?.autoCreateClient),
+    autoCreateProcess: Boolean(input?.autoCreateProcess),
+    visibility: input?.visibility ?? defaultTemplateMetadata.visibility,
+  };
 }
 
-export interface Tag {
-  id: number;
-  key: string;
-  label: string;
-  example?: string;
-  group_name?: string;
+function isEditorJsonNode(value: unknown): value is EditorJsonContent[number] {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    'type' in (value as Record<string, unknown>) &&
+    typeof (value as { type?: unknown }).type === 'string'
+  );
+}
+
+function ensureJsonContent(value: unknown): EditorJsonContent | null {
+  if (!value) return null;
+  if (Array.isArray(value)) {
+    return value.filter(isEditorJsonNode) as EditorJsonContent;
+  }
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      return ensureJsonContent(parsed);
+    } catch (error) {
+      console.warn('Failed to parse editor JSON content', error);
+      return null;
+    }
+  }
+  if (typeof value === 'object') {
+    const maybeArray = (value as { nodes?: unknown }).nodes;
+    if (Array.isArray(maybeArray)) {
+      return ensureJsonContent(maybeArray);
+    }
+  }
+  return null;
+}
+
+export function parseTemplate(dto: TemplateDTO): Template {
+  const rawContent = dto.content ?? '';
+  let contentHtml = rawContent || '<p></p>';
+  let contentJson: EditorJsonContent | null = null;
+  let metadata = defaultTemplateMetadata;
+
+  if (rawContent) {
+    try {
+      const parsed = JSON.parse(rawContent) as {
+        content_html?: string;
+        content_editor_json?: unknown;
+        metadata?: Partial<TemplateMetadata>;
+      };
+      contentHtml = parsed?.content_html ?? contentHtml;
+      contentJson = ensureJsonContent(parsed?.content_editor_json);
+      metadata = normalizeMetadata(parsed?.metadata);
+    } catch (error) {
+      console.info('Template content stored as raw HTML. Using fallback format.');
+    }
+  }
+
+  return {
+    id: dto.id,
+    title: dto.title,
+    content: rawContent,
+    content_html: contentHtml,
+    content_editor_json: contentJson,
+    metadata,
+  };
+}
+
+function serializeTemplatePayload(payload: TemplatePayload): Partial<TemplateDTO> {
+  const serialized = {
+    content_html: payload.content_html,
+    content_editor_json: payload.content_editor_json,
+    metadata: normalizeMetadata(payload.metadata),
+  };
+
+  return {
+    title: payload.title,
+    content: JSON.stringify(serialized),
+  };
 }
 
 export async function fetchTemplates(): Promise<Template[]> {
   const res = await fetch(getApiUrl('templates'));
-  return res.json();
+  const data = (await res.json()) as TemplateDTO[];
+  return data.map(parseTemplate);
 }
 
 export async function getTemplate(id: number): Promise<Template> {
   const res = await fetch(getApiUrl(`templates/${id}`));
-  return res.json();
+  const data = (await res.json()) as TemplateDTO;
+  return parseTemplate(data);
 }
 
-export async function createTemplate(template: Partial<Template>): Promise<Template> {
+export async function createTemplate(template: TemplatePayload): Promise<Template> {
   const res = await fetch(getApiUrl('templates'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(template),
+    body: JSON.stringify(serializeTemplatePayload(template)),
   });
-  return res.json();
+  const data = (await res.json()) as TemplateDTO;
+  return parseTemplate(data);
 }
 
-export async function updateTemplate(id: number, template: Partial<Template>): Promise<Template> {
+export async function updateTemplate(id: number, template: TemplatePayload): Promise<Template> {
   const res = await fetch(getApiUrl(`templates/${id}`), {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(template),
+    body: JSON.stringify(serializeTemplatePayload(template)),
   });
-  return res.json();
+  const data = (await res.json()) as TemplateDTO;
+  return parseTemplate(data);
 }
 
 export async function deleteTemplate(id: number): Promise<void> {
@@ -49,6 +134,14 @@ export async function deleteTemplate(id: number): Promise<void> {
 export async function fetchTags(): Promise<Tag[]> {
   const res = await fetch(getApiUrl('tags'));
   return res.json();
+}
+
+export interface Tag {
+  id: number;
+  key: string;
+  label: string;
+  example?: string;
+  group_name?: string;
 }
 
 export async function generateWithAI(id: number): Promise<string> {
@@ -65,4 +158,12 @@ export async function generateDocument(templateId: number, values: Record<string
   });
   const data = await res.json();
   return data.content;
+}
+
+export async function exportTemplatePdf(id: number): Promise<Blob> {
+  const res = await fetch(getApiUrl(`templates/${id}/export`));
+  if (!res.ok) {
+    throw new Error('Não foi possível exportar o template.');
+  }
+  return res.blob();
 }

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -1,144 +1,777 @@
-import { useParams, useNavigate } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getTemplate, createTemplate, updateTemplate, fetchTags, generateWithAI, generateDocument } from '@/lib/templates';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
-import { useState, useRef, useEffect } from 'react';
-import FontSelector from '@/components/FontSelector';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { createTemplate, getTemplate, updateTemplate } from '@/lib/templates';
+import type {
+  EditorJsonContent,
+  EditorJsonNode,
+  TemplatePayload,
+} from '@/types/templates';
+import { defaultTemplateMetadata } from '@/types/templates';
+import type { VariableMenuItem } from '@/features/document-editor/data/variable-items';
+import { InsertMenu } from '@/features/document-editor/components/InsertMenu';
+import { EditorToolbar, type ToolbarAlignment, type ToolbarBlock, type ToolbarState } from '@/features/document-editor/components/EditorToolbar';
+import { SidebarNavigation } from '@/features/document-editor/components/SidebarNavigation';
+import { MetadataModal, type MetadataFormValues } from '@/features/document-editor/components/MetadataModal';
+import { SaveButton } from '@/features/document-editor/components/SaveButton';
+import { Menu } from 'lucide-react';
+
+function escapeHtml(text: string): string {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+function nodeToHtml(node: EditorJsonNode): string {
+  if (node.type === 'text') {
+    return escapeHtml(node.text ?? '');
+  }
+
+  const attrs = node.attrs
+    ? Object.entries(node.attrs)
+        .map(([key, value]) => `${key}="${escapeHtml(value)}"`)
+        .join(' ')
+    : '';
+  const children = (node.children ?? []).map(nodeToHtml).join('');
+  if (['img', 'br', 'hr'].includes(node.type)) {
+    return `<${node.type}${attrs ? ` ${attrs}` : ''} />`;
+  }
+  return `<${node.type}${attrs ? ` ${attrs}` : ''}>${children}</${node.type}>`;
+}
+
+function jsonToHtml(content: EditorJsonContent | null): string {
+  if (!content) return '<p></p>';
+  return content.map(nodeToHtml).join('');
+}
+
+function serializeNode(node: Node): EditorJsonNode | null {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return { type: 'text', text: node.textContent ?? '' };
+  }
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    const element = node as HTMLElement;
+    const attrs: Record<string, string> = {};
+    Array.from(element.attributes).forEach(attr => {
+      if (attr.name === 'style' && attr.value.trim().length === 0) return;
+      attrs[attr.name] = attr.value;
+    });
+    const children = Array.from(element.childNodes)
+      .map(child => serializeNode(child))
+      .filter((child): child is EditorJsonNode => child !== null);
+    return {
+      type: element.tagName.toLowerCase(),
+      attrs,
+      children,
+    };
+  }
+  return null;
+}
+
+function htmlToJson(html: string): EditorJsonContent {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  const nodes: EditorJsonContent = [];
+  Array.from(doc.body.childNodes).forEach(node => {
+    const serialized = serializeNode(node);
+    if (serialized) {
+      nodes.push(serialized);
+    }
+  });
+  return nodes;
+}
+
+function extractPlaceholders(html: string): string[] {
+  const regex = /{{\s*([\w.]+)\s*}}/g;
+  const matches = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(html))) {
+    matches.add(match[1]);
+  }
+  return Array.from(matches);
+}
+
+function formatVariableLabel(name: string, label?: string | null): string {
+  if (label && label.trim().length > 0) {
+    return label.trim();
+  }
+  return name
+    .split('.')
+    .map(part =>
+      part
+        .replace(/_/g, ' ')
+        .replace(/\b\w/g, char => char.toUpperCase()),
+    )
+    .join(' • ');
+}
+
+const fontSizeMap: Record<string, string> = {
+  '1': '10px',
+  '2': '12px',
+  '3': '16px',
+  '4': '18px',
+  '5': '24px',
+  '6': '32px',
+  '7': '48px',
+};
+
+const initialToolbarState: ToolbarState = {
+  block: 'paragraph',
+  fontSize: 'default',
+  align: 'left',
+  bold: false,
+  italic: false,
+  underline: false,
+  strike: false,
+  orderedList: false,
+  bulletList: false,
+  blockquote: false,
+  highlight: false,
+};
 
 export default function EditorPage() {
   const { id } = useParams();
-  const isNew = id === 'novo';
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('<p></p>');
-  const editorRef = useRef<HTMLDivElement>(null);
+  const location = useLocation();
+  const isNew = !id || id === 'novo';
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const isMobile = useIsMobile();
 
-  useQuery({
+  const editorRef = useRef<HTMLDivElement | null>(null);
+  const [title, setTitle] = useState('');
+  const [metadata, setMetadata] = useState(defaultTemplateMetadata);
+  const [contentHtml, setContentHtml] = useState('<p></p>');
+  const [editorJson, setEditorJson] = useState<EditorJsonContent | null>(null);
+  const [isMetadataModalOpen, setIsMetadataModalOpen] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(isMobile);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const [activeSection, setActiveSection] = useState<'editor' | 'metadata' | 'placeholders'>('editor');
+  const [toolbarState, setToolbarState] = useState<ToolbarState>(initialToolbarState);
+  const [tagEditor, setTagEditor] = useState<{ element: HTMLElement; label: string } | null>(null);
+
+  const editorSectionRef = useRef<HTMLDivElement | null>(null);
+  const metadataSectionRef = useRef<HTMLDivElement | null>(null);
+  const placeholdersSectionRef = useRef<HTMLDivElement | null>(null);
+
+  const locationState = location.state as { openMetadata?: boolean } | null;
+
+  useEffect(() => {
+    if (locationState?.openMetadata) {
+      setIsMetadataModalOpen(true);
+    }
+  }, [locationState]);
+
+  useEffect(() => {
+    setSidebarCollapsed(isMobile);
+    if (!isMobile) {
+      setMobileSidebarOpen(false);
+    }
+  }, [isMobile]);
+
+  const templateQuery = useQuery({
     queryKey: ['template', id],
     queryFn: () => getTemplate(Number(id)),
     enabled: !isNew,
-    onSuccess: tpl => {
-      setTitle(tpl.title);
-      setContent(tpl.content);
-    }
+    onSuccess: data => {
+      setTitle(data.title);
+      setMetadata(data.metadata);
+      const html = data.content_editor_json ? jsonToHtml(data.content_editor_json) : data.content_html;
+      setContentHtml(html);
+      setEditorJson(data.content_editor_json ?? htmlToJson(html));
+      setIsDirty(false);
+    },
   });
 
-  const { data: tags } = useQuery({ queryKey: ['tags'], queryFn: fetchTags });
-
-  const saveMut = useMutation({
-    mutationFn: () =>
-      isNew ? createTemplate({ title, content }) : updateTemplate(Number(id), { title, content }),
-    onSuccess: template => {
+  const saveMutation = useMutation({
+    mutationFn: (payload: TemplatePayload) =>
+      isNew ? createTemplate(payload) : updateTemplate(Number(id), payload),
+    onSuccess: data => {
       queryClient.invalidateQueries({ queryKey: ['templates'] });
+      setIsDirty(false);
       if (isNew) {
-        navigate(`/documentos/editor/${template.id}`);
-      } else {
-        navigate('/documentos');
+        navigate(`/documentos/editor/${data.id}`);
       }
-    }
+    },
   });
 
-  function handleDrop(e: React.DragEvent<HTMLDivElement>) {
-    e.preventDefault();
-    const text = e.dataTransfer.getData('text/plain');
-    insertAtCaret(text);
-    setContent(editorRef.current?.innerHTML || '');
-  }
+  const decorateVariableTags = useCallback((container?: HTMLElement | null) => {
+    const host = container ?? editorRef.current;
+    if (!host) return;
+    const tags = host.querySelectorAll<HTMLElement>('[data-variable]');
+    tags.forEach(tag => {
+      tag.classList.add('variable-tag');
+      tag.setAttribute('contenteditable', 'false');
+      tag.setAttribute('tabindex', '0');
+      const variable = tag.getAttribute('data-variable') ?? '';
+      const label = tag.getAttribute('data-label');
+      tag.textContent = formatVariableLabel(variable, label);
+      tag.setAttribute('role', 'button');
+      tag.setAttribute('aria-label', `Editar rótulo para ${variable}`);
+    });
+  }, []);
 
-  function insertAtCaret(text: string) {
-    const sel = window.getSelection();
-    if (!sel || sel.rangeCount === 0) return;
-    const range = sel.getRangeAt(0);
-    range.deleteContents();
-    range.insertNode(document.createTextNode(text));
-    range.collapse(false);
-    sel.removeAllRanges();
-    sel.addRange(range);
-  }
+  const normalizeFontTags = useCallback(() => {
+    const container = editorRef.current;
+    if (!container) return;
+    const fonts = container.querySelectorAll('font');
+    fonts.forEach(font => {
+      const size = font.getAttribute('size') ?? '3';
+      const span = document.createElement('span');
+      span.style.fontSize = fontSizeMap[size] ?? fontSizeMap['3'];
+      span.innerHTML = font.innerHTML;
+      font.replaceWith(span);
+    });
+  }, []);
 
-  function exec(cmd: string, value?: string) {
-    editorRef.current?.focus();
-    document.execCommand(cmd, false, value);
-    setContent(editorRef.current?.innerHTML || '');
-  }
+  const updateToolbarState = useCallback(() => {
+    const selection = document.getSelection();
+    if (!selection || !editorRef.current) return;
+    if (!editorRef.current.contains(selection.anchorNode)) return;
+
+    const blockValue = (document.queryCommandValue('formatBlock') || 'p').toString().toLowerCase();
+    const block: ToolbarBlock = blockValue === 'h1' ? 'h1' : blockValue === 'h2' ? 'h2' : blockValue === 'h3' ? 'h3' : 'paragraph';
+    const fontSizeValue = document.queryCommandValue('fontSize')?.toString() ?? 'default';
+    let align: ToolbarAlignment = 'left';
+    if (document.queryCommandState('justifyCenter')) align = 'center';
+    else if (document.queryCommandState('justifyRight')) align = 'right';
+    else if (document.queryCommandState('justifyFull')) align = 'justify';
+
+    const highlightValue = document.queryCommandValue('hiliteColor') || document.queryCommandValue('backColor');
+    const highlight =
+      typeof highlightValue === 'string' &&
+      highlightValue !== 'transparent' &&
+      highlightValue !== 'rgba(0, 0, 0, 0)' &&
+      highlightValue !== '';
+
+    setToolbarState({
+      block,
+      fontSize: fontSizeValue || 'default',
+      align,
+      bold: document.queryCommandState('bold'),
+      italic: document.queryCommandState('italic'),
+      underline: document.queryCommandState('underline'),
+      strike: document.queryCommandState('strikeThrough'),
+      orderedList: document.queryCommandState('insertOrderedList'),
+      bulletList: document.queryCommandState('insertUnorderedList'),
+      blockquote: blockValue === 'blockquote',
+      highlight,
+    });
+  }, []);
+
+  const handleContentUpdate = useCallback(() => {
+    const container = editorRef.current;
+    if (!container) return;
+    decorateVariableTags(container);
+    normalizeFontTags();
+    const html = container.innerHTML;
+    setContentHtml(html);
+    setEditorJson(htmlToJson(html));
+    setIsDirty(true);
+  }, [decorateVariableTags, normalizeFontTags]);
 
   useEffect(() => {
-    if (editorRef.current && editorRef.current.innerHTML !== content) {
-      editorRef.current.innerHTML = content;
-    }
-  }, [content]);
+    const editor = editorRef.current;
+    if (!editor) return;
+    document.execCommand('styleWithCSS', false, 'true');
 
-  function handleGenerateAI() {
-    if (isNew) return;
-    generateWithAI(Number(id)).then(t => setContent(t));
-  }
+    const handleInput = () => {
+      handleContentUpdate();
+      updateToolbarState();
+    };
 
-  async function handlePreview() {
-    const regex = /{{\s*([\w.]+)\s*}}/g;
-    const vars = Array.from(new Set(Array.from(content.matchAll(regex)).map(m => m[1])));
-    const values: Record<string, string> = {};
-    for (const v of vars) {
-      const val = window.prompt(`Valor para ${v}`) || '';
-      values[v] = val;
+    const handleDrop = (event: DragEvent) => {
+      event.preventDefault();
+      const text = event.dataTransfer?.getData('text/plain');
+      if (text) {
+        document.execCommand('insertText', false, text);
+        handleContentUpdate();
+      }
+    };
+
+    const handleClick = (event: MouseEvent) => {
+      const target = (event.target as HTMLElement).closest<HTMLElement>('.variable-tag');
+      if (target) {
+        event.preventDefault();
+        setTagEditor({ element: target, label: target.getAttribute('data-label') ?? target.textContent ?? '' });
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement;
+      if (target && target.classList.contains('variable-tag') && (event.key === 'Enter' || event.key === ' ')) {
+        event.preventDefault();
+        setTagEditor({ element: target, label: target.getAttribute('data-label') ?? target.textContent ?? '' });
+      }
+    };
+
+    editor.addEventListener('input', handleInput);
+    editor.addEventListener('blur', handleInput);
+    editor.addEventListener('drop', handleDrop);
+    editor.addEventListener('click', handleClick);
+    editor.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      editor.removeEventListener('input', handleInput);
+      editor.removeEventListener('blur', handleInput);
+      editor.removeEventListener('drop', handleDrop);
+      editor.removeEventListener('click', handleClick);
+      editor.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleContentUpdate, updateToolbarState]);
+
+  useEffect(() => {
+    const handleSelectionChange = () => updateToolbarState();
+    document.addEventListener('selectionchange', handleSelectionChange);
+    return () => document.removeEventListener('selectionchange', handleSelectionChange);
+  }, [updateToolbarState]);
+
+  useEffect(() => {
+    if (!tagEditor) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      if (
+        tagEditor &&
+        !tagEditor.element.contains(target) &&
+        !target.closest('.variable-tag-editor')
+      ) {
+        setTagEditor(null);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [tagEditor]);
+
+  useEffect(() => {
+    if (templateQuery.data && editorRef.current) {
+      const html = templateQuery.data.content_editor_json
+        ? jsonToHtml(templateQuery.data.content_editor_json)
+        : templateQuery.data.content_html;
+      editorRef.current.innerHTML = html;
+      decorateVariableTags(editorRef.current);
+      setContentHtml(html);
+      setEditorJson(templateQuery.data.content_editor_json ?? htmlToJson(html));
+      setIsDirty(false);
+      updateToolbarState();
+    } else if (isNew && editorRef.current) {
+      editorRef.current.innerHTML = '<p></p>';
+      setEditorJson(htmlToJson('<p></p>'));
+      decorateVariableTags(editorRef.current);
+      updateToolbarState();
     }
-    const html = await generateDocument(isNew ? 0 : Number(id), values);
-    const win = window.open('', '_blank');
-    if (win) {
-      win.document.write(html);
+  }, [decorateVariableTags, isNew, templateQuery.data, updateToolbarState]);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 's') {
+        event.preventDefault();
+        setIsMetadataModalOpen(true);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  const focusEditor = () => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    editor.focus({ preventScroll: true });
+  };
+
+  const executeCommand = (command: string, value?: string) => {
+    focusEditor();
+    document.execCommand(command, false, value);
+    handleContentUpdate();
+    updateToolbarState();
+  };
+
+  const handleAlignmentChange = (value: ToolbarAlignment) => {
+    const commands: Record<ToolbarAlignment, string> = {
+      left: 'justifyLeft',
+      center: 'justifyCenter',
+      right: 'justifyRight',
+      justify: 'justifyFull',
+    };
+    executeCommand(commands[value]);
+  };
+
+  const handleBlockChange = (value: ToolbarBlock) => {
+    const blockMap: Record<ToolbarBlock, string> = {
+      paragraph: 'P',
+      h1: 'H1',
+      h2: 'H2',
+      h3: 'H3',
+    };
+    executeCommand('formatBlock', blockMap[value]);
+  };
+
+  const handleFontSizeChange = (value: string) => {
+    const size = value === 'default' ? '3' : value;
+    executeCommand('fontSize', size);
+    normalizeFontTags();
+    handleContentUpdate();
+  };
+
+  const toggleHighlight = () => {
+    focusEditor();
+    const color = toolbarState.highlight ? 'transparent' : '#fef08a';
+    document.execCommand('hiliteColor', false, color);
+    handleContentUpdate();
+    updateToolbarState();
+  };
+
+  const handleInsertImage = () => {
+    const src = window.prompt('Informe a URL ou base64 da imagem:');
+    if (!src) return;
+    executeCommand('insertImage', src);
+  };
+
+  const handleInsertTable = () => {
+    const rows = 3;
+    const cols = 3;
+    let html = '<table class="editor-table"><tbody>';
+    for (let r = 0; r < rows; r += 1) {
+      html += '<tr>';
+      for (let c = 0; c < cols; c += 1) {
+        html += '<td style="border:1px solid #d4d4d8;padding:8px;min-width:80px">&nbsp;</td>';
+      }
+      html += '</tr>';
     }
-  }
+    html += '</tbody></table>';
+    executeCommand('insertHTML', html);
+  };
+
+  const handleInsertVariable = (item: VariableMenuItem) => {
+    const selection = document.getSelection();
+    const editor = editorRef.current;
+    if (!selection || !editor || selection.rangeCount === 0) return;
+    focusEditor();
+    const range = selection.getRangeAt(0);
+    range.deleteContents();
+    const span = document.createElement('span');
+    span.className = 'variable-tag';
+    span.setAttribute('data-variable', item.value);
+    span.setAttribute('data-label', item.label);
+    span.setAttribute('contenteditable', 'false');
+    span.setAttribute('tabindex', '0');
+    span.setAttribute('role', 'button');
+    span.setAttribute('aria-label', `Editar rótulo para ${item.value}`);
+    span.textContent = formatVariableLabel(item.value, item.label);
+    range.insertNode(span);
+    range.setStartAfter(span);
+    range.setEndAfter(span);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    handleContentUpdate();
+    updateToolbarState();
+    focusSection('editor');
+  };
+
+  const handleMetadataConfirm = (values: MetadataFormValues) => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    const html = editor.innerHTML;
+    const json = htmlToJson(html);
+    setTitle(values.title);
+    const payloadMetadata = {
+      type: values.type,
+      area: values.area,
+      complexity: values.complexity,
+      autoCreateClient: values.autoCreateClient,
+      autoCreateProcess: values.autoCreateProcess,
+      visibility: values.visibility,
+    };
+    setMetadata(payloadMetadata);
+    const payload: TemplatePayload = {
+      title: values.title,
+      content_html: html,
+      content_editor_json: json,
+      metadata: payloadMetadata,
+    };
+    setEditorJson(json);
+    saveMutation.mutate(payload);
+    setIsMetadataModalOpen(false);
+  };
+
+  const focusSection = (section: 'editor' | 'metadata' | 'placeholders') => {
+    setActiveSection(section);
+    const refMap: Record<typeof section, React.RefObject<HTMLDivElement>> = {
+      editor: editorSectionRef,
+      metadata: metadataSectionRef,
+      placeholders: placeholdersSectionRef,
+    };
+    refMap[section].current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    if (isMobile) {
+      setMobileSidebarOpen(false);
+    }
+  };
+
+  const handleUndo = () => {
+    focusEditor();
+    document.execCommand('undo');
+    handleContentUpdate();
+    updateToolbarState();
+  };
+
+  const handleRedo = () => {
+    focusEditor();
+    document.execCommand('redo');
+    handleContentUpdate();
+    updateToolbarState();
+  };
+
+  const placeholderList = useMemo(() => extractPlaceholders(contentHtml), [contentHtml]);
+
+  const metadataFormDefaults: MetadataFormValues = {
+    title,
+    type: metadata.type,
+    area: metadata.area,
+    complexity: metadata.complexity,
+    autoCreateClient: metadata.autoCreateClient,
+    autoCreateProcess: metadata.autoCreateProcess,
+    visibility: metadata.visibility,
+  };
+
+  const handleTagEditorSubmit = (label: string) => {
+    if (!tagEditor) return;
+    const element = tagEditor.element;
+    const variable = element.getAttribute('data-variable') ?? '';
+    const formatted = formatVariableLabel(variable, label);
+    element.setAttribute('data-label', label.trim());
+    element.textContent = formatted;
+    setTagEditor(null);
+    handleContentUpdate();
+  };
 
   return (
-    <div className="p-6 space-y-4">
-      <input className="border p-2 w-full" placeholder="Título" value={title} onChange={e => setTitle(e.target.value)} />
-      <div className="flex gap-4 justify-center">
-        <div className="w-64 border rounded p-2 space-y-2" onDragOver={e => e.preventDefault()}>
-          <h2 className="font-bold">Tags</h2>
-          {tags?.map(tag => (
-            <div
-              key={tag.id}
-              draggable
-              onDragStart={e => e.dataTransfer.setData('text/plain', `{{${tag.key}}}`)}
-              className="cursor-move p-1 border rounded"
-            >
-              {tag.label}
-            </div>
-          ))}
-        </div>
-        <div className="flex-1 space-y-2">
-          <div className="flex gap-2 flex-wrap justify-center">
-            <FontSelector onChange={f => exec('fontName', f)} />
-            <Button variant="outline" size="sm" onClick={() => exec('bold')}><b>B</b></Button>
-            <Button variant="outline" size="sm" onClick={() => exec('italic')}><i>I</i></Button>
-            <Button variant="outline" size="sm" onClick={() => exec('underline')}><u>U</u></Button>
-            <Button variant="outline" size="sm" onClick={() => exec('strikeThrough')}><s>S</s></Button>
-            <Button variant="outline" size="sm" onClick={() => exec('insertOrderedList')}>OL</Button>
-            <Button variant="outline" size="sm" onClick={() => exec('insertUnorderedList')}>UL</Button>
-            <Button variant="outline" size="sm" onClick={() => exec('justifyLeft')}>Left</Button>
-            <Button variant="outline" size="sm" onClick={() => exec('justifyCenter')}>Center</Button>
-            <Button variant="outline" size="sm" onClick={() => exec('justifyRight')}>Right</Button>
-            <Button variant="outline" size="sm" onClick={() => exec('justifyFull')}>Justify</Button>
-            <Button variant="outline" size="sm" onClick={() => exec('undo')}>Undo</Button>
-            <Button variant="outline" size="sm" onClick={() => exec('redo')}>Redo</Button>
-            <Button variant="outline" size="sm" onClick={() => exec('formatBlock', 'H1')}>H1</Button>
-            <Button variant="outline" size="sm" onClick={() => exec('formatBlock', 'H2')}>H2</Button>
-          </div>
-          <div
-            className="border rounded bg-white mx-auto shadow"
-            style={{ width: '210mm', minHeight: '297mm', direction: 'ltr' }}
-            contentEditable
-            ref={editorRef}
-            onDrop={handleDrop}
-            onInput={e => setContent((e.target as HTMLDivElement).innerHTML)}
+    <div className="flex min-h-screen bg-muted/20 text-foreground">
+      <SidebarNavigation
+        collapsed={sidebarCollapsed}
+        onToggle={() => setSidebarCollapsed(prev => !prev)}
+        activeSection={activeSection}
+        onSelectSection={focusSection}
+        onInsertVariable={handleInsertVariable}
+        className="hidden md:flex"
+      />
+
+      <Sheet open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen}>
+        <SheetContent side="left" className="w-72 p-0">
+          <SheetHeader className="px-4 py-4 text-left">
+            <SheetTitle>Navegação</SheetTitle>
+          </SheetHeader>
+          <SidebarNavigation
+            collapsed={false}
+            onToggle={() => setMobileSidebarOpen(false)}
+            activeSection={activeSection}
+            onSelectSection={focusSection}
+            onInsertVariable={handleInsertVariable}
+            className="border-r-0"
           />
+        </SheetContent>
+      </Sheet>
+
+      <div className="flex flex-1 flex-col">
+        <header className="sticky top-0 z-30 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/75">
+          <div className="flex flex-col gap-3 px-4 py-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex flex-1 items-center gap-2">
+                {isMobile && (
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    onClick={() => setMobileSidebarOpen(true)}
+                    aria-label="Abrir navegação"
+                  >
+                    <Menu className="h-5 w-5" />
+                  </Button>
+                )}
+                <div className="min-w-[200px] flex-1">
+                  <Input
+                    value={title}
+                    placeholder="Título do modelo"
+                    onChange={event => {
+                      setTitle(event.target.value);
+                      setIsDirty(true);
+                    }}
+                    className="text-lg font-semibold"
+                    aria-label="Título do modelo"
+                  />
+                </div>
+              </div>
+              <InsertMenu onSelect={handleInsertVariable} />
+            </div>
+            <EditorToolbar
+              state={toolbarState}
+              onBlockChange={handleBlockChange}
+              onFontSizeChange={handleFontSizeChange}
+              onAlignmentChange={handleAlignmentChange}
+              onCommand={executeCommand}
+              onHighlight={toggleHighlight}
+              onInsertImage={handleInsertImage}
+              onInsertTable={handleInsertTable}
+              onUndo={handleUndo}
+              onRedo={handleRedo}
+            />
+          </div>
+        </header>
+
+        <main className="flex-1 overflow-y-auto">
+          <section ref={editorSectionRef} id="editor" className="px-4 py-6">
+            <div className="mx-auto flex max-w-[1100px] flex-col gap-6">
+              {templateQuery.isLoading ? (
+                <Skeleton className="h-[500px] w-full" />
+              ) : (
+                <div className="relative flex justify-center">
+                  <div className="w-full max-w-[210mm]">
+                    <div className="mx-auto min-h-[297mm] w-full max-w-[210mm] bg-white px-12 py-16 shadow-lg">
+                      <div
+                        ref={editorRef}
+                        className="wysiwyg-editor focus:outline-none"
+                        contentEditable
+                        role="textbox"
+                        aria-multiline="true"
+                        spellCheck
+                        suppressContentEditableWarning
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
+              <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
+                <span>
+                  Atalhos: Ctrl/⌘ + B (negrito), Ctrl/⌘ + I (itálico), Ctrl/⌘ + U (sublinhar), Ctrl/⌘ + S (salvar)
+                </span>
+                <Button variant="outline" onClick={() => setIsMetadataModalOpen(true)}>
+                  Editar metadados
+                </Button>
+              </div>
+            </div>
+          </section>
+
+          <section ref={metadataSectionRef} id="metadata" className="px-4 py-6">
+            <div className="mx-auto max-w-[1100px]">
+              <Card>
+                <CardHeader className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                  <CardTitle>Metadados do modelo</CardTitle>
+                  <Button size="sm" variant="ghost" onClick={() => setIsMetadataModalOpen(true)}>
+                    Ajustar metadados
+                  </Button>
+                </CardHeader>
+                <CardContent className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  <div>
+                    <p className="text-xs uppercase text-muted-foreground">Tipo</p>
+                    <p className="text-sm font-medium">{metadata.type}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase text-muted-foreground">Área</p>
+                    <p className="text-sm font-medium">{metadata.area || '—'}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase text-muted-foreground">Complexidade</p>
+                    <p className="text-sm font-medium">{metadata.complexity}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase text-muted-foreground">Cadastrar cliente</p>
+                    <p className="text-sm font-medium">{metadata.autoCreateClient ? 'Sim' : 'Não'}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase text-muted-foreground">Cadastrar processo</p>
+                    <p className="text-sm font-medium">{metadata.autoCreateProcess ? 'Sim' : 'Não'}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase text-muted-foreground">Visibilidade</p>
+                    <p className="text-sm font-medium">
+                      {metadata.visibility === 'publico'
+                        ? 'Público'
+                        : metadata.visibility.charAt(0).toUpperCase() + metadata.visibility.slice(1)}
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          </section>
+
+          <section ref={placeholdersSectionRef} id="placeholders" className="px-4 py-6">
+            <div className="mx-auto max-w-[1100px]">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Variáveis utilizadas</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {placeholderList.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      Insira placeholders pelo menu “Inserir” ou pela barra lateral para preencher dados automaticamente.
+                    </p>
+                  ) : (
+                    <div className="flex flex-wrap gap-2">
+                      {placeholderList.map(variable => (
+                        <Badge key={variable} variant="secondary" className="text-xs font-medium">
+                          {`{{${variable}}}`}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          </section>
+        </main>
+      </div>
+
+      {tagEditor && editorRef.current && (
+        <div
+          className="variable-tag-editor fixed z-50 rounded-md border bg-card p-3 shadow-lg"
+          style={{
+            top: `${tagEditor.element.getBoundingClientRect().bottom + 8}px`,
+            left: `${tagEditor.element.getBoundingClientRect().left}px`,
+          }}
+        >
+          <div className="flex items-center gap-2">
+            <Input
+              value={tagEditor.label}
+              onChange={event => setTagEditor({ element: tagEditor.element, label: event.target.value })}
+              onKeyDown={event => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  handleTagEditorSubmit(tagEditor.label);
+                }
+                if (event.key === 'Escape') {
+                  event.preventDefault();
+                  setTagEditor(null);
+                }
+              }}
+              autoFocus
+              className="h-9 w-48"
+            />
+            <Button type="button" size="sm" onClick={() => handleTagEditorSubmit(tagEditor.label)}>
+              Salvar
+            </Button>
+          </div>
         </div>
-      </div>
-      <div className="space-x-2 flex justify-center">
-        <Button onClick={() => saveMut.mutate()}>Salvar template</Button>
-        <Button variant="outline" onClick={handleGenerateAI}>Gerar texto com IA</Button>
-        <Button variant="outline" onClick={handlePreview}>Preview / Preencher</Button>
-      </div>
+      )}
+
+      <MetadataModal
+        open={isMetadataModalOpen}
+        onOpenChange={setIsMetadataModalOpen}
+        defaultValues={metadataFormDefaults}
+        onConfirm={handleMetadataConfirm}
+        isSaving={saveMutation.isPending}
+      />
+
+      <SaveButton onClick={() => setIsMetadataModalOpen(true)} disabled={saveMutation.isPending} isDirty={isDirty} />
     </div>
   );
 }

--- a/frontend/src/pages/LibraryPage.tsx
+++ b/frontend/src/pages/LibraryPage.tsx
@@ -1,61 +1,305 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { fetchTemplates, deleteTemplate, createTemplate, Template } from '@/lib/templates';
-import { Button } from '@/components/ui/button';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { ExternalLink, Pencil, Trash2, Download, FilePlus2 } from 'lucide-react';
+import { fetchTemplates, deleteTemplate, updateTemplate, exportTemplatePdf } from '@/lib/templates';
+import type { Template } from '@/types/templates';
+import type { TemplatePayload } from '@/types/templates';
+
+function getSnippet(html: string): string {
+  return html
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 180);
+}
 
 export default function LibraryPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { data: templates } = useQuery({ queryKey: ['templates'], queryFn: fetchTemplates });
-  const deleteMut = useMutation({
+  const { data: templates, isLoading } = useQuery({ queryKey: ['templates'], queryFn: fetchTemplates });
+
+  const [searchTerm, setSearchTerm] = useState('');
+  const [typeFilter, setTypeFilter] = useState<'todos' | string>('todos');
+  const [renamingId, setRenamingId] = useState<number | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [exportingId, setExportingId] = useState<number | null>(null);
+
+  const deleteMutation = useMutation({
     mutationFn: (id: number) => deleteTemplate(id),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['templates'] })
-  });
-  const duplicateMut = useMutation({
-    mutationFn: (tpl: Template) => createTemplate({ title: tpl.title + ' (cópia)', content: tpl.content }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['templates'] })
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['templates'] }),
   });
 
+  const renameMutation = useMutation({
+    mutationFn: ({ template, title }: { template: Template; title: string }) => {
+      const payload: TemplatePayload = {
+        title,
+        content_html: template.content_html,
+        content_editor_json: template.content_editor_json,
+        metadata: template.metadata,
+      };
+      return updateTemplate(template.id, payload);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['templates'] });
+      setRenamingId(null);
+    },
+  });
+
+  const typeOptions = useMemo(() => {
+    const options = new Set<string>();
+    templates?.forEach(template => {
+      if (template.metadata.type) {
+        options.add(template.metadata.type);
+      }
+    });
+    return Array.from(options);
+  }, [templates]);
+
+  const filteredTemplates = useMemo(() => {
+    return (
+      templates?.filter(template => {
+        const matchesSearch = template.title.toLowerCase().includes(searchTerm.toLowerCase());
+        const matchesType = typeFilter === 'todos' || template.metadata.type === typeFilter;
+        return matchesSearch && matchesType;
+      }) ?? []
+    );
+  }, [templates, searchTerm, typeFilter]);
+
+  async function handleExport(template: Template) {
+    try {
+      setExportingId(template.id);
+      const blob = await exportTemplatePdf(template.id);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${template.title || 'template'}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('Erro ao exportar modelo', error);
+    } finally {
+      setExportingId(null);
+    }
+  }
+
+  function handleStartRename(template: Template) {
+    setRenamingId(template.id);
+    setRenameValue(template.title);
+  }
+
+  function handleRenameConfirm(template: Template) {
+    const trimmed = renameValue.trim();
+    if (!trimmed) {
+      setRenameValue(template.title);
+      setRenamingId(null);
+      return;
+    }
+    if (trimmed === template.title) {
+      setRenamingId(null);
+      return;
+    }
+    renameMutation.mutate({ template, title: trimmed });
+  }
+
   return (
-    <div className="p-6 space-y-4">
-      <div className="flex justify-between items-center">
-        <h1 className="text-3xl font-bold">Templates</h1>
-        <Button onClick={() => navigate('/documentos/editor/novo')}>Novo Template</Button>
+    <div className="space-y-6 px-6 py-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Modelos de documento</h1>
+          <p className="text-muted-foreground">Organize, busque e gerencie seus modelos prontos para uso.</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" onClick={() => navigate('/documentos/editor/novo')}>
+            Em branco
+          </Button>
+          <Button onClick={() => navigate('/documentos/editor/novo', { state: { openMetadata: true } })}>
+            <FilePlus2 className="mr-2 h-4 w-4" />
+            Criar novo modelo
+          </Button>
+        </div>
       </div>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-[60px]">ID</TableHead>
-            <TableHead>Título</TableHead>
-            <TableHead className="hidden md:table-cell">Prévia</TableHead>
-            <TableHead className="text-right">Ações</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {templates?.map(t => (
-            <TableRow key={t.id}>
-              <TableCell className="font-medium">{t.id}</TableCell>
-              <TableCell>{t.title}</TableCell>
-              <TableCell className="hidden md:table-cell text-muted-foreground">
-                {t.content.slice(0, 60)}{t.content.length > 60 ? '...' : ''}
-              </TableCell>
-              <TableCell className="text-right space-x-2">
-                <Button variant="outline" size="sm" onClick={() => navigate(`/documentos/editor/${t.id}`)}>Editar</Button>
-                <Button variant="outline" size="sm" onClick={() => duplicateMut.mutate(t)}>Duplicar</Button>
-                <Button variant="destructive" size="sm" onClick={() => deleteMut.mutate(t.id)}>Excluir</Button>
-              </TableCell>
-            </TableRow>
+
+      <div className="flex flex-col gap-4 rounded-md border bg-card p-4 shadow-sm md:flex-row md:items-center md:justify-between">
+        <div className="flex w-full max-w-xl items-center gap-3">
+          <Input
+            value={searchTerm}
+            onChange={event => setSearchTerm(event.target.value)}
+            placeholder="Buscar por nome"
+            aria-label="Buscar modelo"
+          />
+        </div>
+        <div className="flex items-center gap-3">
+          <Select value={typeFilter} onValueChange={value => setTypeFilter(value)}>
+            <SelectTrigger className="w-48">
+              <SelectValue placeholder="Filtrar por tipo" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="todos">Todos os tipos</SelectItem>
+              {typeOptions.map(option => (
+                <SelectItem key={option} value={option}>
+                  {option}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <Skeleton key={index} className="h-[320px] w-full" />
           ))}
-        </TableBody>
-      </Table>
+        </div>
+      ) : filteredTemplates.length === 0 ? (
+        <div className="rounded-md border border-dashed bg-muted/30 p-12 text-center">
+          <p className="text-lg font-semibold">Nenhum modelo encontrado</p>
+          <p className="text-sm text-muted-foreground">
+            Ajuste os filtros ou crie um novo modelo para começar a sua biblioteca.
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {filteredTemplates.map(template => (
+            <Card key={template.id} className="flex flex-col">
+              <CardHeader className="pb-4">
+                {renamingId === template.id ? (
+                  <Input
+                    value={renameValue}
+                    onChange={event => setRenameValue(event.target.value)}
+                    onBlur={() => handleRenameConfirm(template)}
+                    onKeyDown={event => {
+                      if (event.key === 'Enter') {
+                        event.preventDefault();
+                        handleRenameConfirm(template);
+                      }
+                      if (event.key === 'Escape') {
+                        event.preventDefault();
+                        setRenamingId(null);
+                        setRenameValue(template.title);
+                      }
+                    }}
+                    disabled={renameMutation.isPending}
+                    aria-label="Renomear modelo"
+                    className="text-lg font-semibold"
+                    autoFocus
+                  />
+                ) : (
+                  <div className="flex items-start justify-between gap-2">
+                    <CardTitle className="text-lg">{template.title}</CardTitle>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleStartRename(template)}
+                          aria-label="Renomear modelo"
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Renomear</TooltipContent>
+                    </Tooltip>
+                  </div>
+                )}
+                <p className="text-sm text-muted-foreground">{template.metadata.area || 'Área não definida'}</p>
+              </CardHeader>
+              <CardContent className="flex-1 space-y-4">
+                <div className="rounded-md border bg-background/70 p-2">
+                  <div className="relative h-48 overflow-hidden rounded-sm bg-white">
+                    <div
+                      className="pointer-events-none origin-top-left scale-[0.35] transform"
+                      style={{ width: '210mm', minHeight: '297mm' }}
+                      dangerouslySetInnerHTML={{ __html: template.content_html || '<p>Modelo sem conteúdo</p>' }}
+                    />
+                  </div>
+                </div>
+                <p
+                  className="text-sm text-muted-foreground"
+                  style={{
+                    display: '-webkit-box',
+                    WebkitLineClamp: 3,
+                    WebkitBoxOrient: 'vertical',
+                    overflow: 'hidden',
+                  }}
+                >
+                  {getSnippet(template.content_html)}...
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant="secondary">{template.metadata.type}</Badge>
+                  {template.metadata.complexity && (
+                    <Badge variant="outline">Complexidade: {template.metadata.complexity}</Badge>
+                  )}
+                  {template.metadata.visibility && (
+                    <Badge variant="outline">
+                      Visibilidade:{' '}
+                      {template.metadata.visibility === 'publico'
+                        ? 'Público'
+                        : template.metadata.visibility.charAt(0).toUpperCase() + template.metadata.visibility.slice(1)}
+                    </Badge>
+                  )}
+                </div>
+              </CardContent>
+              <CardFooter className="flex flex-col gap-3">
+                <div className="flex w-full flex-wrap justify-between gap-2">
+                  <Button variant="default" onClick={() => navigate(`/documentos/editor/${template.id}`)}>
+                    <ExternalLink className="mr-2 h-4 w-4" />
+                    Abrir
+                  </Button>
+                  <div className="flex items-center gap-2">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleExport(template)}
+                          disabled={exportingId === template.id}
+                          aria-label="Baixar PDF"
+                        >
+                          <Download className="h-4 w-4" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Baixar PDF</TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => {
+                            if (window.confirm('Deseja realmente excluir este modelo?')) {
+                              deleteMutation.mutate(template.id);
+                            }
+                          }}
+                          disabled={deleteMutation.isPending}
+                          aria-label="Excluir modelo"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Excluir</TooltipContent>
+                    </Tooltip>
+                  </div>
+                </div>
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/types/templates.ts
+++ b/frontend/src/types/templates.ts
@@ -1,0 +1,46 @@
+export interface EditorJsonNode {
+  type: string;
+  text?: string;
+  attrs?: Record<string, string>;
+  children?: EditorJsonNode[];
+}
+
+export type EditorJsonContent = EditorJsonNode[];
+
+export interface TemplateMetadata {
+  type: string;
+  area: string;
+  complexity: 'Baixa' | 'Média' | 'Alta' | string;
+  autoCreateClient: boolean;
+  autoCreateProcess: boolean;
+  visibility: 'privado' | 'equipe' | 'publico' | string;
+}
+
+export interface TemplateDTO {
+  id: number;
+  title: string;
+  content: string;
+}
+
+export interface Template extends TemplateDTO {
+  content_html: string;
+  content_editor_json: EditorJsonContent | null;
+  metadata: TemplateMetadata;
+}
+
+export interface TemplatePayload {
+  id?: number;
+  title: string;
+  content_html: string;
+  content_editor_json: EditorJsonContent | null;
+  metadata: TemplateMetadata;
+}
+
+export const defaultTemplateMetadata: TemplateMetadata = {
+  type: 'Documento',
+  area: 'Geral',
+  complexity: 'Média',
+  autoCreateClient: false,
+  autoCreateProcess: false,
+  visibility: 'privado',
+};


### PR DESCRIPTION
## Summary
- create a document editor feature module with toolbar, insert menu, metadata modal, sidebar navigation, and floating save button
- replace the editor page with a responsive content-editable WYSIWYG experience that supports variable tags, metadata capture, JSON serialization, and accessibility improvements
- redesign the template library with search, type filters, card previews, and inline actions while updating template utilities and styles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9594ac2b883268b564ebbaf79ed6c