### PR TITLE
Add WAHA webhook handler for chat messages

### DIFF
--- a/backend/dist/controllers/wahaWebhookController.js
+++ b/backend/dist/controllers/wahaWebhookController.js
@@ -1,0 +1,364 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.handleWahaWebhook = handleWahaWebhook;
+const chatService_1 = __importDefault(require("../services/chatService"));
+const chatService = new chatService_1.default();
+const MESSAGE_EVENTS = new Set([
+    'message',
+    'messages.upsert',
+    'message.created',
+]);
+const STATUS_EVENTS = new Set([
+    'status',
+    'message.ack',
+    'messages.update',
+]);
+const ARRAY_LIKE_KEYS = ['events', 'payload', 'data', 'messages'];
+const TRUTHY_STRINGS = new Set(['true', '1', 'yes', 'on']);
+function toEvent(value, fallbackInstanceId) {
+    if (!value || typeof value !== 'object') {
+        return null;
+    }
+    const record = value;
+    const eventName = typeof record.event === 'string' ? record.event.trim() : '';
+    if (!eventName) {
+        return null;
+    }
+    const instanceId = typeof record.instanceId === 'string' && record.instanceId.trim()
+        ? record.instanceId.trim()
+        : fallbackInstanceId;
+    const type = typeof record.type === 'string' ? record.type.trim() : undefined;
+    const payload = record.payload ?? record.data;
+    return {
+        event: eventName,
+        instanceId,
+        type,
+        payload,
+        data: record.data,
+    };
+}
+function extractEvents(body) {
+    if (Array.isArray(body)) {
+        return body.map((item) => toEvent(item)).filter((item) => Boolean(item));
+    }
+    if (body && typeof body === 'object') {
+        const container = body;
+        for (const key of ARRAY_LIKE_KEYS) {
+            const value = container[key];
+            if (Array.isArray(value)) {
+                return value
+                    .map((item) => toEvent(item, typeof container.instanceId === 'string' ? container.instanceId : undefined))
+                    .filter((item) => Boolean(item));
+            }
+        }
+        const single = toEvent(body);
+        return single ? [single] : [];
+    }
+    return [];
+}
+function asArray(value) {
+    if (Array.isArray(value)) {
+        return value;
+    }
+    if (!value) {
+        return [];
+    }
+    return [value];
+}
+function readString(value) {
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : undefined;
+    }
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return String(value);
+    }
+    return undefined;
+}
+function readBoolean(value) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        if (!normalized) {
+            return undefined;
+        }
+        return TRUTHY_STRINGS.has(normalized);
+    }
+    return undefined;
+}
+function parseTimestamp(value) {
+    if (!value) {
+        return undefined;
+    }
+    if (value instanceof Date) {
+        return value;
+    }
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) {
+            return undefined;
+        }
+        if (value > 1000000000000) {
+            return new Date(value);
+        }
+        return new Date(value * 1000);
+    }
+    if (typeof value === 'string' && value.trim()) {
+        const numeric = Number(value);
+        if (!Number.isNaN(numeric)) {
+            return parseTimestamp(numeric);
+        }
+        const parsed = new Date(value);
+        if (!Number.isNaN(parsed.getTime())) {
+            return parsed;
+        }
+    }
+    return undefined;
+}
+function normalizeStatus(value) {
+    if (typeof value === 'number') {
+        switch (value) {
+            case 0:
+            case 1:
+                return 'sent';
+            case 2:
+                return 'delivered';
+            case 3:
+            case 4:
+                return 'read';
+            default:
+                return null;
+        }
+    }
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        if (!normalized) {
+            return null;
+        }
+        if (['pending', 'sent', 'server_ack', 'ack'].includes(normalized)) {
+            return 'sent';
+        }
+        if (['delivered', 'delivery', 'client_ack', 'received'].includes(normalized)) {
+            return 'delivered';
+        }
+        if (['read', 'viewed', 'played', 'seen'].includes(normalized)) {
+            return 'read';
+        }
+    }
+    return null;
+}
+function deriveChatIdentifier(payload) {
+    return (readString(payload.chatId) ??
+        readString(payload.remoteJid) ??
+        readString(payload.from) ??
+        readString(payload.to) ??
+        readString(payload.chat_id));
+}
+function deriveContactName(payload) {
+    return (readString(payload.senderName) ??
+        readString(payload.pushName) ??
+        readString(payload.notifyName) ??
+        readString(payload.chatName) ??
+        readString(payload.name));
+}
+function extractKeyId(value) {
+    if (!value) {
+        return undefined;
+    }
+    if (typeof value === 'string' || typeof value === 'number') {
+        return readString(value);
+    }
+    if (typeof value !== 'object') {
+        return undefined;
+    }
+    const record = value;
+    const direct = record.id ?? record._serialized;
+    if (typeof direct === 'string' || typeof direct === 'number') {
+        return readString(direct);
+    }
+    if (direct && typeof direct === 'object') {
+        const nested = direct;
+        return readString(nested._serialized ?? nested.id);
+    }
+    return undefined;
+}
+function deriveMessageContent(payload, type) {
+    const text = payload.text;
+    const message = payload.message;
+    const extended = message?.extendedTextMessage;
+    const baseContent = readString(payload.body) ??
+        (text ? readString(text.body) : undefined) ??
+        readString(payload.caption) ??
+        (message ? readString(message.conversation) : undefined) ??
+        (extended ? readString(extended.text) : undefined);
+    if (baseContent) {
+        return baseContent;
+    }
+    return type === 'image' ? 'Imagem recebida' : 'Mensagem recebida';
+}
+function determineMessageType(payload) {
+    const type = readString(payload.type) ?? readString(payload.messageType);
+    if (!type) {
+        return 'text';
+    }
+    const normalized = type.toLowerCase();
+    if (['image', 'sticker', 'document', 'video', 'audio'].includes(normalized)) {
+        return 'image';
+    }
+    return 'text';
+}
+function parseMessagePayload(payload, event) {
+    if (!payload || typeof payload !== 'object') {
+        return null;
+    }
+    const record = payload;
+    const chatId = deriveChatIdentifier(record);
+    if (!chatId) {
+        return null;
+    }
+    const messageType = determineMessageType(record);
+    const fromMeFlag = readBoolean(record.fromMe) ?? readBoolean(record.isMe);
+    const direction = event.type?.toLowerCase();
+    const fromMe = (typeof direction === 'string' && direction === 'outgoing') ||
+        (typeof direction === 'string' && ['sent', 'server_ack'].includes(direction)) ||
+        fromMeFlag === true;
+    const key = record.key;
+    const externalId = readString(record.id) ??
+        readString(record.messageId) ??
+        (key ? extractKeyId(key) : undefined);
+    const messageId = readString(record.messageToken) ?? externalId ?? undefined;
+    const timestamp = parseTimestamp(record.timestamp) ??
+        parseTimestamp(record.messageTimestamp) ??
+        parseTimestamp(record.t) ??
+        parseTimestamp(record.time) ??
+        parseTimestamp(record.sendAt);
+    const contactName = deriveContactName(record) ?? null;
+    const content = deriveMessageContent(record, messageType);
+    return {
+        conversationId: chatId,
+        contactIdentifier: chatId,
+        contactName,
+        content,
+        type: messageType,
+        timestamp,
+        externalId: externalId ?? undefined,
+        messageId,
+        fromMe,
+        sessionId: event.instanceId,
+    };
+}
+async function handleMessageEvent(event) {
+    const payload = (event.payload ?? event.data);
+    const items = asArray(Array.isArray(payload)
+        ? payload
+        : Array.isArray(payload?.messages)
+            ? payload.messages
+            : payload);
+    let processed = 0;
+    for (const item of items) {
+        const parsed = parseMessagePayload(item, event);
+        if (!parsed) {
+            continue;
+        }
+        try {
+            await chatService.ensureConversation({
+                id: parsed.conversationId,
+                contactIdentifier: parsed.contactIdentifier,
+                contactName: parsed.contactName ?? undefined,
+                metadata: parsed.sessionId ? { session: parsed.sessionId } : undefined,
+            });
+            const recordInput = {
+                id: parsed.messageId,
+                externalId: parsed.externalId,
+                conversationId: parsed.conversationId,
+                content: parsed.content,
+                type: parsed.type,
+                timestamp: parsed.timestamp,
+            };
+            if (parsed.fromMe) {
+                await chatService.recordOutgoingMessage(recordInput);
+            }
+            else {
+                await chatService.recordIncomingMessage(recordInput);
+            }
+            processed += 1;
+        }
+        catch (error) {
+            console.error('Failed to persist WAHA message event', error, { item });
+        }
+    }
+    return processed;
+}
+async function handleStatusEvent(event) {
+    const payload = (event.payload ?? event.data);
+    const updates = asArray(Array.isArray(payload)
+        ? payload
+        : Array.isArray(payload?.messages)
+            ? payload.messages
+            : payload);
+    let processed = 0;
+    for (const update of updates) {
+        if (!update || typeof update !== 'object') {
+            continue;
+        }
+        const record = update;
+        const key = record.key;
+        const externalId = readString(record.id) ??
+            readString(record.messageId) ??
+            (key ? extractKeyId(key) : undefined);
+        if (!externalId) {
+            continue;
+        }
+        const status = normalizeStatus(record.status) ??
+            normalizeStatus(record.ack) ??
+            normalizeStatus(event.type);
+        if (!status) {
+            continue;
+        }
+        try {
+            const updated = await chatService.updateMessageStatusByExternalId(externalId, status);
+            if (updated) {
+                processed += 1;
+            }
+        }
+        catch (error) {
+            console.error('Failed to update WAHA message status', error, { update });
+        }
+    }
+    return processed;
+}
+async function handleWahaWebhook(req, res) {
+    const events = extractEvents(req.body);
+    if (events.length === 0) {
+        console.warn('Received WAHA webhook without recognizable events');
+        return res.status(200).json({ messages: 0, statuses: 0 });
+    }
+    let messageCount = 0;
+    let statusCount = 0;
+    for (const event of events) {
+        try {
+            if (MESSAGE_EVENTS.has(event.event)) {
+                messageCount += await handleMessageEvent(event);
+            }
+            else if (STATUS_EVENTS.has(event.event)) {
+                statusCount += await handleStatusEvent(event);
+            }
+            else {
+                // Ignore unsupported events but acknowledge reception
+                continue;
+            }
+        }
+        catch (error) {
+            console.error('Failed to process WAHA webhook event', error, { event: event.event });
+        }
+    }
+    res.status(200).json({ messages: messageCount, statuses: statusCount });
+}
+exports.default = handleWahaWebhook;

