### PR TITLE
Exibe tags e responsável no cabeçalho da conversa

### DIFF
--- a/frontend/src/features/chat/components/ChatSidebar.module.css
+++ b/frontend/src/features/chat/components/ChatSidebar.module.css
@@ -186,52 +186,6 @@
   opacity: 0.85;
 }
 
-.itemMeta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  align-items: center;
-  font-size: 0.78rem;
-  color: hsl(var(--muted-foreground));
-}
-
-.metaResponsible {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  padding: 0.2rem 0.55rem;
-  border-radius: 999px;
-  background: hsl(var(--sidebar-accent));
-  color: inherit;
-  font-weight: 500;
-}
-
-.itemButton[data-active="true"] .metaResponsible {
-  background: rgba(255, 255, 255, 0.2);
-  color: hsl(var(--sidebar-primary-foreground));
-}
-
-.metaTags {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  flex-wrap: wrap;
-}
-
-.tagChip {
-  background: hsl(var(--sidebar-accent));
-  border-radius: 999px;
-  padding: 0.15rem 0.5rem;
-  font-size: 0.72rem;
-  font-weight: 600;
-  color: inherit;
-}
-
-.itemButton[data-active="true"] .tagChip {
-  background: rgba(255, 255, 255, 0.22);
-  color: hsl(var(--sidebar-primary-foreground));
-}
-
 .timestamp {
   font-size: 0.8rem;
   color: hsl(var(--muted-foreground));

--- a/frontend/src/features/chat/components/ChatSidebar.tsx
+++ b/frontend/src/features/chat/components/ChatSidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { MessageCircle, Plus, Search, Pin, UserRound } from "lucide-react";
+import { MessageCircle, Plus, Search, Pin } from "lucide-react";
 import type { ConversationSummary } from "../types";
 import { formatConversationTimestamp, normalizeText } from "../utils/format";
 import styles from "./ChatSidebar.module.css";
@@ -194,26 +194,6 @@ export const ChatSidebar = ({
                       <div className={styles.itemPreview}>
                         {conversation.lastMessage?.sender === "me" && <span>Você:</span>}
                         <span>{preview}</span>
-                      </div>
-                      <div className={styles.itemMeta}>
-                        <span className={styles.metaResponsible}>
-                          <UserRound size={14} aria-hidden="true" />
-                          {conversation.responsible?.name ?? "Sem responsável"}
-                        </span>
-                        {conversation.tags.length > 0 && (
-                          <div className={styles.metaTags}>
-                            {conversation.tags.slice(0, 2).map((tag) => (
-                              <span key={tag} className={styles.tagChip}>
-                                {tag}
-                              </span>
-                            ))}
-                            {conversation.tags.length > 2 && (
-                              <span className={styles.tagChip} aria-label={`Mais ${conversation.tags.length - 2} etiquetas`}>
-                                +{conversation.tags.length - 2}
-                              </span>
-                            )}
-                          </div>
-                        )}
                       </div>
                     </div>
                     <div>

--- a/frontend/src/features/chat/components/ChatWindow.module.css
+++ b/frontend/src/features/chat/components/ChatWindow.module.css
@@ -47,7 +47,7 @@
 .headerText {
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
+  gap: 0.45rem;
 }
 
 .headerTitleRow {
@@ -56,10 +56,57 @@
   gap: 0.6rem;
 }
 
+.headerDetails {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
 .headerTitleRow h2 {
   font-size: 1.25rem;
   font-weight: 700;
   margin: 0;
+}
+
+.headerMeta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.headerResponsible {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.headerTags {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.headerTagChip {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.headerNoTags {
+  font-size: 0.8rem;
+  color: hsl(var(--muted-foreground));
 }
 
 .status {

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -283,8 +283,29 @@ export const ChatWindow = ({
                   </span>
                 )}
               </div>
-              <span className={styles.status}>{conversation.shortStatus}</span>
-              <span className={styles.phoneNumber}>{conversation.phoneNumber ?? "Telefone não informado"}</span>
+              <div className={styles.headerDetails}>
+                <span className={styles.status}>{conversation.shortStatus}</span>
+                <span className={styles.phoneNumber}>
+                  {conversation.phoneNumber ?? "Telefone não informado"}
+                </span>
+              </div>
+              <div className={styles.headerMeta}>
+                <span className={styles.headerResponsible}>
+                  <UserRound size={14} aria-hidden="true" />
+                  {conversation.responsible?.name ?? "Sem responsável"}
+                </span>
+                {conversation.tags.length > 0 ? (
+                  <div className={styles.headerTags}>
+                    {conversation.tags.map((tag) => (
+                      <span key={tag} className={styles.headerTagChip}>
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <span className={styles.headerNoTags}>Sem etiquetas</span>
+                )}
+              </div>
             </div>
           </div>
           <div className={styles.actions} ref={menuRef}>


### PR DESCRIPTION
## Summary
- remove a exibição de etiquetas e responsável dos itens da lista de conversas
- adiciona responsável e etiquetas no cabeçalho da conversa com novos estilos

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c973c103988326a0a08c595efa9c4f