### PR TITLE
feat: integrate WAHA chat listing

### DIFF
--- a/backend/dist/controllers/wahaChatProxyController.js
+++ b/backend/dist/controllers/wahaChatProxyController.js
@@ -1,0 +1,28 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.listWahaChatsProxyHandler = void 0;
+const wahaChatFetcher_1 = require("../services/wahaChatFetcher");
+const listWahaChatsProxyHandler = async (_req, res) => {
+    try {
+        const conversations = await (0, wahaChatFetcher_1.listWahaConversations)();
+        res.json(conversations);
+    }
+    catch (error) {
+        if (error instanceof wahaChatFetcher_1.WahaRequestError) {
+            if (error.status === 401 || error.status === 403) {
+                return res.status(error.status).json({
+                    error: 'Falha de autenticação com o WAHA. Verifique as credenciais configuradas.',
+                });
+            }
+            const status = error.status && error.status >= 400 && error.status < 600 ? error.status : 502;
+            return res.status(status).json({
+                error: error.status === undefined
+                    ? 'Integração com o WAHA não configurada. Defina WAHA_BASE_URL e WAHA_TOKEN.'
+                    : 'Não foi possível consultar as conversas no WAHA.',
+            });
+        }
+        console.error('Erro inesperado ao listar conversas do WAHA', error);
+        res.status(500).json({ error: 'Erro interno ao consultar o WAHA' });
+    }
+};
+exports.listWahaChatsProxyHandler = listWahaChatsProxyHandler;

--- a/backend/dist/routes/chatRoutes.js
+++ b/backend/dist/routes/chatRoutes.js
@@ -3,13 +3,565 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = require("express");
 const chatController_1 = require("../controllers/chatController");
 const wahaIntegrationController_1 = require("../controllers/wahaIntegrationController");
+const wahaChatProxyController_1 = require("../controllers/wahaChatProxyController");
 const router = (0, express_1.Router)();
