### PR TITLE
Fix register and forgot password routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { CRMLayout } from "@/components/layout/CRMLayout";
+import { routes } from "@/config/routes";
 import Dashboard from "./pages/Dashboard";
 import Clientes from "./pages/Clientes";
 import NovoCliente from "./pages/NovoCliente";
@@ -54,6 +55,7 @@ import SessaoDispositivos from "./pages/configuracoes/usuarios/SessaoDispositivo
 import PrivacidadeLGPD from "./pages/configuracoes/usuarios/PrivacidadeLGPD";
 import NotificacoesPreferencias from "./pages/configuracoes/usuarios/NotificacoesPreferencias";
 import Login from "./pages/Login";
+import Register from "./pages/Register";
 import RecuperarSenha from "./pages/RecuperarSenha";
 import NotFound from "./pages/NotFound";
 
@@ -66,8 +68,9 @@ const App = () => (
       <Sonner />
       <BrowserRouter>
         <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route path="/recuperar-senha" element={<RecuperarSenha />} />
+          <Route path={routes.login} element={<Login />} />
+          <Route path={routes.register} element={<Register />} />
+          <Route path={routes.forgotPassword} element={<RecuperarSenha />} />
           <Route element={<CRMLayout />}>
             <Route path="/" element={<Dashboard />} />
             <Route path="/conversas" element={<Conversas />} />

--- a/frontend/src/config/routes.ts
+++ b/frontend/src/config/routes.ts
@@ -6,7 +6,7 @@ export const routes = {
   home: route("/"),
   login: route("/login"),
   register: route("/register"),
-  forgotPassword: route("/forgot-password"),
+  forgotPassword: route("/recuperar-senha"),
   admin: {
     root: route(appConfig.adminBasePath),
     dashboard: route(appConfig.adminBasePath),


### PR DESCRIPTION
## Summary
- add the register page to the router so it can be opened from the login link
- update the forgot password path constant and reuse route constants in the router

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9b20eb020832699e22ecaf6ae80b0