### PR TITLE
Fix conversations page layout overflow

### DIFF
--- a/frontend/src/components/layout/CRMLayout.tsx
+++ b/frontend/src/components/layout/CRMLayout.tsx
@@ -1,16 +1,20 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
 import { SidebarProvider } from "@/components/ui/sidebar";
 
 export function CRMLayout() {
+  const location = useLocation();
+  const isConversationsRoute = location.pathname.startsWith("/conversas");
+  const mainClassName = `flex-1 bg-background ${isConversationsRoute ? "overflow-hidden" : "overflow-auto"}`;
+
   return (
     <SidebarProvider>
       <div className="min-h-screen bg-background flex w-full">
         <Sidebar />
         <div className="flex-1 flex flex-col">
           <Header />
-          <main className="flex-1 overflow-auto bg-background">
+          <main className={mainClassName}>
             <Outlet />
           </main>
         </div>

--- a/frontend/src/components/waha/WhatsAppLayout.tsx
+++ b/frontend/src/components/waha/WhatsAppLayout.tsx
@@ -264,37 +264,38 @@ export const WhatsAppLayout = () => {
         onRefresh={wahaState.checkSessionStatus}
       />
 
-      <div className="h-full pt-14 box-border flex-shrink-0">
-        <CRMChatSidebar
-          conversations={conversations}
-          activeConversationId={activeConversationId}
-          searchValue={searchValue}
-          onSearchChange={setSearchValue}
-          responsibleFilter={responsibleFilter}
-          responsibleOptions={teamMembers}
-          onResponsibleFilterChange={setResponsibleFilter}
-          onSelectConversation={handleSelectConversation}
-          onNewConversation={() => {
-            void wahaState.loadChats();
-          }}
-          searchInputRef={searchInputRef}
-          loading={wahaState.loading}
-        />
-      </div>
+      <div className="flex flex-1 min-h-0 pt-14 box-border overflow-hidden">
+        <aside className="flex flex-shrink-0 h-full min-h-0 overflow-hidden">
+          <CRMChatSidebar
+            conversations={conversations}
+            activeConversationId={activeConversationId}
+            searchValue={searchValue}
+            onSearchChange={setSearchValue}
+            responsibleFilter={responsibleFilter}
+            responsibleOptions={teamMembers}
+            onResponsibleFilterChange={setResponsibleFilter}
+            onSelectConversation={handleSelectConversation}
+            onNewConversation={() => {
+              void wahaState.loadChats();
+            }}
+            searchInputRef={searchInputRef}
+            loading={wahaState.loading}
+          />
+        </aside>
 
-      <div className="flex flex-1 min-w-0 min-h-0 pt-14 box-border overflow-hidden">
-        <CRMChatWindow
-          conversation={activeConversation}
-          messages={messages}
-          hasMore={false}
-          isLoading={messagesLoading}
-          isLoadingMore={false}
-          onSendMessage={handleSendMessage}
-          onLoadOlder={async () => []}
-          onUpdateConversation={handleUpdateConversation}
-          isUpdatingConversation={false}
-        />
-
+        <section className="flex flex-1 min-w-0 min-h-0 overflow-hidden">
+          <CRMChatWindow
+            conversation={activeConversation}
+            messages={messages}
+            hasMore={false}
+            isLoading={messagesLoading}
+            isLoadingMore={false}
+            onSendMessage={handleSendMessage}
+            onLoadOlder={async () => []}
+            onUpdateConversation={handleUpdateConversation}
+            isUpdatingConversation={false}
+          />
+        </section>
       </div>
     </div>
   );

--- a/frontend/src/features/chat/components/ChatWindow.module.css
+++ b/frontend/src/features/chat/components/ChatWindow.module.css
@@ -20,6 +20,7 @@
   flex-direction: column;
   min-height: 0;
   transition: margin-right 0.3s ease;
+  overflow: hidden;
 }
 
 .header {
@@ -29,6 +30,14 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: hsl(var(--background));
+}
+
+.wrapper[data-private="true"] .header {
+  background: linear-gradient(180deg, hsl(var(--background)), hsl(var(--muted) / 0.35));
 }
 
 .headerInfo {

--- a/frontend/src/pages/Conversas.tsx
+++ b/frontend/src/pages/Conversas.tsx
@@ -1,7 +1,7 @@
 import { WhatsAppLayout } from "../components/waha";
 
 const Conversas = () => (
-  <div className="h-full min-h-0 bg-background">
+  <div className="h-full min-h-0 bg-background flex flex-col overflow-hidden">
     <WhatsAppLayout />
   </div>
 );


### PR DESCRIPTION
## Summary
- prevent the main CRM layout container from scrolling on the Conversas route so the chat window stays fixed on screen

## Testing
- `npm run lint` *(fails: existing lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68caf91c655c832685449ae6966a4fd9