+/**
+ * @swagger
+ * tags:
+ *   - name: Conversas
+ *     description: Endpoints para gerenciamento de conversas e integrações de mensagens
+ *   - name: Integrações
+ *     description: Integrações com plataformas externas de comunicação
+ * components:
+ *   schemas:
+ *     ChatMessageAttachment:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *           description: Identificador único do anexo
+ *         type:
+ *           type: string
+ *           description: Tipo de arquivo do anexo
+ *           enum: [image]
+ *         url:
+ *           type: string
+ *           format: uri
+ *           description: URL pública para download do arquivo
+ *         name:
+ *           type: string
+ *           description: Nome amigável do arquivo
+ *     ChatMessage:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *         conversationId:
+ *           type: string
+ *         sender:
+ *           type: string
+ *           enum: [me, contact]
+ *           description: Indica se a mensagem foi enviada pelo operador ou pelo contato
+ *         content:
+ *           type: string
+ *         timestamp:
+ *           type: string
+ *           format: date-time
+ *         status:
+ *           type: string
+ *           enum: [sent, delivered, read]
+ *         type:
+ *           type: string
+ *           enum: [text, image]
+ *         attachments:
+ *           type: array
+ *           nullable: true
+ *           items:
+ *             $ref: '#/components/schemas/ChatMessageAttachment'
+ *     ConversationLastMessage:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *         content:
+ *           type: string
+ *           description: Conteúdo completo armazenado para a pré-visualização
+ *         preview:
+ *           type: string
+ *           description: Texto reduzido apresentado na listagem de conversas
+ *         timestamp:
+ *           type: string
+ *           format: date-time
+ *         sender:
+ *           type: string
+ *           enum: [me, contact]
+ *         type:
+ *           type: string
+ *           enum: [text, image]
+ *         status:
+ *           type: string
+ *           enum: [sent, delivered, read]
+ *     ConversationSummary:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *         name:
+ *           type: string
+ *         avatar:
+ *           type: string
+ *           description: Avatar calculado para o contato
+ *         shortStatus:
+ *           type: string
+ *         description:
+ *           type: string
+ *         unreadCount:
+ *           type: integer
+ *           format: int32
+ *         pinned:
+ *           type: boolean
+ *         lastMessage:
+ *           $ref: '#/components/schemas/ConversationLastMessage'
+ *           nullable: true
+ *     MessagePage:
+ *       type: object
+ *       properties:
+ *         messages:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/ChatMessage'
+ *         nextCursor:
+ *           type: string
+ *           format: date-time
+ *           nullable: true
+ *           description: Cursor a ser enviado na próxima requisição para continuar a paginação
+ *     CreateConversationRequest:
+ *       type: object
+ *       description: Payload utilizado para criar ou atualizar conversas. Informe pelo menos contactIdentifier ou id.
+ *       properties:
+ *         id:
+ *           type: string
+ *           description: Identificador interno da conversa; caso omitido utiliza-se contactIdentifier
+ *         contactIdentifier:
+ *           type: string
+ *           description: Identificador do contato ou chat no provedor externo
+ *         contactName:
+ *           type: string
+ *         description:
+ *           type: string
+ *         shortStatus:
+ *           type: string
+ *         avatar:
+ *           type: string
+ *         pinned:
+ *           type: boolean
+ *         metadata:
+ *           type: object
+ *           nullable: true
+ *           additionalProperties: true
+ *     SendMessageRequest:
+ *       type: object
+ *       required:
+ *         - content
+ *       properties:
+ *         content:
+ *           type: string
+ *           description: Conteúdo textual da mensagem a ser enviada
+ *         type:
+ *           type: string
+ *           enum: [text, image]
+ *           description: Tipo de mensagem. Por padrão envia mensagem de texto
+ *         attachments:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/ChatMessageAttachment'
+ *           description: Lista de anexos a ser enviada junto com a mensagem
+ *           nullable: true
+ *     ErrorResponse:
+ *       type: object
+ *       properties:
+ *         error:
+ *           type: string
+ *           description: Mensagem detalhando o motivo do erro
+
+ *     WahaIntegrationConfig:
+ *       type: object
+ *       required:
+ *         - baseUrl
+ *         - apiKey
+ *         - isActive
+ *         - createdAt
+ *         - updatedAt
+ *       properties:
+ *         baseUrl:
+ *           type: string
+ *           format: uri
+ *           description: URL base do servidor WAHA, sem barra no final
+ *         apiKey:
+ *           type: string
+ *           description: Chave utilizada para autenticar as requisições ao WAHA
+ *         webhookSecret:
+ *           type: string
+ *           nullable: true
+ *           description: Segredo opcional para validação do webhook recebido
+ *         isActive:
+ *           type: boolean
+ *           description: Indica se a integração está ativa para envio/recebimento de mensagens
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *           description: Data de criação do registro de configuração
+ *         updatedAt:
+ *           type: string
+ *           format: date-time
+ *           description: Data da última atualização da configuração
+ */
+/**
+ * @swagger
+ * /api/conversations:
+ *   get:
+ *     summary: Lista conversas sincronizadas com o WAHA
+ *     tags: [Conversas]
+ *     parameters:
+ *       - in: query
+ *         name: session
+ *         schema:
+ *           type: string
+ *         description: Identificador da sessão WAHA (ex.: QuantumTecnologia01) para filtrar a consulta remota.
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 200
+ *         description: Quantidade máxima de chats retornados por sessão ao consultar o WAHA (padrão 30).
+ *       - in: query
+ *         name: source
+ *         schema:
+ *           type: string
+ *           enum: [waha, local]
+ *         description: Define a origem dos dados. Utilize `local` para ignorar o WAHA e retornar apenas registros persistidos.
+ *     summary: Lista todas as conversas cadastradas
+ *     tags: [Conversas]
+ *     responses:
+ *       200:
+ *         description: Lista de conversas ordenadas pela atividade mais recente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/ConversationSummary'
+ *       400:
+ *         description: Parâmetros inválidos para consulta remota
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       502:
+ *         description: Falha ao consultar o WAHA
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+
+ *       500:
+ *         description: Erro interno ao listar conversas
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
 router.get('/conversations', chatController_1.listConversationsHandler);
+router.get('/chats', wahaChatProxyController_1.listWahaChatsProxyHandler);
+/**
+ * @swagger
+ * /api/conversations:
+ *   post:
+ *     summary: Cria ou atualiza uma conversa manualmente
+ *     tags: [Conversas]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CreateConversationRequest'
+ *           examples:
+ *             default:
+ *               summary: Exemplo de criação de conversa
+ *               value:
+ *                 contactIdentifier: 5511999999999@c.us
+ *                 contactName: Cliente Teste
+ *                 shortStatus: Novo lead
+ *                 pinned: false
+ *     responses:
+ *       201:
+ *         description: Conversa criada ou atualizada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ConversationSummary'
+ *       400:
+ *         description: Dados inválidos enviados para criação da conversa
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno ao criar a conversa
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
 router.post('/conversations', chatController_1.createConversationHandler);
+/**
+ * @swagger
+ * /api/conversations/{conversationId}/messages:
+ *   get:
+ *     summary: Lista mensagens de uma conversa
+ *     tags: [Conversas]
+ *     parameters:
+ *       - in: path
+ *         name: conversationId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identificador da conversa
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *         description: Quantidade máxima de mensagens retornadas por página (padrão 20)
+ *       - in: query
+ *         name: cursor
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *         description: Cursor utilizado para paginação reversa das mensagens
+ *     responses:
+ *       200:
+ *         description: Página de mensagens retornada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/MessagePage'
+ *       404:
+ *         description: Conversa não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno ao listar mensagens
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
 router.get('/conversations/:conversationId/messages', chatController_1.getConversationMessagesHandler);
+/**
+ * @swagger
+ * /api/conversations/{conversationId}/messages:
+ *   post:
+ *     summary: Envia uma mensagem através da integração WAHA
+ *     tags: [Conversas]
+ *     parameters:
+ *       - in: path
+ *         name: conversationId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identificador da conversa
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/SendMessageRequest'
+ *           examples:
+ *             texto:
+ *               summary: Envio de mensagem de texto
+ *               value:
+ *                 content: Olá, podemos ajudar?
+ *             imagem:
+ *               summary: Envio de imagem com legenda
+ *               value:
+ *                 content: Veja o documento em anexo
+ *                 type: image
+ *                 attachments:
+ *                   - id: file-123
+ *                     type: image
+ *                     name: comprovante.png
+ *                     url: https://example.com/comprovante.png
+ *     responses:
+ *       201:
+ *         description: Mensagem registrada e enviada ao provedor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ChatMessage'
+ *       400:
+ *         description: Dados inválidos para envio da mensagem
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       503:
+ *         description: Integração WAHA não configurada ou desativada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       502:
+ *         description: Erro ao entregar a mensagem ao provedor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
 router.post('/conversations/:conversationId/messages', chatController_1.sendConversationMessageHandler);
+/**
+ * @swagger
+ * /api/conversations/{conversationId}/read:
+ *   post:
+ *     summary: Marca todas as mensagens da conversa como lidas
+ *     tags: [Conversas]
+ *     parameters:
+ *       - in: path
+ *         name: conversationId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identificador da conversa
+ *     responses:
+ *       204:
+ *         description: Conversa marcada como lida com sucesso
+ *       404:
+ *         description: Conversa não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno ao atualizar a conversa
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
 router.post('/conversations/:conversationId/read', chatController_1.markConversationReadHandler);
+/**
+ * @swagger
+ * /api/webhooks/waha:
+ *   post:
+ *     summary: Recebe eventos de mensagens do WAHA
+ *     tags: [Integrações]
+ *     requestBody:
+ *       required: true
+ *       description: Payload de webhook encaminhado pelo servidor WAHA
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             additionalProperties: true
+ *     responses:
+ *       204:
+ *         description: Webhook processado com sucesso
+ *       400:
+ *         description: Payload inválido recebido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Falha na validação da assinatura do webhook
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       503:
+ *         description: Integração WAHA desativada ou não configurada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro inesperado ao processar o webhook
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
 router.post('/webhooks/waha', chatController_1.wahaWebhookHandler);
+/**
+ * @swagger
+ * /api/integrations/waha:
+ *   get:
+ *     summary: Obtém a configuração atual da integração com o WAHA
+ *     tags: [Integrações]
+ *     responses:
+ *       200:
+ *         description: Configuração encontrada ou null caso não exista
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WahaIntegrationConfig'
+ *               nullable: true
+ *             examples:
+ *               configurado:
+ *                 summary: Configuração ativa
+ *                 value:
+ *                   baseUrl: https://waha.example.com
+ *                   apiKey: super-secret
+ *                   webhookSecret: webhook-secret
+ *                   isActive: true
+ *                   createdAt: '2024-05-05T12:00:00.000Z'
+ *                   updatedAt: '2024-05-06T08:30:00.000Z'
+ *               naoConfigurado:
+ *                 summary: Configuração ausente
+ *                 value: null
+ *       500:
+ *         description: Erro interno ao carregar a configuração
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+
+ */
 router.get('/integrations/waha', wahaIntegrationController_1.getWahaConfigHandler);
