### PR TITLE
Use stored WAHA integration settings when listing chats

### DIFF
--- a/backend/dist/services/wahaChatFetcher.js
+++ b/backend/dist/services/wahaChatFetcher.js
@@ -1,7 +1,41 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.listWahaConversations = exports.WahaRequestError = void 0;
 const promises_1 = require("node:timers/promises");
+const wahaConfigService_1 = __importStar(require("./wahaConfigService"));
 class WahaRequestError extends Error {
     constructor(message, status, responseBody) {
         super(message);
@@ -14,6 +48,7 @@ exports.WahaRequestError = WahaRequestError;
 const DEFAULT_TIMEOUT_MS = 15000;
 const MAX_ATTEMPTS = 3;
 const RETRYABLE_STATUS = new Set([429]);
+const configService = new wahaConfigService_1.default();
 const addRetryableRange = (set, start, end) => {
     for (let status = start; status <= end; status += 1) {
         set.add(status);
@@ -198,12 +233,36 @@ const printTable = (rows, logger) => {
     logger.log(buildSeparator());
 };
 const listWahaConversations = async (logger = console) => {
-    const baseUrlEnv = process.env.WAHA_BASE_URL;
-    if (!baseUrlEnv || !baseUrlEnv.trim()) {
-        throw new WahaRequestError('WAHA_BASE_URL environment variable is not defined');
+    let baseUrl;
+    let token;
+    let configError;
+    try {
+        const config = await configService.requireConfig();
+        baseUrl = config.baseUrl;
+        token = config.apiKey;
     }
-    const baseUrl = normalizeBaseUrl(baseUrlEnv.trim());
-    const token = process.env.WAHA_TOKEN?.trim();
+    catch (error) {
+        if (error instanceof wahaConfigService_1.ValidationError) {
+            configError = error;
+            logger.warn(`WAHA configuration warning: ${error.message}`);
+        }
+        else {
+            throw error;
+        }
+    }
+    if (!baseUrl) {
+        const baseUrlEnv = process.env.WAHA_BASE_URL?.trim();
+        if (baseUrlEnv) {
+            baseUrl = normalizeBaseUrl(baseUrlEnv);
+            token = token ?? process.env.WAHA_TOKEN?.trim();
+        }
+    }
+    if (!baseUrl) {
+        const message = configError?.message ?? 'WAHA_BASE_URL environment variable is not defined';
+        const status = configError ? 503 : undefined;
+        throw new WahaRequestError(message, status);
+    }
+    baseUrl = normalizeBaseUrl(baseUrl);
     const timeoutMs = readTimeoutFromEnv();
     const headers = buildHeaders(token);
     const fetchOptions = { headers, timeoutMs };

--- a/backend/src/services/wahaChatFetcher.ts
+++ b/backend/src/services/wahaChatFetcher.ts
@@ -1,4 +1,7 @@
 import { setTimeout as delay } from 'node:timers/promises';
+import WahaConfigService, {
+  ValidationError as ConfigValidationError,
+} from './wahaConfigService';
 
 export interface WahaConversationRow {
   conversation_id: string;
@@ -33,6 +36,8 @@ type MinimalFetchResponse = {
 const DEFAULT_TIMEOUT_MS = 15_000;
 const MAX_ATTEMPTS = 3;
 const RETRYABLE_STATUS = new Set([429]);
+
+const configService = new WahaConfigService();
 
 const addRetryableRange = (set: Set<number>, start: number, end: number) => {
   for (let status = start; status <= end; status += 1) {
@@ -310,13 +315,39 @@ const printTable = (rows: WahaConversationRow[], logger: Logger) => {
 };
 
 export const listWahaConversations = async (logger: Logger = console): Promise<WahaConversationRow[]> => {
-  const baseUrlEnv = process.env.WAHA_BASE_URL;
-  if (!baseUrlEnv || !baseUrlEnv.trim()) {
-    throw new WahaRequestError('WAHA_BASE_URL environment variable is not defined');
+  let baseUrl: string | undefined;
+  let token: string | undefined;
+  let configError: ConfigValidationError | undefined;
+
+  try {
+    const config = await configService.requireConfig();
+    baseUrl = config.baseUrl;
+    token = config.apiKey;
+  } catch (error) {
+    if (error instanceof ConfigValidationError) {
+      configError = error;
+      logger.warn(`WAHA configuration warning: ${error.message}`);
+    } else {
+      throw error;
+    }
   }
 
-  const baseUrl = normalizeBaseUrl(baseUrlEnv.trim());
-  const token = process.env.WAHA_TOKEN?.trim();
+  if (!baseUrl) {
+    const baseUrlEnv = process.env.WAHA_BASE_URL?.trim();
+    if (baseUrlEnv) {
+      baseUrl = normalizeBaseUrl(baseUrlEnv);
+      token = token ?? process.env.WAHA_TOKEN?.trim();
+    }
+  }
+
+  if (!baseUrl) {
+    const message = configError?.message ?? 'WAHA_BASE_URL environment variable is not defined';
+    const status = configError ? 503 : undefined;
+    throw new WahaRequestError(message, status);
+  }
+
+  baseUrl = normalizeBaseUrl(baseUrl);
+
   const timeoutMs = readTimeoutFromEnv();
   const headers = buildHeaders(token);
   const fetchOptions: FetchOptions = { headers, timeoutMs };


### PR DESCRIPTION
## Summary
- load WAHA base URL and API key from the persisted integration configuration instead of only environment variables
- fall back to the legacy environment variables when no active configuration exists and surface configuration errors as 503 responses
- rebuild the compiled service bundle to include the new behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca20cfbab483269ec0091fd0a183b5