### PR TITLE
Fix WAHA webhook parsing syntax error

### DIFF
--- a/backend/src/controllers/wahaWebhookController.ts
+++ b/backend/src/controllers/wahaWebhookController.ts
@@ -490,12 +490,6 @@ function deriveChatIdentifier(payload: Record<string, unknown>): string | undefi
     (nestedMessage
       ? readString(nestedMessage['chatId']) ?? readString(nestedMessage['remoteJid'])
       : undefined)
-  return (
-    readString(payload.chatId) ??
-    readString(payload.remoteJid) ??
-    readString(payload.from) ??
-    readString(payload.to) ??
-    readString(payload.chat_id)
   );
 }
 
@@ -641,13 +635,6 @@ function deriveContactAvatar(payload: Record<string, unknown>): string | undefin
   }
 
   return undefined;
-  return (
-    readString(payload.senderName) ??
-    readString(payload.pushName) ??
-    readString(payload.notifyName) ??
-    readString(payload.chatName) ??
-    readString(payload.name)
-  );
 }
 
 function extractKeyId(value: unknown): string | undefined {


### PR DESCRIPTION
## Summary
- remove duplicate fallback returns in WAHA webhook helpers so TypeScript compiles again

## Testing
- npm --prefix backend run build

------
https://chatgpt.com/codex/tasks/task_e_68ca4aabb7188326ae5e8691d09c6092