### PR TITLE
Adjust chat layout flex behavior

### DIFF
--- a/frontend/src/components/waha/WhatsAppLayout.tsx
+++ b/frontend/src/components/waha/WhatsAppLayout.tsx
@@ -264,7 +264,7 @@ export const WhatsAppLayout = () => {
         onRefresh={wahaState.checkSessionStatus}
       />
 
-      <div className="h-full pt-14 box-border flex-shrink-0">
+      <div className="h-full pt-14 box-border flex-shrink-0 w-80 max-w-full">
         <CRMChatSidebar
           conversations={conversations}
           activeConversationId={activeConversationId}
@@ -283,18 +283,19 @@ export const WhatsAppLayout = () => {
       </div>
 
       <div className="flex flex-1 min-w-0 min-h-0 pt-14 box-border overflow-hidden">
-        <CRMChatWindow
-          conversation={activeConversation}
-          messages={messages}
-          hasMore={false}
-          isLoading={messagesLoading}
-          isLoadingMore={false}
-          onSendMessage={handleSendMessage}
-          onLoadOlder={async () => []}
-          onUpdateConversation={handleUpdateConversation}
-          isUpdatingConversation={false}
-        />
-
+        <div className="flex flex-1 flex-col min-h-0 w-full">
+          <CRMChatWindow
+            conversation={activeConversation}
+            messages={messages}
+            hasMore={false}
+            isLoading={messagesLoading}
+            isLoadingMore={false}
+            onSendMessage={handleSendMessage}
+            onLoadOlder={async () => []}
+            onUpdateConversation={handleUpdateConversation}
+            isUpdatingConversation={false}
+          />
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/features/chat/components/ChatInput.module.css
+++ b/frontend/src/features/chat/components/ChatInput.module.css
@@ -5,6 +5,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  flex: 0 0 auto;
 }
 
 .toolbar {

--- a/frontend/src/features/chat/components/ChatSidebar.module.css
+++ b/frontend/src/features/chat/components/ChatSidebar.module.css
@@ -1,6 +1,6 @@
 .sidebar {
-  width: 360px;
-  max-width: 100%;
+  width: 100%;
+  max-width: none;
   background: hsl(var(--sidebar-background));
   color: hsl(var(--sidebar-foreground));
   border-right: 1px solid hsl(var(--sidebar-border));
@@ -8,6 +8,7 @@
   flex-direction: column;
   height: 100%;
   min-height: 0;
+  min-width: 0;
 }
 
 .header {
@@ -15,12 +16,14 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  min-width: 0;
 }
 
 .titleRow {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
+  min-width: 0;
 }
 
 .titleRow h1 {
@@ -54,6 +57,7 @@
   background: hsl(var(--sidebar-accent));
   border-radius: 999px;
   padding: 0.5rem 0.75rem;
+  min-width: 0;
 }
 
 .searchInput {
@@ -162,6 +166,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.3rem;
+  min-width: 0;
 }
 
 .itemTitle {
@@ -170,6 +175,7 @@
   justify-content: space-between;
   gap: 0.5rem;
   font-weight: 600;
+  min-width: 0;
 }
 
 .itemPreview {
@@ -179,6 +185,7 @@
   align-items: center;
   gap: 0.35rem;
   line-height: 1.4;
+  min-width: 0;
 }
 
 .itemButton[data-active="true"] .itemPreview {
@@ -237,7 +244,7 @@
 
 @media (max-width: 1200px) {
   .sidebar {
-    width: 320px;
+    width: 100%;
   }
 }
 

--- a/frontend/src/features/chat/components/ChatWindow.module.css
+++ b/frontend/src/features/chat/components/ChatWindow.module.css
@@ -1,10 +1,10 @@
 .wrapper {
-  flex: 1;
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   background: hsl(var(--background));
-  height: 100%;
   min-height: 0;
+  min-width: 0;
   position: relative;
   overflow: hidden;
   --details-panel-width: min(420px, 32vw);
@@ -15,10 +15,11 @@
 }
 
 .mainColumn {
-  flex: 1;
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   min-height: 0;
+  min-width: 0;
   transition: margin-right 0.3s ease;
 }
 
@@ -29,12 +30,14 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
+  min-width: 0;
 }
 
 .headerInfo {
   display: flex;
   align-items: center;
   gap: 1rem;
+  min-width: 0;
 }
 
 .headerInfo img {
@@ -48,12 +51,14 @@
   display: flex;
   flex-direction: column;
   gap: 0.45rem;
+  min-width: 0;
 }
 
 .headerTitleRow {
   display: flex;
   align-items: center;
   gap: 0.6rem;
+  min-width: 0;
 }
 
 .headerDetails {
@@ -61,6 +66,7 @@
   align-items: center;
   flex-wrap: wrap;
   gap: 0.65rem;
+  min-width: 0;
 }
 
 .headerTitleRow h2 {
@@ -74,6 +80,7 @@
   align-items: center;
   flex-wrap: wrap;
   gap: 0.6rem;
+  min-width: 0;
 }
 
 .headerResponsible {
@@ -598,9 +605,11 @@
 
 .viewportWrapper {
   position: relative;
-  flex: 1;
+  flex: 1 1 auto;
   display: flex;
+  flex-direction: column;
   min-height: 0;
+  overflow-y: auto;
 }
 
 @media (max-width: 1100px) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -138,6 +138,12 @@
     @apply border-border;
   }
 
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
+
   body {
     @apply bg-background text-foreground;
   }


### PR DESCRIPTION
## Summary
- wrap the CRM chat window in a flex column container and set a fixed width wrapper for the sidebar in the WhatsApp layout
- update chat window, sidebar, and input styles to use flexible columns, min-width safeguards, and scrolling areas that keep the input footer fixed
- ensure the global document root fills the viewport height so chat panels can stretch reliably

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68caf624fa3483268720a2f748f95613