--- a/backend/dist/index.js
+++ b/backend/dist/index.js
@@ -34,6 +34,7 @@ const supportRoutes_1 = __importDefault(require("./routes/supportRoutes"));
 const notificationRoutes_1 = __importDefault(require("./routes/notificationRoutes"));
 const integrationApiKeyRoutes_1 = __importDefault(require("./routes/integrationApiKeyRoutes"));
 const chatRoutes_1 = __importDefault(require("./routes/chatRoutes"));
+const wahaWebhookRoutes_1 = __importDefault(require("./routes/wahaWebhookRoutes"));
 const swagger_ui_express_1 = __importDefault(require("swagger-ui-express"));
 const swagger_jsdoc_1 = __importDefault(require("swagger-jsdoc"));
 const swagger_1 = __importDefault(require("./swagger"));
@@ -106,6 +107,7 @@ app.use('/api', supportRoutes_1.default);
 app.use('/api', notificationRoutes_1.default);
 app.use('/api', integrationApiKeyRoutes_1.default);
 app.use('/api', chatRoutes_1.default);
+app.use('/api', wahaWebhookRoutes_1.default);
 // Background jobs
 cronJobs_1.default.startProjudiSyncJob();
 // Swagger

--- a/backend/dist/routes/wahaWebhookRoutes.js
+++ b/backend/dist/routes/wahaWebhookRoutes.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = require("express");
+const wahaWebhookController_1 = require("../controllers/wahaWebhookController");
+const router = (0, express_1.Router)();
+router.post('/webhooks/waha', wahaWebhookController_1.handleWahaWebhook);
+exports.default = router;

