### PR TITLE
Implement Gemini AI text generation

### DIFF
--- a/backend/dist/services/aiProviders/errors.js
+++ b/backend/dist/services/aiProviders/errors.js
@@ -1,0 +1,11 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AiProviderError = void 0;
+class AiProviderError extends Error {
+    constructor(message, statusCode = 502) {
+        super(message);
+        this.statusCode = statusCode;
+        this.name = 'AiProviderError';
+    }
+}
+exports.AiProviderError = AiProviderError;

--- a/backend/dist/services/aiProviders/geminiProvider.js
+++ b/backend/dist/services/aiProviders/geminiProvider.js
@@ -1,0 +1,287 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.generateDocumentWithGemini = exports.convertPlainTextToHtml = exports.buildHtmlFromGeminiStructuredResponse = exports.parseGeminiStructuredResponse = void 0;
+const errors_1 = require("./errors");
+const html_1 = require("../../utils/html");
+const GEMINI_API_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta/models';
+const GEMINI_MODEL_BY_ENVIRONMENT = {
+    producao: 'gemini-2.5-flash',
+    homologacao: 'gemini-2.5-flash',
+};
+const mapGeminiStatusToHttp = (status) => {
+    if (status === 401 || status === 403) {
+        return 401;
+    }
+    if (status === 429) {
+        return 429;
+    }
+    if (status >= 500) {
+        return 502;
+    }
+    return 502;
+};
+const extractGeminiErrorMessage = (payload, status) => {
+    if (payload && typeof payload === 'object') {
+        const errorObject = payload.error;
+        const message = (errorObject === null || errorObject === void 0 ? void 0 : errorObject.message) || payload.message;
+        if (typeof message === 'string' && message.trim().length > 0) {
+            return message.trim();
+        }
+    }
+    return `Gemini API request failed with status ${status}`;
+};
+const buildGeminiPrompt = (documentType, prompt) => {
+    const sanitizedPrompt = prompt.trim();
+    return [
+        'Você é um assistente jurídico especializado em elaborar minutas estruturadas e coerentes.',
+        'Crie um rascunho detalhado para o documento descrito a seguir, mantendo linguagem formal e objetiva.',
+        'Responda exclusivamente em JSON com o formato:',
+        '{',
+        '  "intro": "Resumo introdutório do documento",',
+        '  "sections": [',
+        '    {',
+        '      "title": "Título da seção",',
+        '      "paragraphs": ["Parágrafo 1", "Parágrafo 2"],',
+        '      "bullets": ["Item opcional 1", "Item opcional 2"]',
+        '    }',
+        '  ],',
+        '  "highlights": ["Tópicos chave considerados"],',
+        '  "conclusion": "Orientações finais"',
+        '}',
+        'Regras:',
+        '- Utilize sempre português brasileiro.',
+        '- Inclua pelo menos duas seções relevantes.',
+        '- Limite cada seção a no máximo três parágrafos objetivos.',
+        '- Quando apropriado, utilize listas em "bullets" para destacar pontos importantes.',
+        '- Não adicione comentários fora do JSON especificado.',
+        `Tipo de documento: ${documentType}.`,
+        'Informações fornecidas:',
+        sanitizedPrompt ? `"""${sanitizedPrompt}"""` : 'Nenhum detalhe adicional fornecido.',
+    ].join('\n');
+};
+const toSafeString = (value) => {
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : null;
+    }
+    if (typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
+    }
+    if (value && typeof value === 'object' && 'text' in value) {
+        const potential = value.text;
+        if (typeof potential === 'string') {
+            const trimmed = potential.trim();
+            return trimmed.length > 0 ? trimmed : null;
+        }
+    }
+    return null;
+};
+const toStringArray = (value) => {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+    return value
+        .map(item => toSafeString(item))
+        .filter((item) => typeof item === 'string' && item.length > 0);
+};
+const firstNonEmptyString = (values) => {
+    for (const value of values) {
+        const normalized = toSafeString(value);
+        if (normalized) {
+            return normalized;
+        }
+    }
+    return null;
+};
+const cleanGeminiJsonPayload = (text) => {
+    let cleaned = text.trim();
+    cleaned = cleaned.replace(/^```(?:json)?\s*/i, '');
+    cleaned = cleaned.replace(/```\s*$/i, '');
+    return cleaned.trim();
+};
+const parseGeminiStructuredResponse = (text) => {
+    if (!text.trim()) {
+        return null;
+    }
+    const cleaned = cleanGeminiJsonPayload(text);
+    if (!cleaned) {
+        return null;
+    }
+    try {
+        const parsed = JSON.parse(cleaned);
+        if (!parsed || typeof parsed !== 'object') {
+            return null;
+        }
+        return parsed;
+    }
+    catch (error) {
+        return null;
+    }
+};
+exports.parseGeminiStructuredResponse = parseGeminiStructuredResponse;
+const buildHtmlFromGeminiStructuredResponse = (documentType, payload) => {
+    const htmlParts = [`<p><strong>${(0, html_1.escapeHtml)(documentType)}</strong></p>`];
+    const intro = firstNonEmptyString([payload.intro, payload.summary, payload.overview]);
+    if (intro) {
+        htmlParts.push(`<p>${(0, html_1.escapeHtml)(intro)}</p>`);
+    }
+    const sections = Array.isArray(payload.sections) ? payload.sections : [];
+    sections.forEach(section => {
+        const title = firstNonEmptyString([section.title]);
+        if (title) {
+            htmlParts.push(`<p><strong>${(0, html_1.escapeHtml)(title)}</strong></p>`);
+        }
+        const paragraphs = toStringArray(section.paragraphs);
+        paragraphs.forEach(paragraph => {
+            htmlParts.push(`<p>${(0, html_1.escapeHtml)(paragraph)}</p>`);
+        });
+        const bulletCandidates = [section.bullets, section.items, section.points];
+        const bulletSource = bulletCandidates.find(value => Array.isArray(value)) || [];
+        const bullets = toStringArray(bulletSource);
+        if (bullets.length > 0) {
+            htmlParts.push('<ul>');
+            bullets.forEach(item => {
+                htmlParts.push(`<li>${(0, html_1.escapeHtml)(item)}</li>`);
+            });
+            htmlParts.push('</ul>');
+        }
+    });
+    const highlights = toStringArray(payload.highlights || payload.directives || payload.topics);
+    if (highlights.length > 0) {
+        htmlParts.push('<p>Principais pontos considerados:</p>');
+        htmlParts.push('<ul>');
+        highlights.forEach(item => {
+            htmlParts.push(`<li>${(0, html_1.escapeHtml)(item)}</li>`);
+        });
+        htmlParts.push('</ul>');
+    }
+    const conclusion = firstNonEmptyString([payload.conclusion, payload.finalThoughts, payload.recommendations]);
+    if (conclusion) {
+        htmlParts.push(`<p>${(0, html_1.escapeHtml)(conclusion)}</p>`);
+    }
+    const notes = toStringArray(payload.additionalNotes || payload.notes || payload.disclaimer);
+    notes.forEach(note => {
+        htmlParts.push(`<p>${(0, html_1.escapeHtml)(note)}</p>`);
+    });
+    return htmlParts.join('');
+};
+exports.buildHtmlFromGeminiStructuredResponse = buildHtmlFromGeminiStructuredResponse;
+const convertPlainTextToHtml = (documentType, text) => {
+    const normalized = text.replace(/\r\n/g, '\n').trim();
+    const htmlParts = [`<p><strong>${(0, html_1.escapeHtml)(documentType)}</strong></p>`];
+    if (!normalized) {
+        return htmlParts.join('');
+    }
+    const lines = normalized.split('\n');
+    let listBuffer = [];
+    const flushList = () => {
+        if (listBuffer.length > 0) {
+            htmlParts.push('<ul>');
+            listBuffer.forEach(item => {
+                htmlParts.push(`<li>${(0, html_1.escapeHtml)(item)}</li>`);
+            });
+            htmlParts.push('</ul>');
+            listBuffer = [];
+        }
+    };
+    lines.forEach(rawLine => {
+        const line = rawLine.trim();
+        if (!line) {
+            flushList();
+            return;
+        }
+        const listMatch = line.match(/^[-*•]\s*(.+)$/);
+        if (listMatch) {
+            listBuffer.push(listMatch[1]);
+            return;
+        }
+        flushList();
+        htmlParts.push(`<p>${(0, html_1.escapeHtml)(line)}</p>`);
+    });
+    flushList();
+    return htmlParts.join('');
+};
+exports.convertPlainTextToHtml = convertPlainTextToHtml;
+const generateDocumentWithGemini = async ({ apiKey, documentType, prompt, environment, }) => {
+    const trimmedKey = apiKey.trim();
+    if (!trimmedKey) {
+        throw new errors_1.AiProviderError('A chave de API da integração não está configurada.', 400);
+    }
+    const model = GEMINI_MODEL_BY_ENVIRONMENT[environment] || GEMINI_MODEL_BY_ENVIRONMENT.producao;
+    const url = `${GEMINI_API_BASE_URL}/${model}:generateContent`;
+    const requestBody = {
+        contents: [
+            {
+                parts: [{ text: buildGeminiPrompt(documentType, prompt) }],
+            },
+        ],
+        generationConfig: {
+            thinkingConfig: {
+                thinkingBudget: 0,
+            },
+        },
+    };
+    let response;
+    try {
+        response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-goog-api-key': trimmedKey,
+            },
+            body: JSON.stringify(requestBody),
+        });
+    }
+    catch (error) {
+        throw new errors_1.AiProviderError(error instanceof Error ? `Falha ao contactar a API da Gemini: ${error.message}` : 'Falha ao contactar a API da Gemini.', 502);
+    }
+    const rawPayload = await response.text();
+    let parsedPayload = null;
+    if (rawPayload) {
+        try {
+            parsedPayload = JSON.parse(rawPayload);
+        }
+        catch (error) {
+            if (!response.ok) {
+                throw new errors_1.AiProviderError(`Gemini API request failed with status ${response.status}`, mapGeminiStatusToHttp(response.status));
+            }
+            throw new errors_1.AiProviderError('Resposta da Gemini em formato inválido.', 502);
+        }
+    }
+    if (!response.ok) {
+        const message = extractGeminiErrorMessage(parsedPayload, response.status);
+        throw new errors_1.AiProviderError(message, mapGeminiStatusToHttp(response.status));
+    }
+    const candidates = (parsedPayload === null || parsedPayload === void 0 ? void 0 : parsedPayload.candidates) || [];
+    const firstCandidate = candidates.find(candidate => {
+        const parts = candidate.content && Array.isArray(candidate.content.parts)
+            ? candidate.content.parts
+            : null;
+        if (!parts) {
+            return false;
+        }
+        return parts.some(part => typeof part.text === 'string' && part.text.trim().length > 0);
+    });
+    if (!firstCandidate) {
+        throw new errors_1.AiProviderError('A resposta da Gemini não continha conteúdo gerado.', 502);
+    }
+    const candidateParts = firstCandidate.content && Array.isArray(firstCandidate.content.parts)
+        ? firstCandidate.content.parts
+        : [];
+    const combinedText = candidateParts
+        .map(part => (typeof part.text === 'string' ? part.text : ''))
+        .join('\n')
+        .trim();
+    if (!combinedText) {
+        throw new errors_1.AiProviderError('A resposta da Gemini retornou texto vazio.', 502);
+    }
+    const structured = parseGeminiStructuredResponse(combinedText);
+    if (structured) {
+        const html = buildHtmlFromGeminiStructuredResponse(documentType, structured);
+        if (html.trim().length > 0) {
+            return html;
+        }
+    }
+    return convertPlainTextToHtml(documentType, combinedText);
+};
+exports.generateDocumentWithGemini = generateDocumentWithGemini;

