### PR TITLE
Improve WAHA chat error messaging for gateway errors

### DIFF
--- a/frontend/src/features/chat/services/wahaChatApi.ts
+++ b/frontend/src/features/chat/services/wahaChatApi.ts
@@ -4,10 +4,83 @@ export interface WahaChatSummary {
   photo_url: string | null;
 }
 
+const STATUS_MESSAGES: Partial<Record<number, string>> = {
+  502:
+    "Não foi possível acessar o serviço de conversas (erro 502). Verifique se o WAHA está em execução.",
+  503:
+    "O serviço de conversas está indisponível no momento (erro 503). Tente novamente em instantes.",
+  504:
+    "O serviço de conversas demorou muito para responder (erro 504). Tente novamente em instantes.",
+};
+
+const sanitizeHtml = (value: string) =>
+  value
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const extractMessageFromJson = (payload: unknown) => {
+  if (typeof payload === "string") {
+    const trimmed = payload.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (payload && typeof payload === "object") {
+    const data = payload as Record<string, unknown>;
+    for (const key of ["message", "error", "detail"]) {
+      const value = data[key];
+      if (typeof value === "string" && value.trim().length > 0) {
+        return value.trim();
+      }
+    }
+  }
+
+  return null;
+};
+
+const buildErrorMessage = (response: Response, rawBody: string) => {
+  const fallback =
+    STATUS_MESSAGES[response.status] ??
+    (response.status
+      ? `Erro ao consultar conversas (${response.status}${
+          response.statusText ? ` - ${response.statusText}` : ""
+        })`
+      : "Erro ao consultar conversas");
+
+  const trimmedBody = rawBody.trim();
+
+  if (!trimmedBody) {
+    return fallback;
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  const looksLikeJson = trimmedBody.startsWith("{") || trimmedBody.startsWith("[");
+
+  if (contentType.includes("application/json") || looksLikeJson) {
+    try {
+      const parsed = JSON.parse(trimmedBody) as unknown;
+      const message = extractMessageFromJson(parsed);
+      if (message) {
+        return message;
+      }
+    } catch {
+      // Se não for possível interpretar como JSON, seguimos para as demais heurísticas.
+    }
+  }
+
+  if (/<!doctype html/i.test(trimmedBody) || /^<html/i.test(trimmedBody)) {
+    return fallback;
+  }
+
+  const sanitized = sanitizeHtml(trimmedBody);
+  return sanitized.length > 0 ? sanitized : fallback;
+};
+
 const parseResponse = async (response: Response): Promise<WahaChatSummary[]> => {
   const text = await response.text();
   if (!response.ok) {
-    throw new Error(text || `Erro ao consultar conversas (${response.status})`);
+    throw new Error(buildErrorMessage(response, text));
   }
   if (!text) {
     return [];


### PR DESCRIPTION
## Summary
- add heuristics to sanitize WAHA chat API error responses and provide friendly messaging for gateway outages
- keep JSON parsing when available while avoiding raw HTML bubbling into the UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca157103e883268e26d3fbdc0f4beb