### PR TITLE
Handle WAHA outages gracefully when listing conversations

### DIFF
--- a/backend/src/controllers/chatController.ts
+++ b/backend/src/controllers/chatController.ts
@@ -92,6 +92,8 @@ export async function listConversationsHandler(req: Request, res: Response) {
   const forceRemote = source === 'waha';
   const session = typeof req.query.session === 'string' ? req.query.session : undefined;
   const limit = parseConversationLimit(req.query.limit);
+  let wahaStatus: 'disabled' | 'degraded' | 'local-only' | undefined;
+  let wahaError: string | undefined;
 
   if (!preferLocal) {
     try {
@@ -106,17 +108,35 @@ export async function listConversationsHandler(req: Request, res: Response) {
           return res.status(503).json({ error: error.message });
         }
         console.warn('WAHA integration not configured, falling back to local conversations');
+        wahaStatus = 'disabled';
+        wahaError = error.message;
       } else if (error instanceof ChatValidationError) {
         return res.status(400).json({ error: error.message });
       } else {
         console.error('Failed to list WAHA chats', error);
-        return res.status(502).json({ error: 'Failed to load conversations from WAHA' });
+        if (forceRemote) {
+          return res.status(502).json({ error: 'Failed to load conversations from WAHA' });
+        }
+        wahaStatus = 'degraded';
+        wahaError = 'Failed to load conversations from WAHA';
       }
     }
   }
 
   try {
     const conversations = await chatService.listConversations();
+    if (!wahaStatus && preferLocal) {
+      wahaStatus = 'local-only';
+    }
+    if (wahaStatus) {
+      res.setHeader('X-WAHA-Status', wahaStatus);
+    }
+    if (wahaError) {
+      const sanitizedError = wahaError.replace(/[\r\n]+/g, ' ').trim();
+      if (sanitizedError) {
+        res.setHeader('X-WAHA-Error', sanitizedError);
+      }
+    }
     res.json(conversations);
   } catch (error) {
     console.error('Failed to list conversations', error);


### PR DESCRIPTION
## Summary
- fall back to local conversations when the WAHA integration is unavailable and surface status headers
- log WAHA status indicators on the chat list client to aid troubleshooting when the backend degrades

## Testing
- npm test
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68ca1c61d4708326ae406b539d720c69