### PR TITLE
Adjust WAHA integration to match sendText API

### DIFF
--- a/backend/src/routes/chatRoutes.ts
+++ b/backend/src/routes/chatRoutes.ts
@@ -14,13 +14,534 @@ import {
 
 const router = Router();
 
+/**
+ * @swagger
+ * tags:
+ *   - name: Conversas
+ *     description: Endpoints para gerenciamento de conversas e integrações de mensagens
+ *   - name: Integrações
+ *     description: Integrações com plataformas externas de comunicação
+ * components:
+ *   schemas:
+ *     ChatMessageAttachment:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *           description: Identificador único do anexo
+ *         type:
+ *           type: string
+ *           description: Tipo de arquivo do anexo
+ *           enum: [image]
+ *         url:
+ *           type: string
+ *           format: uri
+ *           description: URL pública para download do arquivo
+ *         name:
+ *           type: string
+ *           description: Nome amigável do arquivo
+ *     ChatMessage:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *         conversationId:
+ *           type: string
+ *         sender:
+ *           type: string
+ *           enum: [me, contact]
+ *           description: Indica se a mensagem foi enviada pelo operador ou pelo contato
+ *         content:
+ *           type: string
+ *         timestamp:
+ *           type: string
+ *           format: date-time
+ *         status:
+ *           type: string
+ *           enum: [sent, delivered, read]
+ *         type:
+ *           type: string
+ *           enum: [text, image]
+ *         attachments:
+ *           type: array
+ *           nullable: true
+ *           items:
+ *             $ref: '#/components/schemas/ChatMessageAttachment'
+ *     ConversationLastMessage:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *         content:
+ *           type: string
+ *           description: Conteúdo completo armazenado para a pré-visualização
+ *         preview:
+ *           type: string
+ *           description: Texto reduzido apresentado na listagem de conversas
+ *         timestamp:
+ *           type: string
+ *           format: date-time
+ *         sender:
+ *           type: string
+ *           enum: [me, contact]
+ *         type:
+ *           type: string
+ *           enum: [text, image]
+ *         status:
+ *           type: string
+ *           enum: [sent, delivered, read]
+ *     ConversationSummary:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *         name:
+ *           type: string
+ *         avatar:
+ *           type: string
+ *           description: Avatar calculado para o contato
+ *         shortStatus:
+ *           type: string
+ *         description:
+ *           type: string
+ *         unreadCount:
+ *           type: integer
+ *           format: int32
+ *         pinned:
+ *           type: boolean
+ *         lastMessage:
+ *           $ref: '#/components/schemas/ConversationLastMessage'
+ *           nullable: true
+ *     MessagePage:
+ *       type: object
+ *       properties:
+ *         messages:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/ChatMessage'
+ *         nextCursor:
+ *           type: string
+ *           format: date-time
+ *           nullable: true
+ *           description: Cursor a ser enviado na próxima requisição para continuar a paginação
+ *     CreateConversationRequest:
+ *       type: object
+ *       description: Payload utilizado para criar ou atualizar conversas. Informe pelo menos contactIdentifier ou id.
+ *       properties:
+ *         id:
+ *           type: string
+ *           description: Identificador interno da conversa; caso omitido utiliza-se contactIdentifier
+ *         contactIdentifier:
+ *           type: string
+ *           description: Identificador do contato ou chat no provedor externo
+ *         contactName:
+ *           type: string
+ *         description:
+ *           type: string
+ *         shortStatus:
+ *           type: string
+ *         avatar:
+ *           type: string
+ *         pinned:
+ *           type: boolean
+ *         metadata:
+ *           type: object
+ *           nullable: true
+ *           additionalProperties: true
+ *     SendMessageRequest:
+ *       type: object
+ *       required:
+ *         - content
+ *       properties:
+ *         content:
+ *           type: string
+ *           description: Conteúdo textual da mensagem a ser enviada
+ *         type:
+ *           type: string
+ *           enum: [text, image]
+ *           description: Tipo de mensagem. Por padrão envia mensagem de texto
+ *         attachments:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/ChatMessageAttachment'
+ *           description: Lista de anexos a ser enviada junto com a mensagem
+ *           nullable: true
+ *     ErrorResponse:
+ *       type: object
+ *       properties:
+ *         error:
+ *           type: string
+ *           description: Mensagem detalhando o motivo do erro
+ *     WahaIntegrationConfig:
+ *       type: object
+ *       required:
+ *         - baseUrl
+ *         - apiKey
+ *         - isActive
+ *         - createdAt
+ *         - updatedAt
+ *       properties:
+ *         baseUrl:
+ *           type: string
+ *           format: uri
+ *           description: URL base do servidor WAHA, sem barra no final
+ *         apiKey:
+ *           type: string
+ *           description: Chave utilizada para autenticar as requisições ao WAHA
+ *         webhookSecret:
+ *           type: string
+ *           nullable: true
+ *           description: Segredo opcional para validação do webhook recebido
+ *         isActive:
+ *           type: boolean
+ *           description: Indica se a integração está ativa para envio/recebimento de mensagens
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *           description: Data de criação do registro de configuração
+ *         updatedAt:
+ *           type: string
+ *           format: date-time
+ *           description: Data da última atualização da configuração
+ */
+
+/**
+ * @swagger
+ * /api/conversations:
+ *   get:
+ *     summary: Lista todas as conversas cadastradas
+ *     tags: [Conversas]
+ *     responses:
+ *       200:
+ *         description: Lista de conversas ordenadas pela atividade mais recente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/ConversationSummary'
+ *       500:
+ *         description: Erro interno ao listar conversas
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
 router.get('/conversations', listConversationsHandler);
+
+/**
+ * @swagger
+ * /api/conversations:
+ *   post:
+ *     summary: Cria ou atualiza uma conversa manualmente
+ *     tags: [Conversas]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CreateConversationRequest'
+ *           examples:
+ *             default:
+ *               summary: Exemplo de criação de conversa
+ *               value:
+ *                 contactIdentifier: 5511999999999@c.us
+ *                 contactName: Cliente Teste
+ *                 shortStatus: Novo lead
+ *                 pinned: false
+ *     responses:
+ *       201:
+ *         description: Conversa criada ou atualizada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ConversationSummary'
+ *       400:
+ *         description: Dados inválidos enviados para criação da conversa
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno ao criar a conversa
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
 router.post('/conversations', createConversationHandler);
+
+/**
+ * @swagger
+ * /api/conversations/{conversationId}/messages:
+ *   get:
+ *     summary: Lista mensagens de uma conversa
+ *     tags: [Conversas]
+ *     parameters:
+ *       - in: path
+ *         name: conversationId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identificador da conversa
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *         description: Quantidade máxima de mensagens retornadas por página (padrão 20)
+ *       - in: query
+ *         name: cursor
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *         description: Cursor utilizado para paginação reversa das mensagens
+ *     responses:
+ *       200:
+ *         description: Página de mensagens retornada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/MessagePage'
+ *       404:
+ *         description: Conversa não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno ao listar mensagens
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
 router.get('/conversations/:conversationId/messages', getConversationMessagesHandler);
+
+/**
+ * @swagger
+ * /api/conversations/{conversationId}/messages:
+ *   post:
+ *     summary: Envia uma mensagem através da integração WAHA
+ *     tags: [Conversas]
+ *     parameters:
+ *       - in: path
+ *         name: conversationId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identificador da conversa
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/SendMessageRequest'
+ *           examples:
+ *             texto:
+ *               summary: Envio de mensagem de texto
+ *               value:
+ *                 content: Olá, podemos ajudar?
+ *             imagem:
+ *               summary: Envio de imagem com legenda
+ *               value:
+ *                 content: Veja o documento em anexo
+ *                 type: image
+ *                 attachments:
+ *                   - id: file-123
+ *                     type: image
+ *                     name: comprovante.png
+ *                     url: https://example.com/comprovante.png
+ *     responses:
+ *       201:
+ *         description: Mensagem registrada e enviada ao provedor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ChatMessage'
+ *       400:
+ *         description: Dados inválidos para envio da mensagem
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       503:
+ *         description: Integração WAHA não configurada ou desativada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       502:
+ *         description: Erro ao entregar a mensagem ao provedor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
 router.post('/conversations/:conversationId/messages', sendConversationMessageHandler);
+
+/**
+ * @swagger
+ * /api/conversations/{conversationId}/read:
+ *   post:
+ *     summary: Marca todas as mensagens da conversa como lidas
+ *     tags: [Conversas]
+ *     parameters:
+ *       - in: path
+ *         name: conversationId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identificador da conversa
+ *     responses:
+ *       204:
+ *         description: Conversa marcada como lida com sucesso
+ *       404:
+ *         description: Conversa não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno ao atualizar a conversa
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
 router.post('/conversations/:conversationId/read', markConversationReadHandler);
+
+/**
+ * @swagger
+ * /api/webhooks/waha:
+ *   post:
+ *     summary: Recebe eventos de mensagens do WAHA
+ *     tags: [Integrações]
+ *     requestBody:
+ *       required: true
+ *       description: Payload de webhook encaminhado pelo servidor WAHA
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             additionalProperties: true
+ *     responses:
+ *       204:
+ *         description: Webhook processado com sucesso
+ *       400:
+ *         description: Payload inválido recebido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Falha na validação da assinatura do webhook
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       503:
+ *         description: Integração WAHA desativada ou não configurada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro inesperado ao processar o webhook
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
 router.post('/webhooks/waha', wahaWebhookHandler);
+
+/**
+ * @swagger
+ * /api/integrations/waha:
+ *   get:
+ *     summary: Obtém a configuração atual da integração com o WAHA
+ *     tags: [Integrações]
+ *     responses:
+ *       200:
+ *         description: Configuração encontrada ou null caso não exista
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WahaIntegrationConfig'
+ *               nullable: true
+ *             examples:
+ *               configurado:
+ *                 summary: Configuração ativa
+ *                 value:
+ *                   baseUrl: https://waha.example.com
+ *                   apiKey: super-secret
+ *                   webhookSecret: webhook-secret
+ *                   isActive: true
+ *                   createdAt: '2024-05-05T12:00:00.000Z'
+ *                   updatedAt: '2024-05-06T08:30:00.000Z'
+ *               naoConfigurado:
+ *                 summary: Configuração ausente
+ *                 value: null
+ *       500:
+ *         description: Erro interno ao carregar a configuração
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
 router.get('/integrations/waha', getWahaConfigHandler);
+
+/**
+ * @swagger
+ * /api/integrations/waha:
+ *   put:
+ *     summary: Cria ou atualiza a configuração da integração com o WAHA
+ *     tags: [Integrações]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - baseUrl
+ *               - apiKey
+ *             properties:
+ *               baseUrl:
+ *                 type: string
+ *                 format: uri
+ *                 example: https://waha.example.com
+ *               apiKey:
+ *                 type: string
+ *                 example: super-secret
+ *               webhookSecret:
+ *                 type: string
+ *                 nullable: true
+ *                 example: webhook-secret
+ *               isActive:
+ *                 type: boolean
+ *                 example: true
+ *     responses:
+ *       200:
+ *         description: Configuração salva com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WahaIntegrationConfig'
+ *       400:
+ *         description: Dados inválidos enviados para configuração
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno ao salvar a configuração
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
 router.put('/integrations/waha', updateWahaConfigHandler);
 
 export default router;

--- a/backend/src/services/chatService.ts
+++ b/backend/src/services/chatService.ts
@@ -498,12 +498,15 @@ export default class ChatService {
        )
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
        ON CONFLICT (id) DO UPDATE
-         SET contact_identifier = COALESCE(chat_conversations.contact_identifier, EXCLUDED.contact_identifier),
-             contact_name = COALESCE(chat_conversations.contact_name, EXCLUDED.contact_name),
-             contact_avatar = COALESCE(chat_conversations.contact_avatar, EXCLUDED.contact_avatar),
-             short_status = COALESCE(chat_conversations.short_status, EXCLUDED.short_status),
-             description = COALESCE(chat_conversations.description, EXCLUDED.description),
-             metadata = COALESCE(chat_conversations.metadata, EXCLUDED.metadata)
+        SET contact_identifier = COALESCE(chat_conversations.contact_identifier, EXCLUDED.contact_identifier),
+            contact_name = COALESCE(chat_conversations.contact_name, EXCLUDED.contact_name),
+            contact_avatar = COALESCE(chat_conversations.contact_avatar, EXCLUDED.contact_avatar),
+            short_status = COALESCE(chat_conversations.short_status, EXCLUDED.short_status),
+            description = COALESCE(chat_conversations.description, EXCLUDED.description),
+            metadata = CASE
+              WHEN chat_conversations.metadata IS NULL AND EXCLUDED.metadata IS NULL THEN NULL
+              ELSE COALESCE(chat_conversations.metadata, '{}'::jsonb) || COALESCE(EXCLUDED.metadata, '{}'::jsonb)
+            END
        RETURNING id, contact_identifier, contact_name, contact_avatar, short_status, description, pinned,
                  unread_count, last_message_id, last_message_preview, last_message_timestamp,
                  last_message_sender, last_message_type, last_message_status, metadata, created_at, updated_at`,

--- a/backend/src/services/wahaConfigService.ts
+++ b/backend/src/services/wahaConfigService.ts
@@ -41,6 +41,27 @@ interface WahaSettingsRow extends QueryResultRow {
   updated_at: string | Date;
 }
 
+function stripKnownSuffixes(pathname: string): string {
+  let result = pathname;
+  const suffixes = [
+    /\/v1\/messages$/i,
+    /\/v1$/i,
+    /\/api\/send[a-z]+$/i,
+    /\/api$/i,
+  ];
+  let updated = true;
+  while (updated) {
+    updated = false;
+    for (const suffix of suffixes) {
+      if (suffix.test(result)) {
+        result = result.replace(suffix, '');
+        updated = true;
+      }
+    }
+  }
+  return result.replace(/\/$/, '');
+}
+
 function normalizeBaseUrl(value: string | undefined): string {
   if (typeof value !== 'string') {
     throw new ValidationError('baseUrl is required');
@@ -58,7 +79,7 @@ function normalizeBaseUrl(value: string | undefined): string {
   if (!['http:', 'https:'].includes(parsed.protocol)) {
     throw new ValidationError('baseUrl must use http or https');
   }
-  parsed.pathname = parsed.pathname.replace(/\/$/, '');
+  parsed.pathname = stripKnownSuffixes(parsed.pathname);
   parsed.hash = '';
   return parsed.toString().replace(/\/$/, '');
 }

--- a/backend/src/services/wahaIntegrationService.ts
+++ b/backend/src/services/wahaIntegrationService.ts
@@ -122,6 +122,7 @@ interface NormalizedIncomingMessage {
   type: ChatMessageType;
   senderName?: string;
   attachments?: MessageAttachment[];
+  sessionId?: string;
 }
 
 interface StatusUpdate {
@@ -261,7 +262,7 @@ function collectAttachments(candidate: any, _type: ChatMessageType): MessageAtta
   return attachments.length > 0 ? attachments : undefined;
 }
 
-function parseIncomingMessage(candidate: any): NormalizedIncomingMessage | null {
+function parseIncomingMessage(candidate: any, inheritedSessionId?: string): NormalizedIncomingMessage | null {
   if (!candidate || typeof candidate !== 'object') {
     return null;
   }
@@ -281,11 +282,16 @@ function parseIncomingMessage(candidate: any): NormalizedIncomingMessage | null 
     candidate.chatId,
     candidate.chat?.id,
     candidate.chat?.jid,
+    candidate.chat?.remoteJid,
     candidate.from,
+    candidate.to,
     candidate.remoteJid,
     candidate.author,
     candidate.key?.remoteJid,
+    candidate.key?.participant,
     candidate._data?.from,
+    candidate._data?.remoteJid,
+    candidate._data?.Info?.Chat,
   );
   if (!conversationIdCandidate) {
     return null;
@@ -294,16 +300,23 @@ function parseIncomingMessage(candidate: any): NormalizedIncomingMessage | null 
   const messageIdCandidate = firstNonEmpty(
     candidate.id,
     candidate.messageId,
+    candidate.message_id,
     candidate._id,
     candidate.key?.id,
     candidate.message?.key?.id,
+    candidate._data?.id,
+    candidate._data?.key?.id,
+    candidate._data?.Info?.ID,
+    candidate.media?.Info?.ID,
   );
 
   const externalIdCandidate = firstNonEmpty(
     candidate.externalId,
     candidate.key?.id,
     candidate.messageId,
+    candidate.message_id,
     candidate.id,
+    candidate._data?.Info?.ID,
   );
 
   if (!messageIdCandidate && !externalIdCandidate) {
@@ -314,8 +327,14 @@ function parseIncomingMessage(candidate: any): NormalizedIncomingMessage | null 
     candidate.timestamp,
     candidate.ts,
     candidate.sentAt,
+    candidate.sent_at,
     candidate.messageTimestamp,
+    candidate.message?.timestamp,
+    candidate.message?.messageTimestamp,
     candidate._data?.t,
+    candidate._data?.timestamp,
+    candidate._data?.Info?.Timestamp,
+    candidate._data?.Info?.MessageTimestamp,
   );
   const timestamp = normalizeTimestamp(timestampCandidate);
 
@@ -325,11 +344,20 @@ function parseIncomingMessage(candidate: any): NormalizedIncomingMessage | null 
     candidate.message?.conversation,
     candidate.message?.text,
     candidate.message?.extendedTextMessage?.text,
+    candidate.message?.message?.conversation,
+    candidate.message?.message?.extendedTextMessage?.text,
+    candidate.caption,
     candidate._data?.body,
+    candidate.media?.Message?.conversation,
   );
   const rawContent = typeof contentCandidate === 'string' ? contentCandidate.trim() : '';
 
-  const typeCandidate = firstNonEmpty(candidate.type, candidate.message?.type, candidate._data?.type);
+  const typeCandidate = firstNonEmpty(
+    candidate.type,
+    candidate.message?.type,
+    candidate._data?.type,
+    candidate.media?.Info?.Type,
+  );
   const attachments = collectAttachments(candidate, normalizeMessageType(typeCandidate, false));
   const type = normalizeMessageType(typeCandidate, Boolean(attachments && attachments.length > 0));
 
@@ -339,9 +367,21 @@ function parseIncomingMessage(candidate: any): NormalizedIncomingMessage | null 
     candidate.chat?.name,
     candidate.pushName,
     candidate.notifyName,
+    candidate._data?.pushName,
+    candidate._data?.notifyName,
   );
 
   const content = rawContent || (attachments && attachments.length > 0 ? 'Arquivo recebido' : 'Mensagem recebida');
+
+  const sessionCandidate = firstNonEmpty(
+    candidate.session,
+    candidate.sessionId,
+    candidate.session_id,
+    candidate.metadata?.session,
+    candidate.context?.session,
+    candidate.me?.session,
+    inheritedSessionId,
+  );
 
   return {
     conversationId: String(conversationIdCandidate),
@@ -352,63 +392,103 @@ function parseIncomingMessage(candidate: any): NormalizedIncomingMessage | null 
     type,
     senderName: senderNameCandidate ? String(senderNameCandidate) : undefined,
     attachments,
+    sessionId: sessionCandidate ? String(sessionCandidate) : undefined,
   };
 }
 
-function collectMessageCandidates(payload: any): any[] {
-  const results: any[] = [];
-  if (!payload) {
-    return results;
-  }
+interface CandidateWrapper {
+  node: any;
+  sessionId?: string;
+}
 
-  const push = (value: unknown) => {
-    if (value && typeof value === 'object') {
-      results.push(value);
+function collectCandidates(payload: any, predicate: (value: any) => boolean): CandidateWrapper[] {
+  const results: CandidateWrapper[] = [];
+  const visited = new Set<any>();
+
+  const visit = (value: any, inheritedSession?: string) => {
+    if (!value || typeof value !== 'object' || visited.has(value)) {
+      return;
+    }
+    visited.add(value);
+
+    const sessionCandidate = firstNonEmpty(
+      value.session,
+      value.payload?.session,
+      value.data?.session,
+      value.context?.session,
+      inheritedSession,
+    );
+    const sessionId = sessionCandidate ? String(sessionCandidate) : inheritedSession;
+
+    if (predicate(value)) {
+      results.push({ node: value, sessionId });
+    }
+
+    const childSources: unknown[] = [value.payload, value.data, value.value, value.body];
+    const arrayProps = ['messages', 'message', 'statuses', 'entries', 'entry', 'changes', 'items', 'events', 'records'];
+
+    for (const prop of arrayProps) {
+      const candidate = (value as Record<string, unknown>)[prop];
+      for (const item of toArray<any>(candidate)) {
+        if (item && typeof item === 'object') {
+          visit(item, sessionId);
+        }
+      }
+    }
+
+    for (const child of childSources) {
+      if (!child) {
+        continue;
+      }
+      if (Array.isArray(child)) {
+        for (const item of child) {
+          if (item && typeof item === 'object') {
+            visit(item, sessionId);
+          }
+        }
+      } else if (typeof child === 'object') {
+        visit(child, sessionId);
+      }
     }
   };
 
-  for (const item of toArray<any>(payload.messages)) {
-    push(item);
-  }
-
-  if (payload.message) {
-    push(payload.message);
-  }
-
-  if (payload.data) {
-    if (Array.isArray(payload.data)) {
-      for (const item of payload.data) {
-        for (const message of toArray<any>(item?.messages)) {
-          push(message);
-        }
-      }
-    } else {
-      for (const message of toArray<any>(payload.data.messages)) {
-        push(message);
-      }
+  if (Array.isArray(payload)) {
+    for (const item of payload) {
+      visit(item);
     }
-  }
-
-  if (payload.event === 'message' && payload.data) {
-    push(payload.data);
-  }
-
-  for (const entry of toArray<any>(payload.entry)) {
-    for (const change of toArray<any>(entry?.changes)) {
-      for (const message of toArray<any>(change?.value?.messages)) {
-        push(message);
-      }
-    }
+  } else {
+    visit(payload);
   }
 
   return results;
+}
+
+function isMessageCandidate(value: any): boolean {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  return (
+    typeof value.from !== 'undefined' ||
+    typeof value.to !== 'undefined' ||
+    typeof value.chatId !== 'undefined' ||
+    typeof value.remoteJid !== 'undefined' ||
+    typeof value.author !== 'undefined' ||
+    typeof value.body === 'string' ||
+    typeof value.text === 'string' ||
+    typeof value.message === 'object' ||
+    typeof value._data === 'object'
+  );
+}
+
+function collectMessageCandidates(payload: any): CandidateWrapper[] {
+  return collectCandidates(payload, isMessageCandidate);
 }
 
 function normalizeWebhookMessages(payload: unknown): NormalizedIncomingMessage[] {
   const candidates = collectMessageCandidates(payload);
   const normalized: NormalizedIncomingMessage[] = [];
   for (const candidate of candidates) {
-    const parsed = parseIncomingMessage(candidate);
+    const parsed = parseIncomingMessage(candidate.node, candidate.sessionId);
     if (parsed) {
       normalized.push(parsed);
     }
@@ -416,73 +496,53 @@ function normalizeWebhookMessages(payload: unknown): NormalizedIncomingMessage[]
   return normalized;
 }
 
-function collectStatusCandidates(payload: any): any[] {
-  const results: any[] = [];
-  if (!payload) {
-    return results;
+function isStatusCandidate(value: any): boolean {
+  if (!value || typeof value !== 'object') {
+    return false;
   }
-
-  const push = (value: unknown) => {
-    if (value && typeof value === 'object') {
-      results.push(value);
-    }
-  };
-
-  for (const status of toArray<any>(payload.statuses)) {
-    push(status);
+  if (
+    typeof value.ack !== 'undefined' ||
+    typeof value.status !== 'undefined' ||
+    typeof value.state !== 'undefined' ||
+    typeof value.deliveryStatus !== 'undefined'
+  ) {
+    return true;
   }
-
-  if (payload.data) {
-    if (Array.isArray(payload.data)) {
-      for (const item of payload.data) {
-        for (const status of toArray<any>(item?.statuses)) {
-          push(status);
-        }
-      }
-    } else {
-      for (const status of toArray<any>(payload.data.statuses)) {
-        push(status);
-      }
-    }
+  if (typeof value.event === 'string') {
+    const normalized = value.event.toLowerCase();
+    return normalized.includes('status') || normalized.includes('ack');
   }
+  return false;
+}
 
-  if (payload.event === 'status' && payload.data) {
-    push(payload.data);
-  }
-
-  for (const entry of toArray<any>(payload.entry)) {
-    for (const change of toArray<any>(entry?.changes)) {
-      for (const status of toArray<any>(change?.value?.statuses)) {
-        push(status);
-      }
-    }
-  }
-
-  return results;
+function collectStatusCandidates(payload: any): CandidateWrapper[] {
+  return collectCandidates(payload, isStatusCandidate);
 }
 
 function normalizeStatusUpdates(payload: unknown): StatusUpdate[] {
   const candidates = collectStatusCandidates(payload);
   const updates: StatusUpdate[] = [];
   for (const candidate of candidates) {
-    if (!candidate || typeof candidate !== 'object') {
+    const value = candidate.node;
+    if (!value || typeof value !== 'object') {
       continue;
     }
     const externalIdCandidate = firstNonEmpty(
-      candidate.id,
-      candidate.messageId,
-      candidate.message_id,
-      candidate.key?.id,
-      candidate.status?.id,
+      value.id,
+      value.messageId,
+      value.message_id,
+      value.key?.id,
+      value.status?.id,
+      value._data?.Info?.ID,
     );
     if (!externalIdCandidate) {
       continue;
     }
     const statusCandidate = firstNonEmpty(
-      candidate.status,
-      candidate.state,
-      candidate.ack,
-      candidate.deliveryStatus,
+      value.status,
+      value.state,
+      value.ack,
+      value.deliveryStatus,
     );
     updates.push({
       externalId: String(externalIdCandidate),
@@ -492,54 +552,56 @@ function normalizeStatusUpdates(payload: unknown): StatusUpdate[] {
   return updates;
 }
 
-function resolveChatId(conversation: ConversationDetails): string {
-  const metadataChatId = (conversation.metadata?.chatId ?? conversation.metadata?.chat_id ?? conversation.metadata?.id) as
-    | string
-    | undefined;
-  if (metadataChatId && metadataChatId.trim()) {
-    return metadataChatId.trim();
-  }
-  return conversation.contactIdentifier || conversation.id;
-}
-
-function resolveMessagesEndpoint(baseUrl: string): string {
-  const normalized = baseUrl.replace(/\/$/, '');
-  if (normalized.toLowerCase().endsWith('/v1/messages')) {
-    return normalized;
-  }
-  if (normalized.toLowerCase().endsWith('/v1')) {
-    return `${normalized}/messages`;
-  }
-  return `${normalized}/v1/messages`;
-}
-
-function buildSendPayload(chatId: string, payload: SendMessageInput): Record<string, unknown> {
-  const type: ChatMessageType = payload.type ?? 'text';
-  const messagePayload: Record<string, unknown> = {
-    type,
-    text: payload.content,
-  };
-
-  if (type === 'image') {
-    const attachment = payload.attachments?.[0];
-    if (attachment) {
-      messagePayload.image = {
-        url: attachment.url,
-        caption: payload.content || undefined,
-        name: attachment.name,
-      };
-    }
+function resolveConversationContext(conversation: ConversationDetails): { chatId: string; sessionId: string } {
+  const metadata = (conversation.metadata ?? {}) as Record<string, unknown>;
+  const chatIdCandidate = firstNonEmpty(
+    metadata.chatId,
+    metadata.chat_id,
+    metadata.id,
+    metadata.remoteJid,
+    metadata.contactIdentifier,
+    conversation.contactIdentifier,
+    conversation.id,
+  );
+  if (!chatIdCandidate || !String(chatIdCandidate).trim()) {
+    throw new ChatValidationError('Conversation is missing WAHA chat identifier');
   }
 
-  if (payload.attachments && payload.attachments.length > 0) {
-    messagePayload.attachments = payload.attachments;
+  const sessionCandidate = firstNonEmpty(
+    metadata.session,
+    metadata.sessionId,
+    metadata.session_id,
+    metadata.wahaSession,
+    metadata.integrationSession,
+  );
+  if (!sessionCandidate || !String(sessionCandidate).trim()) {
+    throw new ChatValidationError('Conversation is missing WAHA session information');
   }
 
   return {
+    chatId: String(chatIdCandidate).trim(),
+    sessionId: String(sessionCandidate).trim(),
+  };
+}
+
+function resolveSendTextEndpoint(baseUrl: string): string {
+  const normalized = baseUrl.replace(/\/$/, '');
+  const lower = normalized.toLowerCase();
+  if (lower.endsWith('/api/sendtext') || lower.endsWith('/sendtext')) {
+    return normalized;
+  }
+  if (lower.endsWith('/api')) {
+    return `${normalized}/sendText`;
+  }
+  return `${normalized}/api/sendText`;
+}
+
+function buildSendTextPayload(chatId: string, sessionId: string, payload: SendMessageInput): Record<string, unknown> {
+  return {
     chatId,
-    type,
+    session: sessionId,
     text: payload.content,
-    message: messagePayload,
+    linkPreview: true,
   };
 }
 
@@ -550,8 +612,20 @@ function extractMessageMetadata(data: unknown): { id?: string; timestamp?: Date 
   const root = data as Record<string, unknown>;
   const messages = toArray<any>(root.messages);
   const candidate = messages[0] ?? root;
-  const id = firstNonEmpty(candidate?.id, candidate?.messageId, candidate?.message_id, root.id);
-  const timestampCandidate = firstNonEmpty(candidate?.timestamp, candidate?.ts, candidate?.sentAt, candidate?.messageTimestamp);
+  const id = firstNonEmpty(
+    candidate?.id,
+    candidate?.messageId,
+    candidate?.message_id,
+    candidate?._data?.Info?.ID,
+    root.id,
+  );
+  const timestampCandidate = firstNonEmpty(
+    candidate?.timestamp,
+    candidate?.ts,
+    candidate?.sentAt,
+    candidate?.messageTimestamp,
+    candidate?._data?.Info?.Timestamp,
+  );
   const timestamp = timestampCandidate ? normalizeTimestamp(timestampCandidate) : undefined;
   return {
     id: id ? String(id) : undefined,
@@ -582,13 +656,22 @@ export default class WahaIntegrationService {
       throw error;
     }
 
-    const chatId = resolveChatId(conversation);
-    const endpoint = resolveMessagesEndpoint(config.baseUrl);
-    const requestBody = buildSendPayload(chatId, payload);
+    const { chatId, sessionId } = resolveConversationContext(conversation);
+
+    if (payload.attachments && payload.attachments.length > 0) {
+      throw new ChatValidationError('WAHA sendText endpoint does not support attachments');
+    }
+    if (payload.type && payload.type !== 'text') {
+      throw new ChatValidationError('Only text messages are supported by the WAHA integration');
+    }
+
+    const endpoint = resolveSendTextEndpoint(config.baseUrl);
+    const requestBody = buildSendTextPayload(chatId, sessionId, payload);
 
     const headers = {
       Authorization: `Bearer ${config.apiKey}`,
-      'X-API-Key': config.apiKey,
+      'X-Api-Key': config.apiKey,
+      Accept: 'application/json',
     };
 
     const response = await this.httpClient.postJson(endpoint, requestBody, headers);
@@ -633,14 +716,18 @@ export default class WahaIntegrationService {
 
     const messages = normalizeWebhookMessages(body);
     for (const message of messages) {
+      const metadata: Record<string, unknown> = {
+        provider: 'waha',
+        chatId: message.conversationId,
+      };
+      if (message.sessionId) {
+        metadata.session = message.sessionId;
+      }
       const conversation = await this.chatService.ensureConversation({
         id: message.conversationId,
         contactIdentifier: message.conversationId,
         contactName: message.senderName ?? message.conversationId,
-        metadata: {
-          provider: 'waha',
-          chatId: message.conversationId,
-        },
+        metadata,
       });
       await this.chatService.recordIncomingMessage({
         id: message.messageId,


### PR DESCRIPTION
## Summary
- merge incoming WAHA metadata into existing conversations so chat IDs and sessions persist
- normalize stored WAHA base URLs and switch outbound sends to the /api/sendText endpoint with session-aware payloads
- expand webhook parsing to capture session IDs, traverse nested payloads, and update message statuses reliably

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9cc4e873883269afc6122e7ce7f54