### PR TITLE
Handle WAHA session configuration and add coverage

### DIFF
--- a/backend/dist/services/wahaChatFetcher.js
+++ b/backend/dist/services/wahaChatFetcher.js
@@ -47,6 +47,12 @@ exports.WahaRequestError = WahaRequestError;
 const DEFAULT_TIMEOUT_MS = 15000;
 const MAX_ATTEMPTS = 3;
 const RETRYABLE_STATUS = new Set([429]);
+const BASE_URL_SUFFIXES_TO_REMOVE = [
+    /\/v\d+\/messages$/i,
+    /\/v\d+$/i,
+    /\/api\/send[a-z]+$/i,
+    /\/api$/i,
+];
 let configModulePromise;
 let cachedConfigService;
 const isMissingDatabaseError = (error) => error instanceof Error &&
@@ -82,7 +88,57 @@ const addRetryableRange = (set, start, end) => {
     }
 };
 addRetryableRange(RETRYABLE_STATUS, 500, 599);
-const normalizeBaseUrl = (value) => value.replace(/\/+$/, '');
+const stripKnownSuffixes = (pathname) => {
+    let result = pathname;
+    let updated = true;
+    while (updated) {
+        updated = false;
+        for (const suffix of BASE_URL_SUFFIXES_TO_REMOVE) {
+            if (suffix.test(result)) {
+                result = result.replace(suffix, '');
+                updated = true;
+            }
+        }
+    }
+    return result.replace(/\/+$/, '');
+};
+const tryParsePathname = (value) => {
+    try {
+        const parsed = new URL(value);
+        return parsed.pathname ?? '';
+    }
+    catch {
+        return '';
+    }
+};
+const normalizeBaseUrl = (value) => {
+    const trimmed = value.trim().replace(/\/+$/, '');
+    try {
+        const parsed = new URL(trimmed);
+        parsed.pathname = stripKnownSuffixes(parsed.pathname ?? '');
+        parsed.hash = '';
+        return parsed.toString().replace(/\/+$/, '');
+    }
+    catch {
+        return trimmed;
+    }
+};
+const hasSessionPath = (baseUrl) => {
+    const pathname = tryParsePathname(baseUrl);
+    return looksLikeSessionScopedPath(pathname);
+};
+const DATABASE_CONNECTION_ERROR_CODES = new Set([
+    'ECONNREFUSED',
+    'ENOTFOUND',
+    'EAI_AGAIN',
+    'ECONNRESET',
+    'ETIMEDOUT',
+]);
+const isDatabaseConnectionError = (error) => !!error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    typeof error.code === 'string' &&
+    DATABASE_CONNECTION_ERROR_CODES.has(error.code);
 const looksLikeSessionScopedPath = (pathname) => {
     const segments = pathname
         .split('/')
@@ -97,32 +153,28 @@ const looksLikeSessionScopedPath = (pathname) => {
     const second = segments[1];
     return !/^v\d+$/i.test(second);
 };
-const buildChatEndpointCandidates = (baseUrl) => {
-    const normalized = normalizeBaseUrl(baseUrl);
+const buildChatEndpointCandidates = (baseUrl, sessionId) => {
+    const normalized = baseUrl;
     const candidates = new Set();
     if (/\/chats$/i.test(normalized)) {
         candidates.add(normalized);
         return Array.from(candidates);
     }
-    let pathname = '';
-    try {
-        const parsed = new URL(normalized);
-        pathname = parsed.pathname ?? '';
-    }
-    catch {
-        pathname = '';
-    }
-    const hasSessionPath = looksLikeSessionScopedPath(pathname);
-    if (!hasSessionPath) {
-        candidates.add(`${normalized}/api/QuantumTecnologia01/chats`);
+    const hasSession = hasSessionPath(normalized);
+    if (!hasSession) {
+        if (sessionId) {
+            const encodedSession = encodeURIComponent(sessionId);
+            candidates.add(`${normalized}/api/${encodedSession}/chats`);
+        }
+        candidates.add(`${normalized}/api/v1/chats`);
         candidates.add(`${normalized}/api/chats`);
     }
     candidates.add(`${normalized}/chats`);
     return Array.from(candidates);
 };
 const shouldFallbackToNextEndpoint = (error) => error instanceof WahaRequestError && typeof error.status === 'number' && [404, 405].includes(error.status);
-const fetchChatsPayload = async (baseUrl, options, logger) => {
-    const endpoints = buildChatEndpointCandidates(baseUrl);
+const fetchChatsPayload = async (baseUrl, options, logger, sessionId) => {
+    const endpoints = buildChatEndpointCandidates(baseUrl, sessionId);
     let lastError;
     for (const endpoint of endpoints) {
         try {
@@ -166,6 +218,7 @@ const firstNonEmptyString = (...values) => {
     }
     return undefined;
 };
+const resolveConfiguredSessionId = () => firstNonEmptyString(process.env.WAHA_SESSION, process.env.WAHA_SESSION_ID, process.env.WAHA_DEFAULT_SESSION);
 const buildHeaders = (token) => {
     const headers = {
         Accept: 'application/json',
@@ -276,10 +329,20 @@ const ensureConversationId = (chat) => firstNonEmptyString(chat.id, chat.chatId,
 const resolveContactName = (chat, fallbackId) => firstNonEmptyString(chat.name, chat.contactName, chat.pushName, chat.formattedName, chat.contact?.name, fallbackId) ?? fallbackId;
 const resolveAvatar = (chat) => firstNonEmptyString(chat.avatar, chat.photoUrl, chat.photoURL, chat.profilePicUrl, chat.profilePicURL, chat.contact?.avatar, chat.contact?.profilePicUrl);
 const resolveContactIdentifier = (chat, fallbackId) => firstNonEmptyString(chat.contactId, chat.contact_id, chat.contact?.id, fallbackId);
-const buildContactUrl = (baseUrl, contactId) => `${baseUrl}/api/QuantumTecnologia01/contacts/${encodeURIComponent(contactId)}`;
-async function fetchAvatarFromContact(baseUrl, contactId, options, logger) {
+const buildContactUrl = (baseUrl, contactId, sessionId) => {
+    const encodedContact = encodeURIComponent(contactId);
+    if (hasSessionPath(baseUrl)) {
+        return `${baseUrl}/contacts/${encodedContact}`;
+    }
+    if (sessionId) {
+        const encodedSession = encodeURIComponent(sessionId);
+        return `${baseUrl}/api/${encodedSession}/contacts/${encodedContact}`;
+    }
+    return `${baseUrl}/api/v1/contacts/${encodedContact}`;
+};
+async function fetchAvatarFromContact(baseUrl, contactId, options, logger, sessionId) {
     try {
-        const payload = await fetchJson(buildContactUrl(baseUrl, contactId), options, logger);
+        const payload = await fetchJson(buildContactUrl(baseUrl, contactId, sessionId), options, logger);
         if (!payload || typeof payload !== 'object') {
             return null;
         }
@@ -325,29 +388,33 @@ const listWahaConversations = async (logger = console) => {
     let baseUrl;
     let token;
     let configError;
-    const configDependencies = await getConfigDependencies();
-    if (configDependencies) {
-        const { service, ValidationError: ConfigValidationError } = configDependencies;
-        try {
-            const config = await service.requireConfig();
-            baseUrl = config.baseUrl;
-            token = config.apiKey;
-        }
-        catch (error) {
-            if (error instanceof ConfigValidationError) {
-                configError = error;
-                logger.warn(`WAHA configuration warning: ${error.message}`);
-            }
-            else {
-                throw error;
-            }
-        }
+    const baseUrlEnv = process.env.WAHA_BASE_URL?.trim();
+    if (baseUrlEnv) {
+        baseUrl = baseUrlEnv;
+        token = process.env.WAHA_TOKEN?.trim();
     }
-    if (!baseUrl) {
-        const baseUrlEnv = process.env.WAHA_BASE_URL?.trim();
-        if (baseUrlEnv) {
-            baseUrl = normalizeBaseUrl(baseUrlEnv);
-            token = token ?? process.env.WAHA_TOKEN?.trim();
+    if (!baseUrl || !token) {
+        const configDependencies = await getConfigDependencies();
+        if (configDependencies) {
+            const { service, ValidationError: ConfigValidationError } = configDependencies;
+            try {
+                const config = await service.requireConfig();
+                if (!baseUrl) {
+                    baseUrl = config.baseUrl;
+                }
+                if (!token) {
+                    token = config.apiKey;
+                }
+            }
+            catch (error) {
+                if (error instanceof ConfigValidationError || isDatabaseConnectionError(error)) {
+                    configError = error;
+                    logger.warn(`WAHA configuration warning: ${error.message}`);
+                }
+                else {
+                    throw error;
+                }
+            }
         }
     }
     if (!baseUrl) {
@@ -356,10 +423,11 @@ const listWahaConversations = async (logger = console) => {
         throw new WahaRequestError(message, status);
     }
     baseUrl = normalizeBaseUrl(baseUrl);
+    const sessionId = resolveConfiguredSessionId();
     const timeoutMs = readTimeoutFromEnv();
     const headers = buildHeaders(token);
     const fetchOptions = { headers, timeoutMs };
-    const { payload } = await fetchChatsPayload(baseUrl, fetchOptions, logger);
+    const { payload } = await fetchChatsPayload(baseUrl, fetchOptions, logger, sessionId);
     const chats = extractChatArray(payload);
     const results = [];
     for (const item of chats) {
@@ -376,7 +444,7 @@ const listWahaConversations = async (logger = console) => {
         if (!photoUrl) {
             const contactIdentifier = resolveContactIdentifier(chat, conversationId);
             if (contactIdentifier) {
-                photoUrl = await fetchAvatarFromContact(baseUrl, contactIdentifier, fetchOptions, logger);
+                photoUrl = await fetchAvatarFromContact(baseUrl, contactIdentifier, fetchOptions, logger, sessionId);
             }
         }
         results.push({

--- a/backend/src/services/wahaChatFetcher.ts
+++ b/backend/src/services/wahaChatFetcher.ts
@@ -34,6 +34,13 @@ const DEFAULT_TIMEOUT_MS = 15_000;
 const MAX_ATTEMPTS = 3;
 const RETRYABLE_STATUS = new Set([429]);
 
+const BASE_URL_SUFFIXES_TO_REMOVE = [
+  /\/v\d+\/messages$/i,
+  /\/v\d+$/i,
+  /\/api\/send[a-z]+$/i,
+  /\/api$/i,
+];
+
 type WahaConfigModule = typeof import('./wahaConfigService');
 type WahaConfigServiceInstance = InstanceType<WahaConfigModule['default']>;
 type ConfigValidationErrorConstructor = WahaConfigModule['ValidationError'];
@@ -91,7 +98,64 @@ const addRetryableRange = (set: Set<number>, start: number, end: number) => {
 
 addRetryableRange(RETRYABLE_STATUS, 500, 599);
 
-const normalizeBaseUrl = (value: string) => value.replace(/\/+$/, '');
+const stripKnownSuffixes = (pathname: string): string => {
+  let result = pathname;
+  let updated = true;
+
+  while (updated) {
+    updated = false;
+    for (const suffix of BASE_URL_SUFFIXES_TO_REMOVE) {
+      if (suffix.test(result)) {
+        result = result.replace(suffix, '');
+        updated = true;
+      }
+    }
+  }
+
+  return result.replace(/\/+$/, '');
+};
+
+const tryParsePathname = (value: string): string => {
+  try {
+    const parsed = new URL(value);
+    return parsed.pathname ?? '';
+  } catch {
+    return '';
+  }
+};
+
+const normalizeBaseUrl = (value: string): string => {
+  const trimmed = value.trim().replace(/\/+$/, '');
+
+  try {
+    const parsed = new URL(trimmed);
+    parsed.pathname = stripKnownSuffixes(parsed.pathname ?? '');
+    parsed.hash = '';
+    return parsed.toString().replace(/\/+$/, '');
+  } catch {
+    return trimmed;
+  }
+};
+
+const hasSessionPath = (baseUrl: string): boolean => {
+  const pathname = tryParsePathname(baseUrl);
+  return looksLikeSessionScopedPath(pathname);
+};
+
+const DATABASE_CONNECTION_ERROR_CODES = new Set([
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'ECONNRESET',
+  'ETIMEDOUT',
+]);
+
+const isDatabaseConnectionError = (error: unknown): error is NodeJS.ErrnoException =>
+  !!error &&
+  typeof error === 'object' &&
+  'code' in error &&
+  typeof (error as NodeJS.ErrnoException).code === 'string' &&
+  DATABASE_CONNECTION_ERROR_CODES.has((error as NodeJS.ErrnoException).code as string);
 
 const looksLikeSessionScopedPath = (pathname: string): boolean => {
   const segments = pathname
@@ -111,8 +175,8 @@ const looksLikeSessionScopedPath = (pathname: string): boolean => {
   return !/^v\d+$/i.test(second);
 };
 
-const buildChatEndpointCandidates = (baseUrl: string): string[] => {
-  const normalized = normalizeBaseUrl(baseUrl);
+const buildChatEndpointCandidates = (baseUrl: string, sessionId?: string): string[] => {
+  const normalized = baseUrl;
   const candidates = new Set<string>();
 
   if (/\/chats$/i.test(normalized)) {
@@ -120,18 +184,13 @@ const buildChatEndpointCandidates = (baseUrl: string): string[] => {
     return Array.from(candidates);
   }
 
-  let pathname = '';
+  const hasSession = hasSessionPath(normalized);
 
-  try {
-    const parsed = new URL(normalized);
-    pathname = parsed.pathname ?? '';
-  } catch {
-    pathname = '';
-  }
-
-  const hasSessionPath = looksLikeSessionScopedPath(pathname);
-
-  if (!hasSessionPath) {
+  if (!hasSession) {
+    if (sessionId) {
+      const encodedSession = encodeURIComponent(sessionId);
+      candidates.add(`${normalized}/api/${encodedSession}/chats`);
+    }
     candidates.add(`${normalized}/api/v1/chats`);
     candidates.add(`${normalized}/api/chats`);
   }
@@ -148,8 +207,9 @@ const fetchChatsPayload = async (
   baseUrl: string,
   options: FetchOptions,
   logger: Logger,
+  sessionId: string | undefined,
 ): Promise<{ payload: unknown; endpoint: string }> => {
-  const endpoints = buildChatEndpointCandidates(baseUrl);
+  const endpoints = buildChatEndpointCandidates(baseUrl, sessionId);
   let lastError: unknown;
 
   for (const endpoint of endpoints) {
@@ -200,6 +260,13 @@ const firstNonEmptyString = (...values: unknown[]): string | undefined => {
   }
   return undefined;
 };
+
+const resolveConfiguredSessionId = (): string | undefined =>
+  firstNonEmptyString(
+    process.env.WAHA_SESSION,
+    process.env.WAHA_SESSION_ID,
+    process.env.WAHA_DEFAULT_SESSION,
+  );
 
 const buildHeaders = (token: string | undefined): Record<string, string> => {
   const headers: Record<string, string> = {
@@ -365,17 +432,30 @@ const resolveContactIdentifier = (chat: Record<string, unknown>, fallbackId: str
     fallbackId,
   );
 
-const buildContactUrl = (baseUrl: string, contactId: string) =>
-  `${baseUrl}/api/v1/contacts/${encodeURIComponent(contactId)}`;
+const buildContactUrl = (baseUrl: string, contactId: string, sessionId: string | undefined) => {
+  const encodedContact = encodeURIComponent(contactId);
+
+  if (hasSessionPath(baseUrl)) {
+    return `${baseUrl}/contacts/${encodedContact}`;
+  }
+
+  if (sessionId) {
+    const encodedSession = encodeURIComponent(sessionId);
+    return `${baseUrl}/api/${encodedSession}/contacts/${encodedContact}`;
+  }
+
+  return `${baseUrl}/api/v1/contacts/${encodedContact}`;
+};
 
 async function fetchAvatarFromContact(
   baseUrl: string,
   contactId: string,
   options: FetchOptions,
   logger: Logger,
+  sessionId: string | undefined,
 ): Promise<string | null> {
   try {
-    const payload = await fetchJson(buildContactUrl(baseUrl, contactId), options, logger);
+    const payload = await fetchJson(buildContactUrl(baseUrl, contactId, sessionId), options, logger);
     if (!payload || typeof payload !== 'object') {
       return null;
     }
@@ -448,30 +528,34 @@ export const listWahaConversations = async (logger: Logger = console): Promise<W
   let token: string | undefined;
   let configError: Error | undefined;
 
-  const configDependencies = await getConfigDependencies();
-
-  if (configDependencies) {
-    const { service, ValidationError: ConfigValidationError } = configDependencies;
-
-    try {
-      const config = await service.requireConfig();
-      baseUrl = config.baseUrl;
-      token = config.apiKey;
-    } catch (error) {
-      if (error instanceof ConfigValidationError) {
-        configError = error;
-        logger.warn(`WAHA configuration warning: ${error.message}`);
-      } else {
-        throw error;
-      }
-    }
+  const baseUrlEnv = process.env.WAHA_BASE_URL?.trim();
+  if (baseUrlEnv) {
+    baseUrl = baseUrlEnv;
+    token = process.env.WAHA_TOKEN?.trim();
   }
 
-  if (!baseUrl) {
-    const baseUrlEnv = process.env.WAHA_BASE_URL?.trim();
-    if (baseUrlEnv) {
-      baseUrl = normalizeBaseUrl(baseUrlEnv);
-      token = token ?? process.env.WAHA_TOKEN?.trim();
+  if (!baseUrl || !token) {
+    const configDependencies = await getConfigDependencies();
+
+    if (configDependencies) {
+      const { service, ValidationError: ConfigValidationError } = configDependencies;
+
+      try {
+        const config = await service.requireConfig();
+        if (!baseUrl) {
+          baseUrl = config.baseUrl;
+        }
+        if (!token) {
+          token = config.apiKey;
+        }
+      } catch (error) {
+        if (error instanceof ConfigValidationError || isDatabaseConnectionError(error)) {
+          configError = error as Error;
+          logger.warn(`WAHA configuration warning: ${error.message}`);
+        } else {
+          throw error;
+        }
+      }
     }
   }
 
@@ -482,12 +566,13 @@ export const listWahaConversations = async (logger: Logger = console): Promise<W
   }
 
   baseUrl = normalizeBaseUrl(baseUrl);
+  const sessionId = resolveConfiguredSessionId();
 
   const timeoutMs = readTimeoutFromEnv();
   const headers = buildHeaders(token);
   const fetchOptions: FetchOptions = { headers, timeoutMs };
 
-  const { payload } = await fetchChatsPayload(baseUrl, fetchOptions, logger);
+  const { payload } = await fetchChatsPayload(baseUrl, fetchOptions, logger, sessionId);
   const chats = extractChatArray(payload);
 
   const results: WahaConversationRow[] = [];
@@ -508,7 +593,13 @@ export const listWahaConversations = async (logger: Logger = console): Promise<W
     if (!photoUrl) {
       const contactIdentifier = resolveContactIdentifier(chat, conversationId);
       if (contactIdentifier) {
-        photoUrl = await fetchAvatarFromContact(baseUrl, contactIdentifier, fetchOptions, logger);
+        photoUrl = await fetchAvatarFromContact(
+          baseUrl,
+          contactIdentifier,
+          fetchOptions,
+          logger,
+          sessionId,
+        );
       }
     }
 

--- a/backend/tests/wahaChatFetcher.test.ts
+++ b/backend/tests/wahaChatFetcher.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { listWahaConversations } from '../src/services/wahaChatFetcher';
+
+const LOGGER: Pick<Console, 'log' | 'warn' | 'error'> = {
+  log: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+const ENV_KEYS = ['WAHA_BASE_URL', 'WAHA_TOKEN', 'WAHA_SESSION', 'WAHA_SESSION_ID', 'WAHA_DEFAULT_SESSION'] as const;
+
+describe('wahaChatFetcher', () => {
+  const originalEnv: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = originalEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    globalThis.fetch = originalFetch;
+  });
+
+  it('normalizes base url with version suffix and applies configured session', async () => {
+    process.env.WAHA_BASE_URL = 'https://waha.example.com/api/v1/';
+    process.env.WAHA_TOKEN = 'token';
+    process.env.WAHA_SESSION = 'QuantumTecnologia01';
+
+    const requestedUrls: string[] = [];
+
+    globalThis.fetch = (async (input: any) => {
+      const url = typeof input === 'string' ? input : input?.toString?.() ?? String(input);
+      requestedUrls.push(url);
+
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify([
+            {
+              id: 'abc123',
+              name: 'Tester',
+              photoUrl: 'https://cdn.example.com/avatar.png',
+            },
+          ]),
+      } as any;
+    }) as typeof fetch;
+
+    const conversations = await listWahaConversations(LOGGER);
+
+    assert.deepEqual(conversations, [
+      {
+        conversation_id: 'abc123',
+        contact_name: 'Tester',
+        photo_url: 'https://cdn.example.com/avatar.png',
+      },
+    ]);
+
+    assert(
+      requestedUrls.includes('https://waha.example.com/api/QuantumTecnologia01/chats'),
+      'expected chats endpoint to include configured session',
+    );
+
+    assert(
+      !requestedUrls.some((url) => url.includes('/api/v1/api/')),
+      'should not duplicate API path segments when normalizing base url',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- normalize WAHA base URLs to strip legacy API suffixes and detect when a session segment is already present
- honour WAHA session environment variables when building chat and contact endpoints while handling database connection issues more gracefully
- cover the new behaviour with a unit test exercising the env-based configuration path

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca2e0f2f3c83269968703fec9246ee