### PR TITLE
Adjust chat layout scroll behavior

### DIFF
--- a/frontend/src/components/waha/WhatsAppLayout.tsx
+++ b/frontend/src/components/waha/WhatsAppLayout.tsx
@@ -264,37 +264,38 @@ export const WhatsAppLayout = () => {
         onRefresh={wahaState.checkSessionStatus}
       />
 
-      <div className="h-full pt-14 box-border flex-shrink-0">
-        <CRMChatSidebar
-          conversations={conversations}
-          activeConversationId={activeConversationId}
-          searchValue={searchValue}
-          onSearchChange={setSearchValue}
-          responsibleFilter={responsibleFilter}
-          responsibleOptions={teamMembers}
-          onResponsibleFilterChange={setResponsibleFilter}
-          onSelectConversation={handleSelectConversation}
-          onNewConversation={() => {
-            void wahaState.loadChats();
-          }}
-          searchInputRef={searchInputRef}
-          loading={wahaState.loading}
-        />
-      </div>
+      <div className="flex flex-1 min-h-0 pt-14 box-border overflow-hidden">
+        <aside className="flex flex-shrink-0 h-full min-h-0 overflow-hidden">
+          <CRMChatSidebar
+            conversations={conversations}
+            activeConversationId={activeConversationId}
+            searchValue={searchValue}
+            onSearchChange={setSearchValue}
+            responsibleFilter={responsibleFilter}
+            responsibleOptions={teamMembers}
+            onResponsibleFilterChange={setResponsibleFilter}
+            onSelectConversation={handleSelectConversation}
+            onNewConversation={() => {
+              void wahaState.loadChats();
+            }}
+            searchInputRef={searchInputRef}
+            loading={wahaState.loading}
+          />
+        </aside>
 
-      <div className="flex flex-1 min-w-0 min-h-0 pt-14 box-border overflow-hidden">
-        <CRMChatWindow
-          conversation={activeConversation}
-          messages={messages}
-          hasMore={false}
-          isLoading={messagesLoading}
-          isLoadingMore={false}
-          onSendMessage={handleSendMessage}
-          onLoadOlder={async () => []}
-          onUpdateConversation={handleUpdateConversation}
-          isUpdatingConversation={false}
-        />
-
+        <section className="flex flex-1 min-w-0 min-h-0 overflow-hidden">
+          <CRMChatWindow
+            conversation={activeConversation}
+            messages={messages}
+            hasMore={false}
+            isLoading={messagesLoading}
+            isLoadingMore={false}
+            onSendMessage={handleSendMessage}
+            onLoadOlder={async () => []}
+            onUpdateConversation={handleUpdateConversation}
+            isUpdatingConversation={false}
+          />
+        </section>
       </div>
     </div>
   );

--- a/frontend/src/features/chat/components/ChatWindow.module.css
+++ b/frontend/src/features/chat/components/ChatWindow.module.css
@@ -20,6 +20,7 @@
   flex-direction: column;
   min-height: 0;
   transition: margin-right 0.3s ease;
+  overflow: hidden;
 }
 
 .header {
@@ -29,6 +30,14 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: hsl(var(--background));
+}
+
+.wrapper[data-private="true"] .header {
+  background: linear-gradient(180deg, hsl(var(--background)), hsl(var(--muted) / 0.35));
 }
 
 .headerInfo {

--- a/frontend/src/pages/Conversas.tsx
+++ b/frontend/src/pages/Conversas.tsx
@@ -1,7 +1,7 @@
 import { WhatsAppLayout } from "../components/waha";
 
 const Conversas = () => (
-  <div className="h-full min-h-0 bg-background">
+  <div className="h-full min-h-0 bg-background flex flex-col overflow-hidden">
     <WhatsAppLayout />
   </div>
 );


### PR DESCRIPTION
## Summary
- wrap the WhatsApp conversations page content in an overflow-hidden flex container so the chat area can use its own scroll containers
- split the layout so the sidebar and chat window live in dedicated wrappers, keeping the message list scroll isolated from the conversations list
- make the chat header sticky so it remains visible while messages scroll

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68caf91c655c832685449ae6966a4fd9