--- a/backend/dist/utils/html.js
+++ b/backend/dist/utils/html.js
@@ -1,0 +1,12 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.escapeHtml = void 0;
+function escapeHtml(value) {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+exports.escapeHtml = escapeHtml;

--- a/backend/src/services/aiProviders/errors.ts
+++ b/backend/src/services/aiProviders/errors.ts
@@ -1,0 +1,7 @@
+export class AiProviderError extends Error {
+  constructor(message: string, public readonly statusCode = 502) {
+    super(message);
+    this.name = 'AiProviderError';
+  }
+}
+

--- a/backend/src/services/aiProviders/geminiProvider.ts
+++ b/backend/src/services/aiProviders/geminiProvider.ts
@@ -1,0 +1,390 @@
+import { AiProviderError } from './errors';
+import type { ApiKeyEnvironment } from '../integrationApiKeyService';
+import { escapeHtml } from '../../utils/html';
+
+interface GeminiGenerationParams {
+  apiKey: string;
+  documentType: string;
+  prompt: string;
+  environment: ApiKeyEnvironment;
+}
+
+interface GeminiCandidatePart {
+  text?: string;
+}
+
+interface GeminiCandidate {
+  content?: {
+    parts?: GeminiCandidatePart[];
+  };
+}
+
+interface GeminiResponsePayload {
+  candidates?: GeminiCandidate[];
+  error?: {
+    message?: string;
+  };
+}
+
+interface FetchResponseLike {
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+}
+
+export interface GeminiStructuredSection {
+  title?: unknown;
+  paragraphs?: unknown;
+  bullets?: unknown;
+  items?: unknown;
+  points?: unknown;
+}
+
+export interface GeminiStructuredResponse {
+  intro?: unknown;
+  summary?: unknown;
+  overview?: unknown;
+  sections?: unknown;
+  highlights?: unknown;
+  directives?: unknown;
+  topics?: unknown;
+  conclusion?: unknown;
+  finalThoughts?: unknown;
+  recommendations?: unknown;
+  additionalNotes?: unknown;
+  notes?: unknown;
+  disclaimer?: unknown;
+}
+
+const GEMINI_API_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta/models';
+const GEMINI_MODEL_BY_ENVIRONMENT: Record<ApiKeyEnvironment, string> = {
+  producao: 'gemini-2.5-flash',
+  homologacao: 'gemini-2.5-flash',
+};
+
+function mapGeminiStatusToHttp(status: number): number {
+  if (status === 401 || status === 403) {
+    return 401;
+  }
+  if (status === 429) {
+    return 429;
+  }
+  if (status >= 500) {
+    return 502;
+  }
+  return 502;
+}
+
+function extractGeminiErrorMessage(payload: unknown, status: number): string {
+  if (payload && typeof payload === 'object') {
+    const errorObject = (payload as { error?: { message?: unknown }; message?: unknown }).error;
+    const message = errorObject?.message ?? (payload as { message?: unknown }).message;
+    if (typeof message === 'string' && message.trim().length > 0) {
+      return message.trim();
+    }
+  }
+  return `Gemini API request failed with status ${status}`;
+}
+
+function buildGeminiPrompt(documentType: string, prompt: string): string {
+  const sanitizedPrompt = prompt.trim();
+  return [
+    'Você é um assistente jurídico especializado em elaborar minutas estruturadas e coerentes.',
+    'Crie um rascunho detalhado para o documento descrito a seguir, mantendo linguagem formal e objetiva.',
+    'Responda exclusivamente em JSON com o formato:',
+    '{',
+    '  "intro": "Resumo introdutório do documento",',
+    '  "sections": [',
+    '    {',
+    '      "title": "Título da seção",',
+    '      "paragraphs": ["Parágrafo 1", "Parágrafo 2"],',
+    '      "bullets": ["Item opcional 1", "Item opcional 2"]',
+    '    }',
+    '  ],',
+    '  "highlights": ["Tópicos chave considerados"],',
+    '  "conclusion": "Orientações finais"',
+    '}',
+    'Regras:',
+    '- Utilize sempre português brasileiro.',
+    '- Inclua pelo menos duas seções relevantes.',
+    '- Limite cada seção a no máximo três parágrafos objetivos.',
+    '- Quando apropriado, utilize listas em "bullets" para destacar pontos importantes.',
+    '- Não adicione comentários fora do JSON especificado.',
+    `Tipo de documento: ${documentType}.`,
+    'Informações fornecidas:',
+    sanitizedPrompt ? `"""${sanitizedPrompt}"""` : 'Nenhum detalhe adicional fornecido.',
+  ].join('\n');
+}
+
+function toSafeString(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (value && typeof value === 'object' && 'text' in (value as { text?: unknown })) {
+    const potential = (value as { text?: unknown }).text;
+    if (typeof potential === 'string') {
+      const trimmed = potential.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    }
+  }
+  return null;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map(item => toSafeString(item))
+    .filter((item): item is string => typeof item === 'string' && item.length > 0);
+}
+
+function firstNonEmptyString(values: unknown[]): string | null {
+  for (const value of values) {
+    const normalized = toSafeString(value);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return null;
+}
+
+function cleanGeminiJsonPayload(text: string): string {
+  let cleaned = text.trim();
+  cleaned = cleaned.replace(/^```(?:json)?\s*/i, '');
+  cleaned = cleaned.replace(/```\s*$/i, '');
+  return cleaned.trim();
+}
+
+export function parseGeminiStructuredResponse(text: string): GeminiStructuredResponse | null {
+  if (!text.trim()) {
+    return null;
+  }
+
+  const cleaned = cleanGeminiJsonPayload(text);
+
+  if (!cleaned) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(cleaned);
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+    return parsed as GeminiStructuredResponse;
+  } catch (error) {
+    return null;
+  }
+}
+
+export function buildHtmlFromGeminiStructuredResponse(
+  documentType: string,
+  payload: GeminiStructuredResponse,
+): string {
+  const htmlParts: string[] = [`<p><strong>${escapeHtml(documentType)}</strong></p>`];
+
+  const intro = firstNonEmptyString([payload.intro, payload.summary, payload.overview]);
+  if (intro) {
+    htmlParts.push(`<p>${escapeHtml(intro)}</p>`);
+  }
+
+  const sections: GeminiStructuredSection[] = Array.isArray(payload.sections)
+    ? (payload.sections as GeminiStructuredSection[])
+    : [];
+
+  sections.forEach(section => {
+    const title = firstNonEmptyString([section.title]);
+    if (title) {
+      htmlParts.push(`<p><strong>${escapeHtml(title)}</strong></p>`);
+    }
+
+    const paragraphs = toStringArray(section.paragraphs);
+    paragraphs.forEach(paragraph => {
+      htmlParts.push(`<p>${escapeHtml(paragraph)}</p>`);
+    });
+
+    const bulletCandidates = [section.bullets, section.items, section.points];
+    const bullets = toStringArray(bulletCandidates.find(value => Array.isArray(value)) ?? []);
+    if (bullets.length > 0) {
+      htmlParts.push('<ul>');
+      bullets.forEach(item => {
+        htmlParts.push(`<li>${escapeHtml(item)}</li>`);
+      });
+      htmlParts.push('</ul>');
+    }
+  });
+
+  const highlights = toStringArray(payload.highlights ?? payload.directives ?? payload.topics);
+  if (highlights.length > 0) {
+    htmlParts.push('<p>Principais pontos considerados:</p>');
+    htmlParts.push('<ul>');
+    highlights.forEach(item => {
+      htmlParts.push(`<li>${escapeHtml(item)}</li>`);
+    });
+    htmlParts.push('</ul>');
+  }
+
+  const conclusion = firstNonEmptyString([payload.conclusion, payload.finalThoughts, payload.recommendations]);
+  if (conclusion) {
+    htmlParts.push(`<p>${escapeHtml(conclusion)}</p>`);
+  }
+
+  const notes = toStringArray(payload.additionalNotes ?? payload.notes ?? payload.disclaimer);
+  notes.forEach(note => {
+    htmlParts.push(`<p>${escapeHtml(note)}</p>`);
+  });
+
+  return htmlParts.join('');
+}
+
+export function convertPlainTextToHtml(documentType: string, text: string): string {
+  const normalized = text.replace(/\r\n/g, '\n').trim();
+  const htmlParts: string[] = [`<p><strong>${escapeHtml(documentType)}</strong></p>`];
+
+  if (!normalized) {
+    return htmlParts.join('');
+  }
+
+  const lines = normalized.split('\n');
+  let listBuffer: string[] = [];
+
+  const flushList = () => {
+    if (listBuffer.length > 0) {
+      htmlParts.push('<ul>');
+      listBuffer.forEach(item => {
+        htmlParts.push(`<li>${escapeHtml(item)}</li>`);
+      });
+      htmlParts.push('</ul>');
+      listBuffer = [];
+    }
+  };
+
+  lines.forEach(rawLine => {
+    const line = rawLine.trim();
+    if (!line) {
+      flushList();
+      return;
+    }
+
+    const listMatch = line.match(/^[-*•]\s*(.+)$/);
+    if (listMatch) {
+      listBuffer.push(listMatch[1]);
+      return;
+    }
+
+    flushList();
+    htmlParts.push(`<p>${escapeHtml(line)}</p>`);
+  });
+
+  flushList();
+
+  return htmlParts.join('');
+}
+
+export async function generateDocumentWithGemini({
+  apiKey,
+  documentType,
+  prompt,
+  environment,
+}: GeminiGenerationParams): Promise<string> {
+  const trimmedKey = apiKey.trim();
+  if (!trimmedKey) {
+    throw new AiProviderError('A chave de API da integração não está configurada.', 400);
+  }
+
+  const model = GEMINI_MODEL_BY_ENVIRONMENT[environment] ?? GEMINI_MODEL_BY_ENVIRONMENT.producao;
+  const url = `${GEMINI_API_BASE_URL}/${model}:generateContent`;
+
+  const requestBody = {
+    contents: [
+      {
+        parts: [{ text: buildGeminiPrompt(documentType, prompt) }],
+      },
+    ],
+    generationConfig: {
+      thinkingConfig: {
+        thinkingBudget: 0,
+      },
+    },
+  };
+
+  let response: FetchResponseLike;
+  try {
+    response = (await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': trimmedKey,
+      },
+      body: JSON.stringify(requestBody),
+    })) as FetchResponseLike;
+  } catch (error) {
+    throw new AiProviderError(
+      error instanceof Error
+        ? `Falha ao contactar a API da Gemini: ${error.message}`
+        : 'Falha ao contactar a API da Gemini.',
+      502,
+    );
+  }
+
+  const rawPayload = await response.text();
+  let parsedPayload: GeminiResponsePayload | null = null;
+
+  if (rawPayload) {
+    try {
+      parsedPayload = JSON.parse(rawPayload) as GeminiResponsePayload;
+    } catch (error) {
+      if (!response.ok) {
+        throw new AiProviderError(
+          `Gemini API request failed with status ${response.status}`,
+          mapGeminiStatusToHttp(response.status),
+        );
+      }
+      throw new AiProviderError('Resposta da Gemini em formato inválido.', 502);
+    }
+  }
+
+  if (!response.ok) {
+    const message = extractGeminiErrorMessage(parsedPayload, response.status);
+    throw new AiProviderError(message, mapGeminiStatusToHttp(response.status));
+  }
+
+  const candidates = parsedPayload?.candidates ?? [];
+  const firstCandidate = candidates.find(candidate => {
+    const parts = candidate.content?.parts;
+    if (!Array.isArray(parts)) {
+      return false;
+    }
+    return parts.some(part => typeof part.text === 'string' && part.text.trim().length > 0);
+  });
+
+  if (!firstCandidate) {
+    throw new AiProviderError('A resposta da Gemini não continha conteúdo gerado.', 502);
+  }
+
+  const combinedText = firstCandidate.content?.parts
+    ?.map(part => (typeof part.text === 'string' ? part.text : ''))
+    .join('\n')
+    .trim();
+
+  if (!combinedText) {
+    throw new AiProviderError('A resposta da Gemini retornou texto vazio.', 502);
+  }
+
+  const structured = parseGeminiStructuredResponse(combinedText);
+
+  if (structured) {
+    const html = buildHtmlFromGeminiStructuredResponse(documentType, structured);
+    if (html.trim().length > 0) {
+      return html;
+    }
+  }
+
+  return convertPlainTextToHtml(documentType, combinedText);
+}
+