--- a/backend/src/controllers/wahaWebhookController.ts
+++ b/backend/src/controllers/wahaWebhookController.ts
@@ -1,0 +1,458 @@
+import { Request, Response } from 'express';
+import ChatService, {
+  ChatMessageStatus,
+} from '../services/chatService';
+
+const chatService = new ChatService();
+
+interface WahaWebhookEvent {
+  event: string;
+  instanceId?: string;
+  type?: string;
+  payload?: unknown;
+  data?: unknown;
+}
+
+interface ParsedWebhookMessage {
+  conversationId: string;
+  contactIdentifier: string;
+  contactName?: string | null;
+  content: string;
+  type: 'text' | 'image';
+  timestamp?: Date;
+  externalId?: string;
+  messageId?: string;
+  fromMe: boolean;
+  sessionId?: string;
+}
+
+const MESSAGE_EVENTS = new Set([
+  'message',
+  'messages.upsert',
+  'message.created',
+]);
+
+const STATUS_EVENTS = new Set([
+  'status',
+  'message.ack',
+  'messages.update',
+]);
+
+const ARRAY_LIKE_KEYS = ['events', 'payload', 'data', 'messages'];
+
+const TRUTHY_STRINGS = new Set(['true', '1', 'yes', 'on']);
+
+function toEvent(value: unknown, fallbackInstanceId?: string): WahaWebhookEvent | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const eventName = typeof record.event === 'string' ? record.event.trim() : '';
+  if (!eventName) {
+    return null;
+  }
+
+  const instanceId =
+    typeof record.instanceId === 'string' && record.instanceId.trim()
+      ? record.instanceId.trim()
+      : fallbackInstanceId;
+
+  const type = typeof record.type === 'string' ? record.type.trim() : undefined;
+
+  const payload = record.payload ?? record.data;
+
+  return {
+    event: eventName,
+    instanceId,
+    type,
+    payload,
+    data: record.data,
+  };
+}
+
+function extractEvents(body: unknown): WahaWebhookEvent[] {
+  if (Array.isArray(body)) {
+    return body.map((item) => toEvent(item)).filter((item): item is WahaWebhookEvent => Boolean(item));
+  }
+
+  if (body && typeof body === 'object') {
+    const container = body as Record<string, unknown>;
+    for (const key of ARRAY_LIKE_KEYS) {
+      const value = container[key];
+      if (Array.isArray(value)) {
+        return (value as unknown[])
+          .map((item) => toEvent(item, typeof container.instanceId === 'string' ? container.instanceId : undefined))
+          .filter((item): item is WahaWebhookEvent => Boolean(item));
+      }
+    }
+
+    const single = toEvent(body);
+    return single ? [single] : [];
+  }
+
+  return [];
+}
+
+function asArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (!value) {
+    return [];
+  }
+  return [value];
+}
+
+function readString(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  return undefined;
+}
+
+function readBoolean(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) {
+      return undefined;
+    }
+    return TRUTHY_STRINGS.has(normalized);
+  }
+  return undefined;
+}
+
+function parseTimestamp(value: unknown): Date | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return undefined;
+    }
+    if (value > 1_000_000_000_000) {
+      return new Date(value);
+    }
+    return new Date(value * 1000);
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const numeric = Number(value);
+    if (!Number.isNaN(numeric)) {
+      return parseTimestamp(numeric);
+    }
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeStatus(value: unknown): ChatMessageStatus | null {
+  if (typeof value === 'number') {
+    switch (value) {
+      case 0:
+      case 1:
+        return 'sent';
+      case 2:
+        return 'delivered';
+      case 3:
+      case 4:
+        return 'read';
+      default:
+        return null;
+    }
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) {
+      return null;
+    }
+    if (['pending', 'sent', 'server_ack', 'ack'].includes(normalized)) {
+      return 'sent';
+    }
+    if (['delivered', 'delivery', 'client_ack', 'received'].includes(normalized)) {
+      return 'delivered';
+    }
+    if (['read', 'viewed', 'played', 'seen'].includes(normalized)) {
+      return 'read';
+    }
+  }
+
+  return null;
+}
+
+function deriveChatIdentifier(payload: Record<string, unknown>): string | undefined {
+  return (
+    readString(payload.chatId) ??
+    readString(payload.remoteJid) ??
+    readString(payload.from) ??
+    readString(payload.to) ??
+    readString(payload.chat_id)
+  );
+}
+
+function deriveContactName(payload: Record<string, unknown>): string | undefined {
+  return (
+    readString(payload.senderName) ??
+    readString(payload.pushName) ??
+    readString(payload.notifyName) ??
+    readString(payload.chatName) ??
+    readString(payload.name)
+  );
+}
+
+function extractKeyId(value: unknown): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    return readString(value);
+  }
+  if (typeof value !== 'object') {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const direct = record.id ?? record._serialized;
+  if (typeof direct === 'string' || typeof direct === 'number') {
+    return readString(direct);
+  }
+  if (direct && typeof direct === 'object') {
+    const nested = direct as Record<string, unknown>;
+    return readString(nested._serialized ?? nested.id);
+  }
+  return undefined;
+}
+
+function deriveMessageContent(payload: Record<string, unknown>, type: 'text' | 'image'): string {
+  const text = payload.text as Record<string, unknown> | undefined;
+  const message = payload.message as Record<string, unknown> | undefined;
+  const extended = message?.extendedTextMessage as Record<string, unknown> | undefined;
+
+  const baseContent =
+    readString(payload.body) ??
+    (text ? readString(text.body) : undefined) ??
+    readString(payload.caption) ??
+    (message ? readString(message.conversation) : undefined) ??
+    (extended ? readString(extended.text) : undefined);
+
+  if (baseContent) {
+    return baseContent;
+  }
+
+  return type === 'image' ? 'Imagem recebida' : 'Mensagem recebida';
+}
+
+function determineMessageType(payload: Record<string, unknown>): 'text' | 'image' {
+  const type = readString(payload.type) ?? readString(payload.messageType);
+  if (!type) {
+    return 'text';
+  }
+  const normalized = type.toLowerCase();
+  if (['image', 'sticker', 'document', 'video', 'audio'].includes(normalized)) {
+    return 'image';
+  }
+  return 'text';
+}
+
+function parseMessagePayload(
+  payload: unknown,
+  event: WahaWebhookEvent,
+): ParsedWebhookMessage | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const record = payload as Record<string, unknown>;
+  const chatId = deriveChatIdentifier(record);
+  if (!chatId) {
+    return null;
+  }
+
+  const messageType = determineMessageType(record);
+  const fromMeFlag = readBoolean(record.fromMe) ?? readBoolean(record.isMe);
+  const direction = event.type?.toLowerCase();
+  const fromMe =
+    (typeof direction === 'string' && direction === 'outgoing') ||
+    (typeof direction === 'string' && ['sent', 'server_ack'].includes(direction)) ||
+    fromMeFlag === true;
+
+  const key = record.key as Record<string, unknown> | undefined;
+  const externalId =
+    readString(record.id) ??
+    readString(record.messageId) ??
+    (key ? extractKeyId(key) : undefined);
+
+  const messageId = readString(record.messageToken) ?? externalId ?? undefined;
+
+  const timestamp =
+    parseTimestamp(record.timestamp) ??
+    parseTimestamp(record.messageTimestamp) ??
+    parseTimestamp(record.t) ??
+    parseTimestamp(record.time) ??
+    parseTimestamp(record.sendAt);
+
+  const contactName = deriveContactName(record) ?? null;
+  const content = deriveMessageContent(record, messageType);
+
+  return {
+    conversationId: chatId,
+    contactIdentifier: chatId,
+    contactName,
+    content,
+    type: messageType,
+    timestamp,
+    externalId: externalId ?? undefined,
+    messageId,
+    fromMe,
+    sessionId: event.instanceId,
+  };
+}
+
+async function handleMessageEvent(event: WahaWebhookEvent): Promise<number> {
+  const payload = (event.payload ?? event.data) as unknown;
+  const items = asArray(
+    Array.isArray(payload)
+      ? payload
+      : Array.isArray((payload as { messages?: unknown[] } | undefined)?.messages)
+        ? (payload as { messages?: unknown[] }).messages
+        : payload,
+  );
+
+  let processed = 0;
+
+  for (const item of items) {
+    const parsed = parseMessagePayload(item, event);
+    if (!parsed) {
+      continue;
+    }
+
+    try {
+      await chatService.ensureConversation({
+        id: parsed.conversationId,
+        contactIdentifier: parsed.contactIdentifier,
+        contactName: parsed.contactName ?? undefined,
+        metadata: parsed.sessionId ? { session: parsed.sessionId } : undefined,
+      });
+
+      const recordInput = {
+        id: parsed.messageId,
+        externalId: parsed.externalId,
+        conversationId: parsed.conversationId,
+        content: parsed.content,
+        type: parsed.type,
+        timestamp: parsed.timestamp,
+      };
+
+      if (parsed.fromMe) {
+        await chatService.recordOutgoingMessage(recordInput);
+      } else {
+        await chatService.recordIncomingMessage(recordInput);
+      }
+
+      processed += 1;
+    } catch (error) {
+      console.error('Failed to persist WAHA message event', error, { item });
+    }
+  }
+
+  return processed;
+}
+
+async function handleStatusEvent(event: WahaWebhookEvent): Promise<number> {
+  const payload = (event.payload ?? event.data) as unknown;
+  const updates = asArray(
+    Array.isArray(payload)
+      ? payload
+      : Array.isArray((payload as { messages?: unknown[] } | undefined)?.messages)
+        ? (payload as { messages?: unknown[] }).messages
+        : payload,
+  );
+
+  let processed = 0;
+
+  for (const update of updates) {
+    if (!update || typeof update !== 'object') {
+      continue;
+    }
+
+    const record = update as Record<string, unknown>;
+    const key = record.key as Record<string, unknown> | undefined;
+    const externalId =
+      readString(record.id) ??
+      readString(record.messageId) ??
+      (key ? extractKeyId(key) : undefined);
+
+    if (!externalId) {
+      continue;
+    }
+
+    const status =
+      normalizeStatus(record.status) ??
+      normalizeStatus(record.ack) ??
+      normalizeStatus(event.type);
+
+    if (!status) {
+      continue;
+    }
+
+    try {
+      const updated = await chatService.updateMessageStatusByExternalId(externalId, status);
+      if (updated) {
+        processed += 1;
+      }
+    } catch (error) {
+      console.error('Failed to update WAHA message status', error, { update });
+    }
+  }
+
+  return processed;
+}
+
+export async function handleWahaWebhook(req: Request, res: Response) {
+  const events = extractEvents(req.body);
+  if (events.length === 0) {
+    console.warn('Received WAHA webhook without recognizable events');
+    return res.status(200).json({ messages: 0, statuses: 0 });
+  }
+
+  let messageCount = 0;
+  let statusCount = 0;
+
+  for (const event of events) {
+    try {
+      if (MESSAGE_EVENTS.has(event.event)) {
+        messageCount += await handleMessageEvent(event);
+      } else if (STATUS_EVENTS.has(event.event)) {
+        statusCount += await handleStatusEvent(event);
+      } else {
+        // Ignore unsupported events but acknowledge reception
+        continue;
+      }
+    } catch (error) {
+      console.error('Failed to process WAHA webhook event', error, { event: event.event });
+    }
+  }
+
+  res.status(200).json({ messages: messageCount, statuses: statusCount });
+}
+
+export default handleWahaWebhook;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -30,6 +30,7 @@ import supportRoutes from './routes/supportRoutes';
 import notificationRoutes from './routes/notificationRoutes';
 import integrationApiKeyRoutes from './routes/integrationApiKeyRoutes';
 import chatRoutes from './routes/chatRoutes';
