### PR TITLE
Integrate WAHA WhatsApp Web embed into chat device linking

### DIFF
--- a/frontend/src/components/waha/WhatsAppWebEmbed.module.css
+++ b/frontend/src/components/waha/WhatsAppWebEmbed.module.css
@@ -1,0 +1,49 @@
+.container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 1rem;
+  border: 1px solid hsl(var(--border));
+  overflow: hidden;
+  background: hsl(var(--muted));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.iframe {
+  width: 100%;
+  height: 100%;
+  min-height: 360px;
+  border: none;
+  background: transparent;
+}
+
+.fallback {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2rem;
+  text-align: center;
+  border-radius: 1rem;
+  border: 1px dashed hsl(var(--border));
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+}
+
+.fallback h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.fallback p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.fallback code {
+  font-family: var(--font-mono, "JetBrains Mono", monospace);
+  font-size: 0.85rem;
+  color: hsl(var(--foreground));
+}

--- a/frontend/src/components/waha/WhatsAppWebEmbed.tsx
+++ b/frontend/src/components/waha/WhatsAppWebEmbed.tsx
@@ -1,0 +1,120 @@
+import { useMemo, type ReactNode } from "react";
+import clsx from "clsx";
+import styles from "./WhatsAppWebEmbed.module.css";
+
+const sanitize = (value?: string | null) => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const toAbsoluteUrl = (value: string) => {
+  try {
+    return new URL(value, window.location.origin).toString();
+  } catch (error) {
+    console.error("Não foi possível normalizar a URL do WhatsApp Web", error);
+    return value;
+  }
+};
+
+const resolvePathWithInstance = (path: string, instanceId: string) => {
+  const encoded = encodeURIComponent(instanceId);
+  if (path.includes(":instanceId") || path.includes("{instanceId}")) {
+    return path.replace(/:instanceId/g, encoded).replace(/{instanceId}/g, encoded);
+  }
+  if (path.length === 0 || path === ".") {
+    return encoded;
+  }
+  return `${path.replace(/\/+$/, "")}/${encoded}`;
+};
+
+export interface WhatsAppWebEmbedProps {
+  className?: string;
+  iframeClassName?: string;
+  title?: string;
+  /**
+   * Permite sobrescrever a URL final do iframe manualmente.
+   * Caso não seja informada, será utilizada a configuração do ambiente.
+   */
+  src?: string;
+  /**
+   * Caso definido, substitui o identificador de instância informado via variável de ambiente.
+   */
+  instanceId?: string;
+  fallback?: ReactNode;
+}
+
+export const WhatsAppWebEmbed = ({
+  className,
+  iframeClassName,
+  title = "WhatsApp Web",
+  src,
+  instanceId,
+  fallback,
+}: WhatsAppWebEmbedProps) => {
+  const resolvedSrc = useMemo(() => {
+    const env = import.meta.env as Record<string, string | undefined>;
+    const directUrl = sanitize(src) ?? sanitize(env.VITE_WAHA_WHATSAPP_WEB_URL);
+    const baseUrl = sanitize(env.VITE_WAHA_BASE_URL);
+    const pathTemplate = sanitize(env.VITE_WAHA_WHATSAPP_WEB_PATH);
+    const envInstanceId = sanitize(env.VITE_WAHA_INSTANCE_ID);
+    const activeInstanceId = sanitize(instanceId ?? envInstanceId);
+
+    if (directUrl) {
+      return toAbsoluteUrl(directUrl);
+    }
+
+    if (!baseUrl) {
+      return undefined;
+    }
+
+    let path = pathTemplate ?? "";
+
+    if (activeInstanceId) {
+      path = resolvePathWithInstance(path, activeInstanceId);
+    }
+
+    try {
+      const base = new URL(baseUrl, window.location.origin);
+      const finalUrl = new URL(path || ".", base).toString();
+      return finalUrl;
+    } catch (error) {
+      console.error("Não foi possível compor a URL do WAHA", error);
+      return undefined;
+    }
+  }, [instanceId, src]);
+
+  if (!resolvedSrc) {
+    return (
+      <div className={clsx(styles.fallback, className)}>
+        {fallback ?? (
+          <>
+            <h2>Integração com WhatsApp indisponível</h2>
+            <p>
+              Configure <code>VITE_WAHA_WHATSAPP_WEB_URL</code> ou defina{' '}
+              <code>VITE_WAHA_BASE_URL</code> e <code>VITE_WAHA_WHATSAPP_WEB_PATH</code> para
+              habilitar o painel.
+            </p>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={clsx(styles.container, className)}>
+      <iframe
+        src={resolvedSrc}
+        title={title}
+        className={clsx(styles.iframe, iframeClassName)}
+        allow="clipboard-read; clipboard-write; camera; microphone"
+        allowFullScreen
+        sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-modals"
+      />
+    </div>
+  );
+};
+
+export default WhatsAppWebEmbed;

--- a/frontend/src/components/waha/index.ts
+++ b/frontend/src/components/waha/index.ts
@@ -1,0 +1,2 @@
+export { WhatsAppWebEmbed } from "./WhatsAppWebEmbed";
+export type { WhatsAppWebEmbedProps } from "./WhatsAppWebEmbed";

--- a/frontend/src/features/chat/components/DeviceLinkModal.module.css
+++ b/frontend/src/features/chat/components/DeviceLinkModal.module.css
@@ -1,89 +1,67 @@
 .container {
-  display: flex;
+  display: grid;
   gap: 2rem;
   padding: 2rem;
-  align-items: stretch;
+  grid-template-columns: minmax(280px, 420px) minmax(0, 1fr);
+  align-items: start;
 }
 
-.qrSection {
+.integrationPanel {
   display: flex;
   flex-direction: column;
-  align-items: center;
   gap: 1rem;
-  min-width: 220px;
-}
-
-.qrFrame {
-  position: relative;
-  width: 220px;
-  aspect-ratio: 1;
-  border-radius: 1.25rem;
-  border: 1px solid hsl(var(--border));
-  background: linear-gradient(135deg, hsl(var(--accent)), hsl(var(--secondary)));
-  display: grid;
-  place-items: center;
-  padding: 1.75rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
-}
-
-.qrPattern {
-  width: 100%;
   height: 100%;
-  border-radius: 1rem;
-  background-image: repeating-linear-gradient(
-      45deg,
-      rgba(30, 64, 175, 0.9) 0,
-      rgba(30, 64, 175, 0.9) 6px,
-      rgba(255, 255, 255, 0.95) 6px,
-      rgba(255, 255, 255, 0.95) 12px
-    ),
-    repeating-linear-gradient(
-      -45deg,
-      rgba(15, 23, 42, 0.9) 0,
-      rgba(15, 23, 42, 0.9) 6px,
-      rgba(255, 255, 255, 0.95) 6px,
-      rgba(255, 255, 255, 0.95) 12px
-    );
-  position: relative;
-  overflow: hidden;
 }
 
-.codeChip {
-  position: absolute;
-  bottom: 1rem;
-  left: 50%;
-  transform: translateX(-50%);
-  background: rgba(15, 23, 42, 0.75);
-  color: #fff;
-  padding: 0.3rem 0.8rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+.integrationHeader h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.35rem;
+  font-weight: 700;
 }
 
-.refreshButton {
-  display: inline-flex;
+.integrationHeader p {
+  margin: 0;
+  color: hsl(var(--muted-foreground));
+  line-height: 1.6;
+}
+
+.embedWrapper {
+  flex: 1;
+  min-height: 380px;
+}
+
+.fallbackMessage {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  justify-content: center;
   align-items: center;
-  gap: 0.5rem;
-  border: none;
-  background: hsl(var(--primary));
-  color: hsl(var(--primary-foreground));
-  padding: 0.6rem 1rem;
-  border-radius: 999px;
-  font-size: 0.875rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: var(--transition-fast);
+  padding: 1.75rem;
+  text-align: center;
+  border-radius: 1rem;
+  border: 1px dashed hsl(var(--border));
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
 }
 
-.refreshButton:hover,
-.refreshButton:focus-visible {
-  background: hsl(var(--primary-hover));
+.fallbackMessage h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.fallbackMessage p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.fallbackMessage code {
+  font-family: var(--font-mono, "JetBrains Mono", monospace);
+  font-size: 0.85rem;
+  color: hsl(var(--foreground));
 }
 
 .instructions {
-  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
@@ -92,9 +70,11 @@
 .instructions h2 {
   font-size: 1.4rem;
   font-weight: 700;
+  margin: 0;
 }
 
 .instructions p {
+  margin: 0;
   color: hsl(var(--muted-foreground));
   line-height: 1.6;
 }
@@ -149,13 +129,16 @@
 
 @media (max-width: 900px) {
   .container {
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
+    grid-template-columns: 1fr;
+  }
+
+  .integrationPanel {
+    order: 2;
   }
 
   .instructions {
-    align-items: center;
+    order: 1;
+    text-align: center;
   }
 
   .stepItem {

--- a/frontend/src/features/chat/components/DeviceLinkModal.tsx
+++ b/frontend/src/features/chat/components/DeviceLinkModal.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useState } from "react";
-import { RefreshCw, Smartphone, QrCode, ShieldCheck } from "lucide-react";
+import { useMemo } from "react";
+import { Smartphone, QrCode, ShieldCheck } from "lucide-react";
 import { Modal } from "./Modal";
+import { WhatsAppWebEmbed } from "../../../components/waha";
 import styles from "./DeviceLinkModal.module.css";
 
 interface DeviceLinkModalProps {
@@ -8,76 +9,61 @@ interface DeviceLinkModalProps {
   onClose: () => void;
 }
 
-const generateCode = () => {
-  const segment = () => Math.floor(100 + Math.random() * 899).toString();
-  const letters = "ABCDEFGHJKLMNPQRSTUVWXYZ";
-  const suffix = letters[Math.floor(Math.random() * letters.length)]!;
-  return `${segment()}-${suffix}${segment().slice(0, 1)}`;
-};
-
 export const DeviceLinkModal = ({ open, onClose }: DeviceLinkModalProps) => {
-  const [code, setCode] = useState(() => generateCode());
-  const [refreshing, setRefreshing] = useState(false);
-
   const steps = useMemo(
     () => [
       {
-        title: "Abra o JusConnect Mobile",
+        title: "Abra o WhatsApp no celular",
         description:
-          "No aplicativo, toque em Mais > Dispositivos Conectados e selecione \"Conectar novo dispositivo\".",
+          "No app, toque em Configurações > Dispositivos Conectados e escolha \"Conectar um dispositivo\".",
         icon: <Smartphone size={18} aria-hidden="true" />,
       },
       {
-        title: "Escaneie o código",
+        title: "Escaneie o QR Code",
         description:
-          "Aponte a câmera para este código para autenticar a sessão com criptografia ponta a ponta.",
+          "Utilize a câmera do aparelho para ler o código exibido no painel do WAHA.",
         icon: <QrCode size={18} aria-hidden="true" />,
       },
       {
-        title: "Pronto para conversar",
+        title: "Sincronização automática",
         description:
-          "As conversas serão sincronizadas instantaneamente com o painel web, mantendo notificações e filtros.",
+          "Aguarde alguns instantes até que o WAHA sincronize as conversas com o JusConnect.",
         icon: <ShieldCheck size={18} aria-hidden="true" />,
       },
     ],
     [],
   );
 
-  const handleRefresh = () => {
-    setRefreshing(true);
-    setTimeout(() => {
-      setCode(generateCode());
-      setRefreshing(false);
-    }, 420);
-  };
-
   return (
     <Modal open={open} onClose={onClose} ariaLabel="Conectar um novo dispositivo">
       <div className={styles.container}>
-        <section className={styles.qrSection} aria-labelledby="qr-title">
-          <h2 id="qr-title" className="sr-only">
-            Código QR para emparelhar dispositivo
-          </h2>
-          <div className={styles.qrFrame} aria-hidden="true">
-            <div className={styles.qrPattern} />
-            <span className={styles.codeChip}>{code}</span>
-          </div>
-          <button
-            type="button"
-            onClick={handleRefresh}
-            className={styles.refreshButton}
-            aria-label="Atualizar código QR"
-            disabled={refreshing}
-          >
-            <RefreshCw size={16} aria-hidden="true" />
-            {refreshing ? "Gerando..." : "Atualizar código"}
-          </button>
+        <section className={styles.integrationPanel} aria-labelledby="waha-integration-title">
+          <header className={styles.integrationHeader}>
+            <h2 id="waha-integration-title">Conecte o WhatsApp Web</h2>
+            <p>
+              Use o painel integrado do WAHA para autenticar sua conta do WhatsApp Business. O QR Code
+              é atualizado automaticamente para garantir uma conexão segura.
+            </p>
+          </header>
+          <WhatsAppWebEmbed
+            className={styles.embedWrapper}
+            fallback={
+              <div className={styles.fallbackMessage}>
+                <h3>Configuração necessária</h3>
+                <p>
+                  Defina <code>VITE_WAHA_WHATSAPP_WEB_URL</code> ou combine{' '}
+                  <code>VITE_WAHA_BASE_URL</code> com <code>VITE_WAHA_WHATSAPP_WEB_PATH</code> para carregar
+                  o WhatsApp Web integrado.
+                </p>
+              </div>
+            }
+          />
         </section>
         <div className={styles.instructions}>
-          <h2>Sincronize o chat com o seu celular</h2>
+          <h2>Como conectar</h2>
           <p>
-            Conecte um dispositivo móvel para responder clientes pelo painel web mantendo a segurança
-            das conversas com autenticação temporária.
+            Após a leitura do QR Code, o WAHA mantém a sessão ativa e sincroniza automaticamente as
+            mensagens com o painel de conversas.
           </p>
           <ol className={styles.steps}>
             {steps.map((step, index) => (


### PR DESCRIPTION
## Summary
- add a reusable WhatsApp Web embed component that reads WAHA configuration and renders the iframe with a graceful fallback
- update the device linking modal to display the WAHA WhatsApp Web panel and refreshed pairing instructions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca4093a7b88326bb9bdc412547c0fd