### PR TITLE
Fix chat layout scroll and input positioning

### DIFF
--- a/frontend/src/components/waha/ChatArea.tsx
+++ b/frontend/src/components/waha/ChatArea.tsx
@@ -59,7 +59,7 @@ export const ChatArea = ({
   }
 
   return (
-    <div className="flex-1 flex flex-col bg-chat-background">
+    <div className="flex-1 flex flex-col bg-chat-background min-h-0">
       {/* Chat Header */}
       <div className="flex items-center justify-between p-4 bg-sidebar border-b border-border shadow-soft">
         <div className="flex items-center gap-3">

--- a/frontend/src/components/waha/WelcomeScreen.tsx
+++ b/frontend/src/components/waha/WelcomeScreen.tsx
@@ -5,7 +5,7 @@ import { WebhookInfo } from './WebhookInfo';
 
 export const WelcomeScreen = () => {
   return (
-    <div className="flex-1 flex flex-col items-center justify-center bg-chat-background p-8 overflow-y-auto">
+    <div className="flex-1 flex flex-col items-center justify-center bg-chat-background p-8 overflow-y-auto min-h-0">
       <div className="max-w-4xl w-full space-y-8">
         {/* Main Welcome */}
         <div className="text-center space-y-4">

--- a/frontend/src/components/waha/WhatsAppLayout.tsx
+++ b/frontend/src/components/waha/WhatsAppLayout.tsx
@@ -7,46 +7,51 @@ import { SessionStatus } from './SessionStatus';
 export const WhatsAppLayout = () => {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const wahaState = useWAHA();
+  const { addMessage } = wahaState;
 
   // Set up webhook receiver for demo purposes
   useEffect(() => {
     window.wahaWebhookReceived = (message) => {
-      wahaState.addMessage(message);
+      addMessage(message);
     };
-    
+
     return () => {
       delete window.wahaWebhookReceived;
     };
-  }, [wahaState.addMessage]);
+  }, [addMessage]);
 
   return (
-    <div className="flex h-screen bg-background overflow-hidden pt-14">
+    <div className="relative flex h-full min-h-0 bg-background overflow-hidden">
       {/* Session Status Bar */}
-      <SessionStatus 
-        status={wahaState.sessionStatus} 
+      <SessionStatus
+        status={wahaState.sessionStatus}
         onRefresh={wahaState.checkSessionStatus}
       />
-      
-      {/* Chat Sidebar */}
-      <div className={`${sidebarOpen ? 'w-80' : 'w-0'} transition-all duration-300 overflow-hidden border-r border-border bg-sidebar`}>
-        <ChatSidebar
-          chats={wahaState.chats}
-          activeChatId={wahaState.activeChatId}
-          onSelectChat={wahaState.selectChat}
-          loading={wahaState.loading}
-          onRefresh={wahaState.loadChats}
-        />
-      </div>
 
-      {/* Main Chat Area */}
-      <div className="flex-1 flex flex-col">
-        <ChatArea
-          activeChat={wahaState.activeChat}
-          messages={wahaState.activeChatMessages}
-          onSendMessage={wahaState.sendMessage}
-          onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
-          sidebarOpen={sidebarOpen}
-        />
+      <div className="flex flex-1 h-full overflow-hidden pt-14 box-border">
+        {/* Chat Sidebar */}
+        <div
+          className={`${sidebarOpen ? 'w-80' : 'w-0'} transition-all duration-300 overflow-hidden border-r border-border bg-sidebar h-full box-border min-w-0`}
+        >
+          <ChatSidebar
+            chats={wahaState.chats}
+            activeChatId={wahaState.activeChatId}
+            onSelectChat={wahaState.selectChat}
+            loading={wahaState.loading}
+            onRefresh={wahaState.loadChats}
+          />
+        </div>
+
+        {/* Main Chat Area */}
+        <div className="flex-1 flex flex-col min-h-0">
+          <ChatArea
+            activeChat={wahaState.activeChat}
+            messages={wahaState.activeChatMessages}
+            onSendMessage={wahaState.sendMessage}
+            onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
+            sidebarOpen={sidebarOpen}
+          />
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/Conversas.tsx
+++ b/frontend/src/pages/Conversas.tsx
@@ -1,7 +1,7 @@
 import { WhatsAppLayout } from "../components/waha";
 
 const Conversas = () => (
-  <div className="h-full bg-background">
+  <div className="h-full min-h-0 bg-background">
     <WhatsAppLayout />
   </div>
 );


### PR DESCRIPTION
## Summary
- restructure the WhatsApp conversation layout to occupy the full viewport height and keep the composer docked to the footer
- allow the chat area and welcome screen to shrink correctly so the message list scrolls inside the conversation panel
- ensure the Conversas page container propagates height constraints to the WhatsApp layout

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cae78d25648326be7a5c3cc4ce1659