+import wahaWebhookRoutes from './routes/wahaWebhookRoutes';
 import swaggerUi from 'swagger-ui-express';
 import swaggerJsdoc from 'swagger-jsdoc';
 import swaggerOptions from './swagger';
@@ -119,6 +120,7 @@ app.use('/api', supportRoutes);
 app.use('/api', notificationRoutes);
 app.use('/api', integrationApiKeyRoutes);
 app.use('/api', chatRoutes);
+app.use('/api', wahaWebhookRoutes);
 
 // Background jobs
 cronJobs.startProjudiSyncJob();

--- a/backend/src/routes/wahaWebhookRoutes.ts
+++ b/backend/src/routes/wahaWebhookRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { handleWahaWebhook } from '../controllers/wahaWebhookController';
+
+const router = Router();
+
+router.post('/webhooks/waha', handleWahaWebhook);
+
+export default router;

--- a/frontend/src/components/waha/WhatsAppWebEmbed.module.css
+++ b/frontend/src/components/waha/WhatsAppWebEmbed.module.css
@@ -1,0 +1,49 @@
+.container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 1rem;
+  border: 1px solid hsl(var(--border));
+  overflow: hidden;
+  background: hsl(var(--muted));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.iframe {
+  width: 100%;
+  height: 100%;
+  min-height: 360px;
+  border: none;
+  background: transparent;
+}
+
+.fallback {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2rem;
+  text-align: center;
+  border-radius: 1rem;
+  border: 1px dashed hsl(var(--border));
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+}
+
+.fallback h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.fallback p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.fallback code {
+  font-family: var(--font-mono, "JetBrains Mono", monospace);
+  font-size: 0.85rem;
+  color: hsl(var(--foreground));
+}

