### PR TITLE
Adapt WAHA layout to shared chat components

### DIFF
--- a/frontend/src/components/waha/WhatsAppLayout.tsx
+++ b/frontend/src/components/waha/WhatsAppLayout.tsx
@@ -1,11 +1,152 @@
-import { useState, useEffect } from 'react';
-import { ChatSidebar } from './ChatSidebar';
-import { ChatArea } from './ChatArea';
-import { useWAHA } from '@/hooks/useWAHA';
-import { SessionStatus } from './SessionStatus';
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useWAHA } from "@/hooks/useWAHA";
+import { SessionStatus } from "./SessionStatus";
+import { ChatSidebar as CRMChatSidebar } from "@/features/chat/components/ChatSidebar";
+import { ChatWindow as CRMChatWindow } from "@/features/chat/components/ChatWindow";
+import type {
+  ConversationSummary,
+  Message as CRMMessage,
+  SendMessageInput,
+  UpdateConversationPayload,
+} from "@/features/chat/types";
+import { teamMembers } from "@/features/chat/data/teamMembers";
+import type { ChatOverview, Message as WAHAMessage } from "@/types/waha";
+import WAHAService from "@/services/waha";
+
+const ensureIsoTimestamp = (value?: number): string => {
+  if (!value) {
+    return new Date().toISOString();
+  }
+  const timestamp = value < 1_000_000_000_000 ? value * 1000 : value;
+  return new Date(timestamp).toISOString();
+};
+
+const mapAckToStatus = (ack?: string | number) => {
+  if (typeof ack === "string") {
+    const normalized = ack.toUpperCase();
+    if (normalized === "READ") return "read";
+    if (normalized === "DELIVERED") return "delivered";
+    return "sent";
+  }
+  if (typeof ack === "number") {
+    if (ack >= 3) return "read";
+    if (ack === 2) return "delivered";
+    return "sent";
+  }
+  return "sent";
+};
+
+const createAvatarUrl = (name: string) =>
+  `https://ui-avatars.com/api/?name=${encodeURIComponent(name)}&background=1D4ED8&color=FFFFFF`;
+
+const mergeOverrides = (
+  base: ConversationSummary,
+  overrides?: Partial<ConversationSummary>,
+): ConversationSummary => {
+  if (!overrides) {
+    return base;
+  }
+  return {
+    ...base,
+    ...overrides,
+    tags: overrides.tags ?? base.tags,
+    customAttributes: overrides.customAttributes ?? base.customAttributes,
+    internalNotes: overrides.internalNotes ?? base.internalNotes,
+    responsible:
+      overrides.responsible !== undefined ? overrides.responsible : base.responsible ?? null,
+    phoneNumber: overrides.phoneNumber ?? base.phoneNumber,
+    clientName: overrides.clientName ?? base.clientName,
+    isLinkedToClient: overrides.isLinkedToClient ?? base.isLinkedToClient,
+    isPrivate: overrides.isPrivate ?? base.isPrivate,
+  };
+};
+
+const mapChatToConversation = (
+  chat: ChatOverview,
+  overrides?: Partial<ConversationSummary>,
+): ConversationSummary => {
+  const fallbackName = WAHAService.extractPhoneFromWhatsAppId(chat.id);
+  const normalizedName = chat.name?.trim() || fallbackName || chat.id;
+  const avatar = chat.avatar && chat.avatar.trim().length > 0
+    ? chat.avatar
+    : createAvatarUrl(normalizedName);
+
+  const lastMessage = chat.lastMessage
+    ? {
+        id: chat.lastMessage.id ?? `${chat.id}-last`,
+        content: chat.lastMessage.body ?? "",
+        preview:
+          chat.lastMessage.body?.trim().length
+            ? chat.lastMessage.body
+            : chat.lastMessage.type === "image"
+              ? "Imagem"
+              : "Nova conversa",
+        timestamp: ensureIsoTimestamp(chat.lastMessage.timestamp),
+        sender: chat.lastMessage.fromMe ? "me" : "contact",
+        type: chat.lastMessage.type === "image" ? "image" : "text",
+        status: mapAckToStatus(chat.lastMessage.ackName ?? chat.lastMessage.ack),
+      }
+    : undefined;
+
+  const base: ConversationSummary = {
+    id: chat.id,
+    name: normalizedName,
+    avatar,
+    shortStatus: chat.isGroup ? "Conversa em grupo" : "Conversa no WhatsApp",
+    description: lastMessage?.content || undefined,
+    unreadCount: chat.unreadCount ?? 0,
+    pinned: chat.pinned ?? false,
+    lastMessage,
+    phoneNumber: WAHAService.extractPhoneFromWhatsAppId(chat.id),
+    responsible: null,
+    tags: [],
+    isLinkedToClient: false,
+    clientName: null,
+    customAttributes: [],
+    isPrivate: false,
+    internalNotes: [],
+  };
+
+  return mergeOverrides(base, overrides);
+};
+
+const mapMessageToCRM = (message: WAHAMessage): CRMMessage => {
+  const hasMedia = Boolean(message.hasMedia && message.mediaUrl);
+  const attachments = hasMedia && message.mediaUrl
+    ? [
+        {
+          id: `${message.id}-attachment`,
+          type: "image" as const,
+          url: message.mediaUrl,
+          name: message.filename ?? "Anexo",
+        },
+      ]
+    : undefined;
+
+  const content = hasMedia
+    ? message.caption ?? message.body ?? message.mediaUrl ?? ""
+    : message.body ?? message.caption ?? "";
+
+  return {
+    id: message.id,
+    conversationId: message.chatId,
+    sender: message.fromMe ? "me" : "contact",
+    content,
+    timestamp: ensureIsoTimestamp(message.timestamp),
+    status: mapAckToStatus(message.ack),
+    type: attachments ? "image" : "text",
+    attachments,
+  };
+};
 
 export const WhatsAppLayout = () => {
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [searchValue, setSearchValue] = useState("");
+  const [responsibleFilter, setResponsibleFilter] = useState("all");
+  const [messagesLoading, setMessagesLoading] = useState(false);
+  const [conversationOverrides, setConversationOverrides] = useState<
+    Record<string, Partial<ConversationSummary>>
+  >({});
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const wahaState = useWAHA();
   const { addMessage } = wahaState;
 
@@ -20,36 +161,139 @@ export const WhatsAppLayout = () => {
     };
   }, [addMessage]);
 