+/**
+ * @swagger
+ * /api/integrations/waha:
+ *   put:
+ *     summary: Cria ou atualiza a configuração da integração com o WAHA
+ *     tags: [Integrações]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - baseUrl
+ *               - apiKey
+ *             properties:
+ *               baseUrl:
+ *                 type: string
+ *                 format: uri
+ *                 example: https://waha.example.com
+ *               apiKey:
+ *                 type: string
+ *                 example: super-secret
+ *               webhookSecret:
+ *                 type: string
+ *                 nullable: true
+ *                 example: webhook-secret
+ *               isActive:
+ *                 type: boolean
+ *                 example: true
+ *     responses:
+ *       200:
+ *         description: Configuração salva com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WahaIntegrationConfig'
+ *       400:
+ *         description: Dados inválidos enviados para configuração
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno ao salvar a configuração
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+
+ */
 router.put('/integrations/waha', wahaIntegrationController_1.updateWahaConfigHandler);
 exports.default = router;

--- a/backend/dist/services/chatService.js
+++ b/backend/dist/services/chatService.js
@@ -260,6 +260,25 @@ class ChatService {
             };
         });
     }
+    async listKnownSessions() {
+        const result = await this.db.query(`SELECT DISTINCT metadata ->> 'session' AS session_id
+         FROM chat_conversations
+        WHERE metadata ? 'session'`);
+        const sessions = [];
+        const seen = new Set();
+        for (const row of result.rows) {
+            if (!row || typeof row.session_id !== 'string') {
+                continue;
+            }
+            const trimmed = row.session_id.trim();
+            if (!trimmed || seen.has(trimmed)) {
+                continue;
+            }
+            seen.add(trimmed);
+            sessions.push(trimmed);
+        }
+        return sessions;
+    }
     async getConversationDetails(conversationId) {
         const result = await this.db.query(`SELECT id, contact_identifier, contact_name, contact_avatar, short_status, description, pinned,
               unread_count, last_message_id, last_message_preview, last_message_timestamp,
@@ -335,12 +354,15 @@ class ChatService {
        )
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
        ON CONFLICT (id) DO UPDATE
-         SET contact_identifier = COALESCE(chat_conversations.contact_identifier, EXCLUDED.contact_identifier),
-             contact_name = COALESCE(chat_conversations.contact_name, EXCLUDED.contact_name),
-             contact_avatar = COALESCE(chat_conversations.contact_avatar, EXCLUDED.contact_avatar),
-             short_status = COALESCE(chat_conversations.short_status, EXCLUDED.short_status),
-             description = COALESCE(chat_conversations.description, EXCLUDED.description),
-             metadata = COALESCE(chat_conversations.metadata, EXCLUDED.metadata)
+        SET contact_identifier = COALESCE(chat_conversations.contact_identifier, EXCLUDED.contact_identifier),
+            contact_name = COALESCE(chat_conversations.contact_name, EXCLUDED.contact_name),
+            contact_avatar = COALESCE(chat_conversations.contact_avatar, EXCLUDED.contact_avatar),
+            short_status = COALESCE(chat_conversations.short_status, EXCLUDED.short_status),
+            description = COALESCE(chat_conversations.description, EXCLUDED.description),
+            metadata = CASE
+              WHEN chat_conversations.metadata IS NULL AND EXCLUDED.metadata IS NULL THEN NULL
+              ELSE COALESCE(chat_conversations.metadata, '{}'::jsonb) || COALESCE(EXCLUDED.metadata, '{}'::jsonb)
+            END
        RETURNING id, contact_identifier, contact_name, contact_avatar, short_status, description, pinned,
                  unread_count, last_message_id, last_message_preview, last_message_timestamp,
                  last_message_sender, last_message_type, last_message_status, metadata, created_at, updated_at`, [conversationId, contactIdentifier, contactName, avatar, shortStatus, description, pinned, metadata]);

--- a/backend/dist/services/wahaChatFetcher.js
+++ b/backend/dist/services/wahaChatFetcher.js
@@ -1,0 +1,239 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.listWahaConversations = exports.WahaRequestError = void 0;
+const promises_1 = require("node:timers/promises");
+class WahaRequestError extends Error {
+    constructor(message, status, responseBody) {
+        super(message);
+        this.status = status;
+        this.responseBody = responseBody;
+        this.name = 'WahaRequestError';
+    }
+}
+exports.WahaRequestError = WahaRequestError;
+const DEFAULT_TIMEOUT_MS = 15000;
+const MAX_ATTEMPTS = 3;
+const RETRYABLE_STATUS = new Set([429]);
+const addRetryableRange = (set, start, end) => {
+    for (let status = start; status <= end; status += 1) {
+        set.add(status);
+    }
+};
+addRetryableRange(RETRYABLE_STATUS, 500, 599);
+const normalizeBaseUrl = (value) => value.replace(/\/+$/, '');
+const toTrimmedString = (value) => {
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : undefined;
+    }
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return String(value);
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'true' : 'false';
+    }
+    return undefined;
+};
+const firstNonEmptyString = (...values) => {
+    for (const value of values) {
+        const normalized = toTrimmedString(value);
+        if (normalized) {
+            return normalized;
+        }
+    }
+    return undefined;
+};
+const buildHeaders = (token) => {
+    const headers = {
+        Accept: 'application/json',
+    };
+    if (token) {
+        headers.Authorization = `Bearer ${token}`;
+    }
+    return headers;
+};
+const readTimeoutFromEnv = () => {
+    const raw = process.env.WAHA_TIMEOUT_MS;
+    if (!raw) {
+        return DEFAULT_TIMEOUT_MS;
+    }
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isNaN(parsed) || parsed <= 0) {
+        return DEFAULT_TIMEOUT_MS;
+    }
+    return parsed;
+};
+async function fetchJson(url, options, logger) {
+    let attempt = 0;
+    let lastError;
+    while (attempt < MAX_ATTEMPTS) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), options.timeoutMs);
+        try {
+            const response = (await fetch(url, {
+                headers: options.headers,
+                signal: controller.signal,
+            }));
+            const bodyText = await response.text();
+            if (!response.ok) {
+                logger.error(`WAHA request failed (${response.status}): ${bodyText || '<empty>'}`);
+                if (RETRYABLE_STATUS.has(response.status) && attempt + 1 < MAX_ATTEMPTS) {
+                    attempt += 1;
+                    await (0, promises_1.setTimeout)(2 ** attempt * 200);
+                    continue;
+                }
+                throw new WahaRequestError(`WAHA request failed with status ${response.status}`, response.status, bodyText);
+            }
+            if (!bodyText) {
+                return null;
+            }
+            try {
+                return JSON.parse(bodyText);
+            }
+            catch (error) {
+                logger.warn(`Failed to parse WAHA response as JSON: ${error.message}`);
+                return bodyText;
+            }
+        }
+        catch (error) {
+            lastError = error;
+            const isAbortError = error instanceof Error && error.name === 'AbortError';
+            if (isAbortError) {
+                logger.error(`WAHA request to ${url} timed out after ${options.timeoutMs}ms`);
+            }
+            else {
+                logger.error(`WAHA request error on attempt ${attempt + 1}:`, error);
+            }
+            if (attempt + 1 >= MAX_ATTEMPTS) {
+                if (error instanceof WahaRequestError) {
+                    throw error;
+                }
+                throw new WahaRequestError(isAbortError
+                    ? `WAHA request timed out after ${options.timeoutMs}ms`
+                    : 'WAHA request failed');
+            }
+            attempt += 1;
+            await (0, promises_1.setTimeout)(2 ** attempt * 200);
+        }
+        finally {
+            clearTimeout(timer);
+        }
+    }
+    if (lastError instanceof WahaRequestError) {
+        throw lastError;
+    }
+    throw new WahaRequestError('WAHA request failed');
+}
+const extractChatArray = (payload) => {
+    if (!payload) {
+        return [];
+    }
+    if (Array.isArray(payload)) {
+        return payload;
+    }
+    if (typeof payload === 'object' && payload !== null) {
+        const record = payload;
+        if (Array.isArray(record.chats)) {
+            return record.chats;
+        }
+        if (record.data) {
+            const data = record.data;
+            if (Array.isArray(data)) {
+                return data;
+            }
+            if (typeof data === 'object' && data !== null && Array.isArray(data.chats)) {
+                return data.chats;
+            }
+        }
+    }
+    return [];
+};
+const ensureConversationId = (chat) => firstNonEmptyString(chat.id, chat.chatId, chat.conversationId, chat.jid, chat.chat_id, chat.key, chat.chat?.id);
+const resolveContactName = (chat, fallbackId) => firstNonEmptyString(chat.name, chat.contactName, chat.pushName, chat.formattedName, chat.contact?.name, fallbackId) ?? fallbackId;
+const resolveAvatar = (chat) => firstNonEmptyString(chat.avatar, chat.photoUrl, chat.photoURL, chat.profilePicUrl, chat.profilePicURL, chat.contact?.avatar, chat.contact?.profilePicUrl);
+const resolveContactIdentifier = (chat, fallbackId) => firstNonEmptyString(chat.contactId, chat.contact_id, chat.contact?.id, fallbackId);
+const buildContactUrl = (baseUrl, contactId) => `${baseUrl}/api/v1/contacts/${encodeURIComponent(contactId)}`;
+async function fetchAvatarFromContact(baseUrl, contactId, options, logger) {
+    try {
+        const payload = await fetchJson(buildContactUrl(baseUrl, contactId), options, logger);
+        if (!payload || typeof payload !== 'object') {
+            return null;
+        }
+        const record = payload;
+        return (firstNonEmptyString(record.profilePicUrl, record.profilePicURL, record.avatar, record.photoUrl, record.photoURL) ?? null);
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warn(`Unable to load avatar for ${contactId}: ${message}`);
+        return null;
+    }
+}
+const printTable = (rows, logger) => {
+    logger.log('Conversas obtidas do WAHA:');
+    if (rows.length === 0) {
+        logger.log('Nenhuma conversa encontrada.');
+        return;
+    }
+    const headers = ['conversation_id', 'contact_name', 'photo_url'];
+    const columnWidths = headers.map((header) => Math.max(header.length, ...rows.map((row) => {
+        const value = row[header];
+        const asString = value === null || value === undefined ? '—' : String(value);
+        return asString.length;
+    })));
+    const buildSeparator = () => `+${columnWidths.map((width) => '-'.repeat(width + 2)).join('+')}+`;
+    const buildRow = (cells) => `| ${cells.map((cell, index) => cell.padEnd(columnWidths[index])).join(' | ')} |`;
+    logger.log(buildSeparator());
+    logger.log(buildRow(headers.map((header) => header
+        .split('_')
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' '))));
+    logger.log(buildSeparator());
+    for (const row of rows) {
+        const cells = headers.map((header) => {
+            const value = row[header];
+            return value === null || value === undefined ? '—' : String(value);
+        });
+        logger.log(buildRow(cells));
+    }
+    logger.log(buildSeparator());
+};
+const listWahaConversations = async (logger = console) => {
+    const baseUrlEnv = process.env.WAHA_BASE_URL;
+    if (!baseUrlEnv || !baseUrlEnv.trim()) {
+        throw new WahaRequestError('WAHA_BASE_URL environment variable is not defined');
+    }
+    const baseUrl = normalizeBaseUrl(baseUrlEnv.trim());
+    const token = process.env.WAHA_TOKEN?.trim();
+    const timeoutMs = readTimeoutFromEnv();
+    const headers = buildHeaders(token);
+    const fetchOptions = { headers, timeoutMs };
+    const payload = await fetchJson(`${baseUrl}/api/v1/chats`, fetchOptions, logger);
+    const chats = extractChatArray(payload);
+    const results = [];
+    for (const item of chats) {
+        if (!item || typeof item !== 'object') {
+            continue;
+        }
+        const chat = item;
+        const conversationId = ensureConversationId(chat);
+        if (!conversationId) {
+            continue;
+        }
+        const contactName = resolveContactName(chat, conversationId);
+        let photoUrl = resolveAvatar(chat) ?? null;
+        if (!photoUrl) {
+            const contactIdentifier = resolveContactIdentifier(chat, conversationId);
+            if (contactIdentifier) {
+                photoUrl = await fetchAvatarFromContact(baseUrl, contactIdentifier, fetchOptions, logger);
+            }
+        }
+        results.push({
+            conversation_id: conversationId,
+            contact_name: contactName,
+            photo_url: photoUrl,
+        });
+    }
+    printTable(results, logger);
+    return results;
+};
+exports.listWahaConversations = listWahaConversations;

