### PR TITLE
Resolve chat schema SQL detection and trim WAHA API parsing

### DIFF
--- a/backend/src/services/chatSchema.ts
+++ b/backend/src/services/chatSchema.ts
@@ -1,6 +1,5 @@
 import { access, readFile } from 'node:fs/promises';
 import { constants } from 'node:fs';
-import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import pool from './db';
 
@@ -46,9 +45,6 @@ async function resolveSchemaPath(): Promise<string> {
     `Chat schema file not found. Checked: ${candidatePaths.map((candidate) => `"${candidate}"`).join(', ')}`,
   );
 }
-=======
-
-const resolveSchemaPath = () => path.resolve(__dirname, '../..', 'sql', 'chat.sql');
 async function loadSchemaSql(): Promise<string> {
   if (cachedSql) {
     return cachedSql;

--- a/frontend/src/features/chat/services/wahaChatApi.ts
+++ b/frontend/src/features/chat/services/wahaChatApi.ts
@@ -78,13 +78,16 @@ const buildErrorMessage = (response: Response, rawBody: string) => {
 };
 
 const parseResponse = async (response: Response): Promise<WahaChatSummary[]> => {
-  const text = await response.text();
+  const rawText = await response.text();
   if (!response.ok) {
-    throw new Error(buildErrorMessage(response, text));
+    throw new Error(buildErrorMessage(response, rawText));
   }
+
+  const text = rawText.trim();
   if (!text) {
     return [];
   }
+
   try {
     return JSON.parse(text) as WahaChatSummary[];
   } catch (error) {


### PR DESCRIPTION
## Summary
- restore the dynamic chat schema path resolution and remove leftover merge conflict markers
- trim WAHA chat API responses before parsing JSON so blank payloads no longer throw syntax errors

## Testing
- npm --prefix backend run build
- npm --prefix frontend run build
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca19bee18c8326a9f55883d0d2ab62