+  useEffect(() => {
+    const activeId = wahaState.activeChatId ?? undefined;
+    if (!activeId) {
+      setMessagesLoading(false);
+      return;
+    }
+    if (wahaState.messages[activeId]) {
+      setMessagesLoading(false);
+    }
+  }, [wahaState.activeChatId, wahaState.messages]);
+
+  const conversations = useMemo(() => {
+    const mapped = wahaState.chats.map((chat) =>
+      mapChatToConversation(chat, conversationOverrides[chat.id]),
+    );
+    return mapped.sort((a, b) => {
+      const timeA = a.lastMessage ? new Date(a.lastMessage.timestamp).getTime() : 0;
+      const timeB = b.lastMessage ? new Date(b.lastMessage.timestamp).getTime() : 0;
+      return timeB - timeA;
+    });
+  }, [wahaState.chats, conversationOverrides]);
+
+  const activeConversationId = wahaState.activeChatId ?? undefined;
+
+  const activeConversation = useMemo(
+    () => conversations.find((conversation) => conversation.id === activeConversationId),
+    [conversations, activeConversationId],
+  );
+
+  const rawMessages = useMemo(
+    () => (activeConversationId ? wahaState.messages[activeConversationId] ?? [] : []),
+    [activeConversationId, wahaState.messages],
+  );
+
+  const messages = useMemo(() => rawMessages.map(mapMessageToCRM), [rawMessages]);
+
+  const handleSelectConversation = async (conversationId: string) => {
+    setMessagesLoading(true);
+    try {
+      await wahaState.selectChat(conversationId);
+    } finally {
+      setMessagesLoading(false);
+    }
+  };
+
+  const handleSendMessage = async (payload: SendMessageInput) => {
+    if (!activeConversationId) {
+      return;
+    }
+    const text = payload.content.trim();
+    if (!text) {
+      return;
+    }
+    await wahaState.sendMessage(activeConversationId, text);
+  };
+
+  const handleUpdateConversation = async (
+    conversationId: string,
+    changes: UpdateConversationPayload,
+  ) => {
+    setConversationOverrides((previous) => {
+      const current = previous[conversationId] ?? {};
+      const next: Partial<ConversationSummary> = { ...current };
+
+      if ("responsibleId" in changes) {
+        const member = changes.responsibleId
+          ? teamMembers.find((item) => item.id === changes.responsibleId) ?? null
+          : null;
+        next.responsible = member;
+      }
+      if ("tags" in changes) {
+        next.tags = changes.tags ?? [];
+      }
+      if ("phoneNumber" in changes) {
+        next.phoneNumber = changes.phoneNumber;
+      }
+      if ("isLinkedToClient" in changes) {
+        next.isLinkedToClient = changes.isLinkedToClient ?? false;
+      }
+      if ("clientName" in changes) {
+        next.clientName = changes.clientName ?? null;
+      }
+      if ("customAttributes" in changes) {
+        next.customAttributes = changes.customAttributes ?? [];
+      }
+      if ("isPrivate" in changes) {
+        next.isPrivate = Boolean(changes.isPrivate);
+      }
+      if ("internalNotes" in changes) {
+        next.internalNotes = changes.internalNotes ?? [];
+      }
+
+      return { ...previous, [conversationId]: next };
+    });
+  };
+
   return (
     <div className="relative flex h-full min-h-0 bg-background overflow-hidden">
-      {/* Session Status Bar */}
       <SessionStatus
         status={wahaState.sessionStatus}
         onRefresh={wahaState.checkSessionStatus}
       />
 
       <div className="flex flex-1 h-full overflow-hidden pt-14 box-border">
-        {/* Chat Sidebar */}
-        <div
-          className={`${sidebarOpen ? 'w-80' : 'w-0'} transition-all duration-300 overflow-hidden border-r border-border bg-sidebar h-full box-border min-w-0`}
-        >
-          <ChatSidebar
-            chats={wahaState.chats}
-            activeChatId={wahaState.activeChatId}
-            onSelectChat={wahaState.selectChat}
+        <div className="h-full">
+          <CRMChatSidebar
+            conversations={conversations}
+            activeConversationId={activeConversationId}
+            searchValue={searchValue}
+            onSearchChange={setSearchValue}
+            responsibleFilter={responsibleFilter}
+            responsibleOptions={teamMembers}
+            onResponsibleFilterChange={setResponsibleFilter}
+            onSelectConversation={handleSelectConversation}
+            onNewConversation={() => {
+              void wahaState.loadChats();
+            }}
+            searchInputRef={searchInputRef}
             loading={wahaState.loading}
-            onRefresh={wahaState.loadChats}
           />
         </div>
 
-        {/* Main Chat Area */}
-        <div className="flex-1 flex flex-col min-h-0">
-          <ChatArea
-            activeChat={wahaState.activeChat}
-            messages={wahaState.activeChatMessages}
-            onSendMessage={wahaState.sendMessage}
-            onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
-            sidebarOpen={sidebarOpen}
+        <div className="flex-1 min-w-0">
+          <CRMChatWindow
+            conversation={activeConversation}
+            messages={messages}
+            hasMore={false}
+            isLoading={messagesLoading}
+            isLoadingMore={false}
+            onSendMessage={handleSendMessage}
+            onLoadOlder={async () => []}
+            onUpdateConversation={handleUpdateConversation}
+            isUpdatingConversation={false}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace the WAHA WhatsApp layout UI with the shared CRM chat sidebar and window components
- map WAHA chat and message data into the conversation/message structures expected by the shared components and keep local overrides for UI-only updates
- hook message sending, selection and refresh actions into the new components while preserving the session status banner

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68caee5ec7708326b1962eef8767aef1