### PR TITLE
Limit conversation scrolling to chat area

### DIFF
--- a/frontend/src/components/waha/ChatArea.tsx
+++ b/frontend/src/components/waha/ChatArea.tsx
@@ -59,7 +59,7 @@ export const ChatArea = ({
   }
 
   return (
-    <div className="flex-1 flex flex-col bg-chat-background">
+    <div className="flex-1 flex flex-col bg-chat-background min-h-0">
       {/* Chat Header */}
       <div className="flex items-center justify-between p-4 bg-sidebar border-b border-border shadow-soft">
         <div className="flex items-center gap-3">
@@ -120,7 +120,7 @@ export const ChatArea = ({
       </div>
 
       {/* Messages Area */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-2 bg-chat-background">
+      <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-2 bg-chat-background">
         {messages.length === 0 ? (
           <div className="flex items-center justify-center h-full text-muted-foreground">
             <p>No messages yet. Start the conversation!</p>

--- a/frontend/src/components/waha/WhatsAppLayout.tsx
+++ b/frontend/src/components/waha/WhatsAppLayout.tsx
@@ -7,17 +7,18 @@ import { SessionStatus } from './SessionStatus';
 export const WhatsAppLayout = () => {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const wahaState = useWAHA();
+  const { addMessage } = wahaState;
 
   // Set up webhook receiver for demo purposes
   useEffect(() => {
     window.wahaWebhookReceived = (message) => {
-      wahaState.addMessage(message);
+      addMessage(message);
     };
-    
+
     return () => {
       delete window.wahaWebhookReceived;
     };
-  }, [wahaState.addMessage]);
+  }, [addMessage]);
 
   return (
     <div className="flex h-screen bg-background overflow-hidden pt-14">


### PR DESCRIPTION
## Summary
- restore the WhatsApp layout structure so the existing page chrome stays intact while keeping the webhook listener stable
- confine the conversation scroll behavior to the ChatArea message list by adding the necessary min-h guard
- return the Conversas wrapper and welcome screen layout to their previous styling so only the chat view manages its own scrolling

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cae78d25648326be7a5c3cc4ce1659