--- a/backend/src/utils/html.ts
+++ b/backend/src/utils/html.ts
@@ -1,0 +1,9 @@
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+

--- a/backend/tests/geminiProvider.test.ts
+++ b/backend/tests/geminiProvider.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  buildHtmlFromGeminiStructuredResponse,
+  convertPlainTextToHtml,
+  parseGeminiStructuredResponse,
+} from '../src/services/aiProviders/geminiProvider';
+
+test('parseGeminiStructuredResponse removes code fences and parses JSON', () => {
+  const raw = `\n\n\n\u0060\u0060\u0060json\n{\n  "intro": "Resumo",\n  "sections": [\n    {\n      "title": "Seção 1",\n      "paragraphs": ["Primeiro parágrafo"]\n    }\n  ],\n  "highlights": ["Ponto A"],\n  "conclusion": "Final"\n}\n\u0060\u0060\u0060`;
+  const parsed = parseGeminiStructuredResponse(raw);
+
+  assert(parsed);
+  assert.equal(typeof parsed?.intro, 'string');
+  assert.ok(Array.isArray(parsed?.sections));
+});
+
+test('buildHtmlFromGeminiStructuredResponse renders headings, paragraphs and lists', () => {
+  const html = buildHtmlFromGeminiStructuredResponse('Petição Inicial', {
+    intro: 'Introdução do documento.',
+    sections: [
+      {
+        title: 'Fatos Relevantes',
+        paragraphs: ['Descrição do caso em questão.'],
+        bullets: ['Parte autora', 'Parte ré'],
+      },
+    ],
+    highlights: ['Prazo de contestação', 'Requerimentos principais'],
+    conclusion: 'Solicita-se deferimento conforme fundamentos apresentados.',
+  });
+
+  assert.match(html, /<strong>Petição Inicial<\/strong>/);
+  assert.match(html, /<p>Introdução do documento\.<\/p>/);
+  assert.match(html, /<p><strong>Fatos Relevantes<\/strong><\/p>/);
+  assert.match(html, /<li>Parte autora<\/li>/);
+  assert.match(html, /<li>Requerimentos principais<\/li>/);
+  assert.match(html, /Solicita-se deferimento/);
+});
+
+test('convertPlainTextToHtml converts bullet lists and paragraphs safely', () => {
+  const html = convertPlainTextToHtml(
+    'Contrato de Prestação de Serviços',
+    'Cláusulas principais:\n- Prazo de 12 meses\n- Renegociação automática\n\nAs partes concordam com os termos.',
+  );
+
+  assert.match(html, /<strong>Contrato de Prestação de Serviços<\/strong>/);
+  assert.match(html, /<li>Prazo de 12 meses<\/li>/);
+  assert.match(html, /<li>Renegociação automática<\/li>/);
+  assert.match(html, /As partes concordam com os termos\./);
+});
+


### PR DESCRIPTION
## Summary
- call Gemini integrations from the template editor endpoint while preserving the fallback generator
- add a Gemini provider service that builds prompts, parses structured responses, sanitises HTML output, and now targets the gemini-2.5-flash endpoint using the required x-goog-api-key header and thinking configuration
- introduce reusable AI provider error handling, HTML escaping utilities, and dedicated unit tests for the Gemini helpers

## Testing
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68c97bcb6bd0832690106cd22a3c39b6