### PR TITLE
Point dev frontend to production API

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,1 @@
+VITE_API_URL=https://jusconnec.quantumtecnologia.com.br

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -40,6 +40,8 @@ npm run dev
 
 O módulo de templates de documentos consome a API disponível em `http://localhost:3001/api`. Caso o backend esteja em outra URL, defina a variável de ambiente `VITE_API_URL` antes de iniciar o projeto. Caso contrário, o frontend utilizará automaticamente o mesmo domínio em que estiver publicado.
 
+Para facilitar o desenvolvimento utilizando a API de produção, o projeto inclui um arquivo `.env.development` com `VITE_API_URL=https://jusconnec.quantumtecnologia.com.br`. Assim, ao executar `npm run dev`, o frontend apontará automaticamente para os endpoints em produção.
+
 ## Conversas (Chat Omnichannel)
 
 Este projeto inclui uma área de conversas inspirada na experiência de mensageria profissional:


### PR DESCRIPTION
## Summary
- add a development environment file that pins `VITE_API_URL` to the production domain
- document the new setup so running the dev server uses the production API automatically

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9767af7648326bd4f6e555f9771d5