--- a/frontend/src/components/waha/WhatsAppWebEmbed.tsx
+++ b/frontend/src/components/waha/WhatsAppWebEmbed.tsx
@@ -1,0 +1,120 @@
+import { useMemo, type ReactNode } from "react";
+import clsx from "clsx";
+import styles from "./WhatsAppWebEmbed.module.css";
+
+const sanitize = (value?: string | null) => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const toAbsoluteUrl = (value: string) => {
+  try {
+    return new URL(value, window.location.origin).toString();
+  } catch (error) {
+    console.error("Não foi possível normalizar a URL do WhatsApp Web", error);
+    return value;
+  }
+};
+
+const resolvePathWithInstance = (path: string, instanceId: string) => {
+  const encoded = encodeURIComponent(instanceId);
+  if (path.includes(":instanceId") || path.includes("{instanceId}")) {
+    return path.replace(/:instanceId/g, encoded).replace(/{instanceId}/g, encoded);
+  }
+  if (path.length === 0 || path === ".") {
+    return encoded;
+  }
+  return `${path.replace(/\/+$/, "")}/${encoded}`;
+};
+
+export interface WhatsAppWebEmbedProps {
+  className?: string;
+  iframeClassName?: string;
+  title?: string;
+  /**
+   * Permite sobrescrever a URL final do iframe manualmente.
+   * Caso não seja informada, será utilizada a configuração do ambiente.
+   */
+  src?: string;
+  /**
+   * Caso definido, substitui o identificador de instância informado via variável de ambiente.
+   */
+  instanceId?: string;
+  fallback?: ReactNode;
+}
+
+export const WhatsAppWebEmbed = ({
+  className,
+  iframeClassName,
+  title = "WhatsApp Web",
+  src,
+  instanceId,
+  fallback,
+}: WhatsAppWebEmbedProps) => {
+  const resolvedSrc = useMemo(() => {
+    const env = import.meta.env as Record<string, string | undefined>;
+    const directUrl = sanitize(src) ?? sanitize(env.VITE_WAHA_WHATSAPP_WEB_URL);
+    const baseUrl = sanitize(env.VITE_WAHA_BASE_URL);
+    const pathTemplate = sanitize(env.VITE_WAHA_WHATSAPP_WEB_PATH);
+    const envInstanceId = sanitize(env.VITE_WAHA_INSTANCE_ID);
+    const activeInstanceId = sanitize(instanceId ?? envInstanceId);
+
+    if (directUrl) {
+      return toAbsoluteUrl(directUrl);
+    }
+
+    if (!baseUrl) {
+      return undefined;
+    }
+
+    let path = pathTemplate ?? "";
+
+    if (activeInstanceId) {
+      path = resolvePathWithInstance(path, activeInstanceId);
+    }
+
+    try {
+      const base = new URL(baseUrl, window.location.origin);
+      const finalUrl = new URL(path || ".", base).toString();
+      return finalUrl;
+    } catch (error) {
+      console.error("Não foi possível compor a URL do WAHA", error);
+      return undefined;
+    }
+  }, [instanceId, src]);
+
+  if (!resolvedSrc) {
+    return (
+      <div className={clsx(styles.fallback, className)}>
+        {fallback ?? (
+          <>
+            <h2>Integração com WhatsApp indisponível</h2>
+            <p>
+              Configure <code>VITE_WAHA_WHATSAPP_WEB_URL</code> ou defina{' '}
+              <code>VITE_WAHA_BASE_URL</code> e <code>VITE_WAHA_WHATSAPP_WEB_PATH</code> para
+              habilitar o painel.
+            </p>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={clsx(styles.container, className)}>
+      <iframe
+        src={resolvedSrc}
+        title={title}
+        className={clsx(styles.iframe, iframeClassName)}
+        allow="clipboard-read; clipboard-write; camera; microphone"
+        allowFullScreen
+        sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-modals"
+      />
+    </div>
+  );
+};
+
+export default WhatsAppWebEmbed;

--- a/frontend/src/components/waha/index.ts
+++ b/frontend/src/components/waha/index.ts
@@ -1,0 +1,2 @@
+export { WhatsAppWebEmbed } from "./WhatsAppWebEmbed";
+export type { WhatsAppWebEmbedProps } from "./WhatsAppWebEmbed";

--- a/frontend/src/features/chat/components/DeviceLinkModal.module.css
+++ b/frontend/src/features/chat/components/DeviceLinkModal.module.css
@@ -1,89 +1,67 @@
 .container {
-  display: flex;
+  display: grid;
   gap: 2rem;
   padding: 2rem;
-  align-items: stretch;
+  grid-template-columns: minmax(280px, 420px) minmax(0, 1fr);
+  align-items: start;
 }
 
-.qrSection {
+.integrationPanel {
   display: flex;
   flex-direction: column;
-  align-items: center;
   gap: 1rem;
-  min-width: 220px;
-}
-
-.qrFrame {
-  position: relative;
-  width: 220px;
-  aspect-ratio: 1;
-  border-radius: 1.25rem;
-  border: 1px solid hsl(var(--border));
-  background: linear-gradient(135deg, hsl(var(--accent)), hsl(var(--secondary)));
-  display: grid;
-  place-items: center;
-  padding: 1.75rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
-}
-
-.qrPattern {
-  width: 100%;
   height: 100%;
-  border-radius: 1rem;
-  background-image: repeating-linear-gradient(
-      45deg,
-      rgba(30, 64, 175, 0.9) 0,
-      rgba(30, 64, 175, 0.9) 6px,
-      rgba(255, 255, 255, 0.95) 6px,
-      rgba(255, 255, 255, 0.95) 12px
-    ),
-    repeating-linear-gradient(
-      -45deg,
-      rgba(15, 23, 42, 0.9) 0,
-      rgba(15, 23, 42, 0.9) 6px,
-      rgba(255, 255, 255, 0.95) 6px,
-      rgba(255, 255, 255, 0.95) 12px
-    );
-  position: relative;
-  overflow: hidden;
 }
 
-.codeChip {
-  position: absolute;
-  bottom: 1rem;
-  left: 50%;
-  transform: translateX(-50%);
-  background: rgba(15, 23, 42, 0.75);
-  color: #fff;
-  padding: 0.3rem 0.8rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+.integrationHeader h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.35rem;
+  font-weight: 700;
 }
 
-.refreshButton {
-  display: inline-flex;
+.integrationHeader p {
+  margin: 0;
+  color: hsl(var(--muted-foreground));
+  line-height: 1.6;
+}
+
+.embedWrapper {
+  flex: 1;
+  min-height: 380px;
+}
+
+.fallbackMessage {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  justify-content: center;
   align-items: center;
-  gap: 0.5rem;
-  border: none;
-  background: hsl(var(--primary));
-  color: hsl(var(--primary-foreground));
-  padding: 0.6rem 1rem;
-  border-radius: 999px;
-  font-size: 0.875rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: var(--transition-fast);
+  padding: 1.75rem;
+  text-align: center;
+  border-radius: 1rem;
+  border: 1px dashed hsl(var(--border));
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
 }
 
-.refreshButton:hover,
-.refreshButton:focus-visible {
-  background: hsl(var(--primary-hover));
+.fallbackMessage h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.fallbackMessage p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.fallbackMessage code {
+  font-family: var(--font-mono, "JetBrains Mono", monospace);
+  font-size: 0.85rem;
+  color: hsl(var(--foreground));
 }
 
 .instructions {
-  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
@@ -92,9 +70,11 @@
 .instructions h2 {
   font-size: 1.4rem;
   font-weight: 700;
+  margin: 0;
 }
 
 .instructions p {
+  margin: 0;
   color: hsl(var(--muted-foreground));
   line-height: 1.6;
 }
@@ -149,13 +129,16 @@
 
 @media (max-width: 900px) {
   .container {
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
+    grid-template-columns: 1fr;
+  }
+
+  .integrationPanel {
+    order: 2;
   }
 
   .instructions {
-    align-items: center;
+    order: 1;
+    text-align: center;
   }
 
   .stepItem {

--- a/frontend/src/features/chat/components/DeviceLinkModal.tsx
+++ b/frontend/src/features/chat/components/DeviceLinkModal.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useState } from "react";
-import { RefreshCw, Smartphone, QrCode, ShieldCheck } from "lucide-react";
+import { useMemo } from "react";
+import { Smartphone, QrCode, ShieldCheck } from "lucide-react";
 import { Modal } from "./Modal";
+import { WhatsAppWebEmbed } from "../../../components/waha";
 import styles from "./DeviceLinkModal.module.css";
 
 interface DeviceLinkModalProps {
@@ -8,76 +9,61 @@ interface DeviceLinkModalProps {
   onClose: () => void;
 }
 
-const generateCode = () => {
-  const segment = () => Math.floor(100 + Math.random() * 899).toString();
-  const letters = "ABCDEFGHJKLMNPQRSTUVWXYZ";
-  const suffix = letters[Math.floor(Math.random() * letters.length)]!;
-  return `${segment()}-${suffix}${segment().slice(0, 1)}`;
-};
-
 export const DeviceLinkModal = ({ open, onClose }: DeviceLinkModalProps) => {
-  const [code, setCode] = useState(() => generateCode());
-  const [refreshing, setRefreshing] = useState(false);
-
   const steps = useMemo(
     () => [
       {
-        title: "Abra o JusConnect Mobile",
+        title: "Abra o WhatsApp no celular",
         description:
-          "No aplicativo, toque em Mais > Dispositivos Conectados e selecione \"Conectar novo dispositivo\".",
+          "No app, toque em Configurações > Dispositivos Conectados e escolha \"Conectar um dispositivo\".",
         icon: <Smartphone size={18} aria-hidden="true" />,
       },
       {
-        title: "Escaneie o código",
+        title: "Escaneie o QR Code",
         description:
-          "Aponte a câmera para este código para autenticar a sessão com criptografia ponta a ponta.",
+          "Utilize a câmera do aparelho para ler o código exibido no painel do WAHA.",
         icon: <QrCode size={18} aria-hidden="true" />,
       },
       {
-        title: "Pronto para conversar",
+        title: "Sincronização automática",
         description:
-          "As conversas serão sincronizadas instantaneamente com o painel web, mantendo notificações e filtros.",
+          "Aguarde alguns instantes até que o WAHA sincronize as conversas com o JusConnect.",
         icon: <ShieldCheck size={18} aria-hidden="true" />,
       },
     ],
     [],
   );
 
-  const handleRefresh = () => {
-    setRefreshing(true);
-    setTimeout(() => {
-      setCode(generateCode());
-      setRefreshing(false);
-    }, 420);
-  };
-
   return (
     <Modal open={open} onClose={onClose} ariaLabel="Conectar um novo dispositivo">
       <div className={styles.container}>
-        <section className={styles.qrSection} aria-labelledby="qr-title">
-          <h2 id="qr-title" className="sr-only">
-            Código QR para emparelhar dispositivo
-          </h2>
-          <div className={styles.qrFrame} aria-hidden="true">
-            <div className={styles.qrPattern} />
-            <span className={styles.codeChip}>{code}</span>
-          </div>
-          <button
-            type="button"
-            onClick={handleRefresh}
-            className={styles.refreshButton}
-            aria-label="Atualizar código QR"
-            disabled={refreshing}
-          >
-            <RefreshCw size={16} aria-hidden="true" />
-            {refreshing ? "Gerando..." : "Atualizar código"}
-          </button>
+        <section className={styles.integrationPanel} aria-labelledby="waha-integration-title">
+          <header className={styles.integrationHeader}>
+            <h2 id="waha-integration-title">Conecte o WhatsApp Web</h2>
+            <p>
+              Use o painel integrado do WAHA para autenticar sua conta do WhatsApp Business. O QR Code
+              é atualizado automaticamente para garantir uma conexão segura.
+            </p>
+          </header>
+          <WhatsAppWebEmbed
+            className={styles.embedWrapper}
+            fallback={
+              <div className={styles.fallbackMessage}>
+                <h3>Configuração necessária</h3>
+                <p>
+                  Defina <code>VITE_WAHA_WHATSAPP_WEB_URL</code> ou combine{' '}
+                  <code>VITE_WAHA_BASE_URL</code> com <code>VITE_WAHA_WHATSAPP_WEB_PATH</code> para carregar
+                  o WhatsApp Web integrado.
+                </p>
+              </div>
+            }
+          />
         </section>
         <div className={styles.instructions}>
-          <h2>Sincronize o chat com o seu celular</h2>
+          <h2>Como conectar</h2>
           <p>
-            Conecte um dispositivo móvel para responder clientes pelo painel web mantendo a segurança
-            das conversas com autenticação temporária.
+            Após a leitura do QR Code, o WAHA mantém a sessão ativa e sincroniza automaticamente as
+            mensagens com o painel de conversas.
           </p>
           <ol className={styles.steps}>
             {steps.map((step, index) => (


### PR DESCRIPTION
## Summary
- add an Express controller that normalizes WAHA webhook payloads, records chat messages, and updates delivery statuses
- register the new /api/webhooks/waha route so incoming WAHA callbacks reach the chat service

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca4093a7b88326bb9bdc412547c0fd