--- a/backend/dist/services/wahaConfigService.js
+++ b/backend/dist/services/wahaConfigService.js
@@ -12,6 +12,26 @@ class ValidationError extends Error {
     }
 }
 exports.ValidationError = ValidationError;
+function stripKnownSuffixes(pathname) {
+    let result = pathname;
+    const suffixes = [
+        /\/v1\/messages$/i,
+        /\/v1$/i,
+        /\/api\/send[a-z]+$/i,
+        /\/api$/i,
+    ];
+    let updated = true;
+    while (updated) {
+        updated = false;
+        for (const suffix of suffixes) {
+            if (suffix.test(result)) {
+                result = result.replace(suffix, '');
+                updated = true;
+            }
+        }
+    }
+    return result.replace(/\/$/, '');
+}
 function normalizeBaseUrl(value) {
     if (typeof value !== 'string') {
         throw new ValidationError('baseUrl is required');
@@ -30,7 +50,7 @@ function normalizeBaseUrl(value) {
     if (!['http:', 'https:'].includes(parsed.protocol)) {
         throw new ValidationError('baseUrl must use http or https');
     }
-    parsed.pathname = parsed.pathname.replace(/\/$/, '');
+    parsed.pathname = stripKnownSuffixes(parsed.pathname);
     parsed.hash = '';
     return parsed.toString().replace(/\/$/, '');
 }

--- a/backend/src/controllers/wahaChatProxyController.ts
+++ b/backend/src/controllers/wahaChatProxyController.ts
@@ -1,0 +1,29 @@
+import { Request, Response } from 'express';
+import { listWahaConversations, WahaRequestError } from '../services/wahaChatFetcher';
+
+export const listWahaChatsProxyHandler = async (_req: Request, res: Response) => {
+  try {
+    const conversations = await listWahaConversations();
+    res.json(conversations);
+  } catch (error) {
+    if (error instanceof WahaRequestError) {
+      if (error.status === 401 || error.status === 403) {
+        return res.status(error.status).json({
+          error: 'Falha de autenticação com o WAHA. Verifique as credenciais configuradas.',
+        });
+      }
+
+      const status = error.status && error.status >= 400 && error.status < 600 ? error.status : 502;
+      return res.status(status).json({
+        error:
+          error.status === undefined
+            ? 'Integração com o WAHA não configurada. Defina WAHA_BASE_URL e WAHA_TOKEN.'
+            : 'Não foi possível consultar as conversas no WAHA.',
+      });
+    }
+
+    console.error('Erro inesperado ao listar conversas do WAHA', error);
+    res.status(500).json({ error: 'Erro interno ao consultar o WAHA' });
+  }
+};
+

--- a/backend/src/routes/chatRoutes.ts
+++ b/backend/src/routes/chatRoutes.ts
@@ -11,6 +11,7 @@ import {
   getWahaConfigHandler,
   updateWahaConfigHandler,
 } from '../controllers/wahaIntegrationController';
+import { listWahaChatsProxyHandler } from '../controllers/wahaChatProxyController';
 
 const router = Router();
 
@@ -264,6 +265,8 @@ const router = Router();
  */
 
 router.get('/conversations', listConversationsHandler);
+
+router.get('/chats', listWahaChatsProxyHandler);
 
 /**
  * @swagger

--- a/backend/src/services/wahaChatFetcher.ts
+++ b/backend/src/services/wahaChatFetcher.ts
@@ -1,0 +1,360 @@
+import { setTimeout as delay } from 'node:timers/promises';
+
+export interface WahaConversationRow {
+  conversation_id: string;
+  contact_name: string;
+  photo_url: string | null;
+}
+
+export class WahaRequestError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+    public readonly responseBody?: string,
+  ) {
+    super(message);
+    this.name = 'WahaRequestError';
+  }
+}
+
+interface FetchOptions {
+  headers: Record<string, string>;
+  timeoutMs: number;
+}
+
+type Logger = Pick<Console, 'log' | 'error' | 'warn'>;
+
+type MinimalFetchResponse = {
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+};
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const MAX_ATTEMPTS = 3;
+const RETRYABLE_STATUS = new Set([429]);
+
+const addRetryableRange = (set: Set<number>, start: number, end: number) => {
+  for (let status = start; status <= end; status += 1) {
+    set.add(status);
+  }
+};
+
+addRetryableRange(RETRYABLE_STATUS, 500, 599);
+
+const normalizeBaseUrl = (value: string) => value.replace(/\/+$/, '');
+
+const toTrimmedString = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+  return undefined;
+};
+
+const firstNonEmptyString = (...values: unknown[]): string | undefined => {
+  for (const value of values) {
+    const normalized = toTrimmedString(value);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return undefined;
+};
+
+const buildHeaders = (token: string | undefined): Record<string, string> => {
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+};
+
+const readTimeoutFromEnv = (): number => {
+  const raw = process.env.WAHA_TIMEOUT_MS;
+  if (!raw) {
+    return DEFAULT_TIMEOUT_MS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return DEFAULT_TIMEOUT_MS;
+  }
+  return parsed;
+};
+
+async function fetchJson(url: string, options: FetchOptions, logger: Logger): Promise<unknown> {
+  let attempt = 0;
+  let lastError: unknown;
+
+  while (attempt < MAX_ATTEMPTS) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), options.timeoutMs);
+
+    try {
+      const response = (await fetch(url, {
+        headers: options.headers,
+        signal: controller.signal,
+      })) as unknown as MinimalFetchResponse;
+      const bodyText = await response.text();
+
+      if (!response.ok) {
+        logger.error(`WAHA request failed (${response.status}): ${bodyText || '<empty>'}`);
+
+        if (RETRYABLE_STATUS.has(response.status) && attempt + 1 < MAX_ATTEMPTS) {
+          attempt += 1;
+          await delay(2 ** attempt * 200);
+          continue;
+        }
+
+        throw new WahaRequestError(
+          `WAHA request failed with status ${response.status}`,
+          response.status,
+          bodyText,
+        );
+      }
+
+      if (!bodyText) {
+        return null;
+      }
+
+      try {
+        return JSON.parse(bodyText);
+      } catch (error) {
+        logger.warn(`Failed to parse WAHA response as JSON: ${(error as Error).message}`);
+        return bodyText;
+      }
+    } catch (error) {
+      lastError = error;
+      const isAbortError = error instanceof Error && error.name === 'AbortError';
+
+      if (isAbortError) {
+        logger.error(`WAHA request to ${url} timed out after ${options.timeoutMs}ms`);
+      } else {
+        logger.error(`WAHA request error on attempt ${attempt + 1}:`, error);
+      }
+
+      if (attempt + 1 >= MAX_ATTEMPTS) {
+        if (error instanceof WahaRequestError) {
+          throw error;
+        }
+        throw new WahaRequestError(
+          isAbortError
+            ? `WAHA request timed out after ${options.timeoutMs}ms`
+            : 'WAHA request failed',
+        );
+      }
+
+      attempt += 1;
+      await delay(2 ** attempt * 200);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  if (lastError instanceof WahaRequestError) {
+    throw lastError;
+  }
+
+  throw new WahaRequestError('WAHA request failed');
+}
+
+const extractChatArray = (payload: unknown): unknown[] => {
+  if (!payload) {
+    return [];
+  }
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  if (typeof payload === 'object' && payload !== null) {
+    const record = payload as Record<string, unknown>;
+    if (Array.isArray(record.chats)) {
+      return record.chats;
+    }
+    if (record.data) {
+      const data = record.data as unknown;
+      if (Array.isArray(data)) {
+        return data;
+      }
+      if (typeof data === 'object' && data !== null && Array.isArray((data as Record<string, unknown>).chats)) {
+        return (data as Record<string, unknown>).chats as unknown[];
+      }
+    }
+  }
+  return [];
+};
+
+const ensureConversationId = (chat: Record<string, unknown>): string | undefined =>
+  firstNonEmptyString(
+    chat.id,
+    chat.chatId,
+    chat.conversationId,
+    chat.jid,
+    chat.chat_id,
+    chat.key,
+    (chat.chat as Record<string, unknown> | undefined)?.id,
+  );
+
+const resolveContactName = (chat: Record<string, unknown>, fallbackId: string): string =>
+  firstNonEmptyString(
+    chat.name,
+    chat.contactName,
+    chat.pushName,
+    chat.formattedName,
+    (chat.contact as Record<string, unknown> | undefined)?.name,
+    fallbackId,
+  ) ?? fallbackId;
+
+const resolveAvatar = (chat: Record<string, unknown>): string | undefined =>
+  firstNonEmptyString(
+    chat.avatar,
+    chat.photoUrl,
+    chat.photoURL,
+    chat.profilePicUrl,
+    chat.profilePicURL,
+    (chat.contact as Record<string, unknown> | undefined)?.avatar,
+    (chat.contact as Record<string, unknown> | undefined)?.profilePicUrl,
+  );
+
+const resolveContactIdentifier = (chat: Record<string, unknown>, fallbackId: string): string | undefined =>
+  firstNonEmptyString(
+    chat.contactId,
+    chat.contact_id,
+    (chat.contact as Record<string, unknown> | undefined)?.id,
+    fallbackId,
+  );
+
+const buildContactUrl = (baseUrl: string, contactId: string) =>
+  `${baseUrl}/api/v1/contacts/${encodeURIComponent(contactId)}`;
+
+async function fetchAvatarFromContact(
+  baseUrl: string,
+  contactId: string,
+  options: FetchOptions,
+  logger: Logger,
+): Promise<string | null> {
+  try {
+    const payload = await fetchJson(buildContactUrl(baseUrl, contactId), options, logger);
+    if (!payload || typeof payload !== 'object') {
+      return null;
+    }
+    const record = payload as Record<string, unknown>;
+    return (
+      firstNonEmptyString(
+        record.profilePicUrl,
+        record.profilePicURL,
+        record.avatar,
+        record.photoUrl,
+        record.photoURL,
+      ) ?? null
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn(`Unable to load avatar for ${contactId}: ${message}`);
+    return null;
+  }
+}
+
+const printTable = (rows: WahaConversationRow[], logger: Logger) => {
+  logger.log('Conversas obtidas do WAHA:');
+  if (rows.length === 0) {
+    logger.log('Nenhuma conversa encontrada.');
+    return;
+  }
+
+  const headers: Array<keyof WahaConversationRow> = ['conversation_id', 'contact_name', 'photo_url'];
+  const columnWidths = headers.map((header) =>
+    Math.max(
+      header.length,
+      ...rows.map((row) => {
+        const value = row[header];
+        const asString = value === null || value === undefined ? '—' : String(value);
+        return asString.length;
+      }),
+    ),
+  );
+
+  const buildSeparator = () => `+${columnWidths.map((width) => '-'.repeat(width + 2)).join('+')}+`;
+  const buildRow = (cells: string[]) =>
+    `| ${cells.map((cell, index) => cell.padEnd(columnWidths[index]!)).join(' | ')} |`;
+
+  logger.log(buildSeparator());
+  logger.log(
+    buildRow(
+      headers.map((header) =>
+        header
+          .split('_')
+          .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+          .join(' '),
+      ),
+    ),
+  );
+  logger.log(buildSeparator());
+
+  for (const row of rows) {
+    const cells = headers.map((header) => {
+      const value = row[header];
+      return value === null || value === undefined ? '—' : String(value);
+    });
+    logger.log(buildRow(cells));
+  }
+
+  logger.log(buildSeparator());
+};
+
+export const listWahaConversations = async (logger: Logger = console): Promise<WahaConversationRow[]> => {
+  const baseUrlEnv = process.env.WAHA_BASE_URL;
+  if (!baseUrlEnv || !baseUrlEnv.trim()) {
+    throw new WahaRequestError('WAHA_BASE_URL environment variable is not defined');
+  }
+
+  const baseUrl = normalizeBaseUrl(baseUrlEnv.trim());
+  const token = process.env.WAHA_TOKEN?.trim();
+  const timeoutMs = readTimeoutFromEnv();
+  const headers = buildHeaders(token);
+  const fetchOptions: FetchOptions = { headers, timeoutMs };
+
+  const payload = await fetchJson(`${baseUrl}/api/v1/chats`, fetchOptions, logger);
+  const chats = extractChatArray(payload);
+
+  const results: WahaConversationRow[] = [];
+
+  for (const item of chats) {
+    if (!item || typeof item !== 'object') {
+      continue;
+    }
+    const chat = item as Record<string, unknown>;
+    const conversationId = ensureConversationId(chat);
+    if (!conversationId) {
+      continue;
+    }
+
+    const contactName = resolveContactName(chat, conversationId);
+    let photoUrl = resolveAvatar(chat) ?? null;
+
+    if (!photoUrl) {
+      const contactIdentifier = resolveContactIdentifier(chat, conversationId);
+      if (contactIdentifier) {
+        photoUrl = await fetchAvatarFromContact(baseUrl, contactIdentifier, fetchOptions, logger);
+      }
+    }
+
+    results.push({
+      conversation_id: conversationId,
+      contact_name: contactName,
+      photo_url: photoUrl,
+    });
+  }
+
+  printTable(results, logger);
+
+  return results;
+};
+

--- a/frontend/src/features/chat/components/WahaConversationsList.tsx
+++ b/frontend/src/features/chat/components/WahaConversationsList.tsx
@@ -1,0 +1,303 @@
+import { useEffect, useMemo, useState, type KeyboardEventHandler } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AlertCircle, Loader2, RefreshCw, Search } from "lucide-react";
+import clsx from "clsx";
+import { fetchWahaChats, type WahaChatSummary } from "../services/wahaChatApi";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { normalizeText } from "../utils/format";
+
+const PAGE_SIZE = 50;
+
+const messages = {
+  "pt-BR": {
+    title: "Conversas",
+    subtitle: "Chats sincronizados com o WAHA",
+    searchPlaceholder: "Buscar por nome ou ID",
+    loading: "Carregando conversas...",
+    empty: "Nenhuma conversa encontrada",
+    error: "Não foi possível carregar as conversas.",
+    retry: "Tentar novamente",
+    refresh: "Atualizar",
+    pagination: {
+      previous: "Anterior",
+      next: "Próxima",
+      summary: (start: number, end: number, total: number) =>
+        `Mostrando ${start}–${end} de ${total}`,
+    },
+  },
+};
+
+const locale = "pt-BR" as const;
+const t = messages[locale];
+
+const getInitials = (value: string) => {
+  const words = value
+    .split(/\s+/)
+    .filter((item) => item.length > 0)
+    .slice(0, 2);
+  if (words.length === 0) {
+    return "?";
+  }
+  return words
+    .map((word) => word.charAt(0).toUpperCase())
+    .join("");
+};
+
+const buildItemId = (conversationId: string) =>
+  `waha-conversation-${conversationId.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+
+const filterConversations = (conversations: WahaChatSummary[], query: string) => {
+  if (!query) {
+    return conversations;
+  }
+  const normalizedQuery = normalizeText(query);
+  return conversations.filter((conversation) => {
+    const normalizedName = normalizeText(conversation.contact_name);
+    const normalizedId = normalizeText(conversation.conversation_id);
+    return (
+      normalizedName.includes(normalizedQuery) ||
+      normalizedId.includes(normalizedQuery)
+    );
+  });
+};
+
+const paginate = (conversations: WahaChatSummary[], page: number) => {
+  const start = page * PAGE_SIZE;
+  const end = start + PAGE_SIZE;
+  return conversations.slice(start, end);
+};
+
+export const WahaConversationsList = () => {
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(0);
+  const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
+  const debouncedSearch = useDebouncedValue(search, 300);
+
+  const { data, isLoading, isError, refetch, isFetching, error } = useQuery({
+    queryKey: ["waha", "chats"],
+    queryFn: ({ signal }) => fetchWahaChats({ signal }),
+    staleTime: 30_000,
+  });
+
+  const filtered = useMemo(
+    () => filterConversations(data ?? [], debouncedSearch),
+    [data, debouncedSearch],
+  );
+
+  useEffect(() => {
+    setPage(0);
+  }, [debouncedSearch]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages - 1);
+  const paginated = useMemo(
+    () => paginate(filtered, currentPage),
+    [filtered, currentPage],
+  );
+
+  useEffect(() => {
+    if (paginated.length > 0) {
+      setFocusedIndex(0);
+    } else {
+      setFocusedIndex(null);
+    }
+  }, [paginated]);
+
+  useEffect(() => {
+    if (focusedIndex === null) {
+      return;
+    }
+    const conversation = paginated[focusedIndex];
+    if (!conversation) {
+      return;
+    }
+    const element = document.getElementById(buildItemId(conversation.conversation_id));
+    element?.scrollIntoView({ block: "nearest" });
+  }, [focusedIndex, paginated]);
+
+  const handleListKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
+    if (!paginated.length) {
+      return;
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setFocusedIndex((current) => {
+        const next = current === null ? 0 : Math.min(paginated.length - 1, current + 1);
+        return next;
+      });
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setFocusedIndex((current) => {
+        const next = current === null ? 0 : Math.max(0, current - 1);
+        return next;
+      });
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      setFocusedIndex(0);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      setFocusedIndex(paginated.length - 1);
+    }
+  };
+
+  const summaryStart = filtered.length === 0 ? 0 : currentPage * PAGE_SIZE + 1;
+  const summaryEnd = Math.min(filtered.length, summaryStart + paginated.length - 1);
+
+  return (
+    <div className="flex h-full flex-col gap-6 p-6">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold leading-tight text-foreground">
+            {t.title}
+          </h1>
+          <p className="text-sm text-muted-foreground">{t.subtitle}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="inline-flex items-center gap-2 rounded-md border border-input bg-background px-4 py-2 text-sm font-medium text-foreground shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={isFetching}
+        >
+          {isFetching ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <RefreshCw className="h-4 w-4" aria-hidden="true" />
+          )}
+          <span className="hidden sm:inline">{t.refresh}</span>
+        </button>
+      </header>
+
+      <div className="flex items-center gap-3 rounded-lg border border-input bg-background px-4 py-3 shadow-sm">
+        <Search className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+        <input
+          type="search"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder={t.searchPlaceholder}
+          className="flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+          aria-label={t.searchPlaceholder}
+        />
+      </div>
+
+      <div className="flex flex-col gap-4">
+        <div
+          role="list"
+          aria-busy={isFetching}
+          tabIndex={0}
+          onKeyDown={handleListKeyDown}
+          className="relative flex-1 overflow-hidden rounded-xl border border-input bg-card shadow-sm focus:outline-none"
+        >
+          <div className="h-full overflow-auto">
+            {isLoading ? (
+              <ul className="divide-y divide-border" aria-label={t.loading}>
+                {Array.from({ length: 6 }).map((_, index) => (
+                  <li key={`skeleton-${index}`} className="flex items-center gap-4 px-4 py-4">
+                    <div className="h-12 w-12 animate-pulse rounded-full bg-muted" />
+                    <div className="flex-1 space-y-2">
+                      <div className="h-4 w-1/3 animate-pulse rounded bg-muted" />
+                      <div className="h-3 w-1/2 animate-pulse rounded bg-muted" />
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : isError ? (
+              <div className="flex h-full flex-col items-center justify-center gap-3 px-6 py-12 text-center">
+                <AlertCircle className="h-6 w-6 text-destructive" aria-hidden="true" />
+                <p className="text-sm text-muted-foreground">
+                  {error instanceof Error ? error.message : t.error}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => refetch()}
+                  className="inline-flex items-center gap-2 rounded-md border border-input bg-background px-4 py-2 text-sm font-medium text-foreground shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                >
+                  {t.retry}
+                </button>
+              </div>
+            ) : filtered.length === 0 ? (
+              <div className="flex h-full items-center justify-center px-6 py-12 text-sm text-muted-foreground">
+                {t.empty}
+              </div>
+            ) : (
+              <ul className="divide-y divide-border">
+                {paginated.map((conversation, index) => {
+                  const itemId = buildItemId(conversation.conversation_id);
+                  const isFocused = focusedIndex === index;
+                  return (
+                    <li
+                      key={conversation.conversation_id}
+                      id={itemId}
+                      role="listitem"
+                      data-focused={isFocused}
+                      className={clsx(
+                        "flex cursor-default items-center gap-4 px-4 py-4 transition",
+                        "focus-within:outline-none",
+                        "data-[focused=true]:bg-muted/40 data-[focused=true]:ring-2 data-[focused=true]:ring-primary",
+                      )}
+                      tabIndex={-1}
+                      onMouseEnter={() => setFocusedIndex(index)}
+                    >
+                      {conversation.photo_url ? (
+                        <img
+                          src={conversation.photo_url}
+                          alt=""
+                          className="h-12 w-12 flex-shrink-0 rounded-full object-cover"
+                          aria-hidden="true"
+                        />
+                      ) : (
+                        <div
+                          className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-muted text-sm font-semibold text-muted-foreground"
+                          aria-hidden="true"
+                        >
+                          {getInitials(conversation.contact_name || conversation.conversation_id)}
+                        </div>
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium text-foreground">
+                          {conversation.contact_name}
+                        </p>
+                        <p className="truncate text-xs text-muted-foreground">
+                          {conversation.conversation_id}
+                        </p>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
+          <p>
+            {filtered.length === 0
+              ? t.pagination.summary(0, 0, 0)
+              : t.pagination.summary(summaryStart, summaryEnd, filtered.length)}
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setPage((value) => Math.max(0, value - 1))}
+              disabled={currentPage === 0 || filtered.length === 0}
+              className="inline-flex items-center rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {t.pagination.previous}
+            </button>
+            <span className="tabular-nums">
+              {filtered.length === 0 ? "0 / 0" : `${currentPage + 1} / ${totalPages}`}
+            </span>
+            <button
+              type="button"
+              onClick={() => setPage((value) => Math.min(totalPages - 1, value + 1))}
+              disabled={currentPage >= totalPages - 1 || filtered.length === 0}
+              className="inline-flex items-center rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {t.pagination.next}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+

--- a/frontend/src/features/chat/services/wahaChatApi.ts
+++ b/frontend/src/features/chat/services/wahaChatApi.ts
@@ -1,0 +1,28 @@
+export interface WahaChatSummary {
+  conversation_id: string;
+  contact_name: string;
+  photo_url: string | null;
+}
+
+const parseResponse = async (response: Response): Promise<WahaChatSummary[]> => {
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(text || `Erro ao consultar conversas (${response.status})`);
+  }
+  if (!text) {
+    return [];
+  }
+  try {
+    return JSON.parse(text) as WahaChatSummary[];
+  } catch (error) {
+    throw new Error(`Não foi possível interpretar a resposta do servidor: ${(error as Error).message}`);
+  }
+};
+
+export const fetchWahaChats = async (options: { signal?: AbortSignal } = {}): Promise<WahaChatSummary[]> => {
+  const response = await fetch("/api/chats", {
+    signal: options.signal,
+  });
+  return parseResponse(response);
+};
+

--- a/frontend/src/hooks/useDebouncedValue.ts
+++ b/frontend/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+export const useDebouncedValue = <T>(value: T, delay: number): T => {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const handler = window.setTimeout(() => {
+      setDebounced(value);
+    }, delay);
+
+    return () => {
+      window.clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debounced;
+};
+

--- a/frontend/src/pages/Conversas.tsx
+++ b/frontend/src/pages/Conversas.tsx
@@ -1,5 +1,9 @@
-import { ChatPage } from "../features/chat/ChatPage";
+import { WahaConversationsList } from "../features/chat/components/WahaConversationsList";
 
-const Conversas = () => <ChatPage />;
+const Conversas = () => (
+  <div className="h-full bg-background">
+    <WahaConversationsList />
+  </div>
+);
 
 export default Conversas;


### PR DESCRIPTION
## Summary
- add a WAHA chat fetcher with retries, logging and console table output alongside a proxy controller
- expose the new `/api/chats` endpoint and ship typed fetch helpers plus UI states for the omnichannel list
- integrate a debounced React conversations table with search, pagination, skeletons and avatar fallbacks

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca08435948832699825e8f95ea6e45