### PR TITLE
Fix CronJobsService initial reference lookback

### DIFF
--- a/backend/dist/services/cronJobs.js
+++ b/backend/dist/services/cronJobs.js
@@ -43,12 +43,15 @@ class CronJobsService {
         this.projudiTimer = null;
         this.projudiRunning = false;
         this.projudiService = service;
+        const intervalMs = this.resolveIntervalFromEnv();
+        const lookbackMs = this.resolveLookbackFromEnv();
+        const overlapMs = this.resolveOverlapFromEnv();
         this.projudiState = {
             enabled: false,
-            intervalMs: this.resolveIntervalFromEnv(),
-            lookbackMs: this.resolveLookbackFromEnv(),
-            overlapMs: this.resolveOverlapFromEnv(),
-            nextReference: this.computeInitialReference(),
+            intervalMs,
+            lookbackMs,
+            overlapMs,
+            nextReference: this.computeInitialReference(lookbackMs),
             lastReferenceUsed: null,
             lastRunAt: null,
             lastSuccessAt: null,
@@ -165,9 +168,10 @@ class CronJobsService {
         const overlap = this.projudiState.overlapMs ?? DEFAULT_OVERLAP_MS;
         return new Date(now - overlap);
     }
-    computeInitialReference() {
+    computeInitialReference(lookbackMs) {
         const now = Date.now();
-        return new Date(now - this.projudiState.lookbackMs);
+        const effectiveLookbackMs = lookbackMs ?? this.projudiState.lookbackMs;
+        return new Date(now - effectiveLookbackMs);
     }
     resolveIntervalFromEnv() {
         const ms = parsePositiveNumber(process.env.PROJUDI_SYNC_INTERVAL_MS);

--- a/backend/src/services/cronJobs.ts
+++ b/backend/src/services/cronJobs.ts
@@ -47,12 +47,17 @@ export class CronJobsService {
 
   constructor(service: ProjudiNotificationService = projudiNotificationService) {
     this.projudiService = service;
+
+    const intervalMs = this.resolveIntervalFromEnv();
+    const lookbackMs = this.resolveLookbackFromEnv();
+    const overlapMs = this.resolveOverlapFromEnv();
+
     this.projudiState = {
       enabled: false,
-      intervalMs: this.resolveIntervalFromEnv(),
-      lookbackMs: this.resolveLookbackFromEnv(),
-      overlapMs: this.resolveOverlapFromEnv(),
-      nextReference: this.computeInitialReference(),
+      intervalMs,
+      lookbackMs,
+      overlapMs,
+      nextReference: this.computeInitialReference(lookbackMs),
       lastReferenceUsed: null,
       lastRunAt: null,
       lastSuccessAt: null,
@@ -192,9 +197,10 @@ export class CronJobsService {
     return new Date(now - overlap);
   }
 
-  private computeInitialReference(): Date {
+  private computeInitialReference(lookbackMs?: number): Date {
     const now = Date.now();
-    return new Date(now - this.projudiState.lookbackMs);
+    const effectiveLookbackMs = lookbackMs ?? this.projudiState.lookbackMs;
+    return new Date(now - effectiveLookbackMs);
   }
 
   private resolveIntervalFromEnv(): number {


### PR DESCRIPTION
## Summary
- ensure the cron job state resolves interval, lookback and overlap before initializing
- compute the initial reference date with the resolved lookback value to avoid undefined state access

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c99940bb94832697b928ae6aac629c