### PR TITLE
Refine WhatsApp chat layout

### DIFF
--- a/frontend/src/components/waha/WhatsAppLayout.tsx
+++ b/frontend/src/components/waha/WhatsAppLayout.tsx
@@ -258,14 +258,14 @@ export const WhatsAppLayout = () => {
   };
 
   return (
-    <div className="relative flex h-full min-h-0 bg-background overflow-hidden">
+    <div className="relative flex h-full min-h-0 overflow-hidden bg-muted/20">
       <SessionStatus
         status={wahaState.sessionStatus}
         onRefresh={wahaState.checkSessionStatus}
       />
 
-      <div className="flex flex-1 min-h-0 pt-14 box-border overflow-hidden">
-        <aside className="flex flex-shrink-0 h-full min-h-0 overflow-hidden">
+      <div className="flex h-full flex-1 min-h-0 pt-14 box-border overflow-hidden">
+        <div className="flex h-full min-h-0 w-[32%] min-w-[320px] max-w-md flex-shrink-0 flex-col overflow-hidden border-r border-border/50 bg-sidebar shadow-[0_12px_24px_rgba(15,23,42,0.06)]">
           <CRMChatSidebar
             conversations={conversations}
             activeConversationId={activeConversationId}
@@ -281,9 +281,9 @@ export const WhatsAppLayout = () => {
             searchInputRef={searchInputRef}
             loading={wahaState.loading}
           />
-        </aside>
+        </div>
 
-        <section className="flex flex-1 min-w-0 min-h-0 overflow-hidden">
+        <div className="flex h-full flex-1 min-w-0 flex-col overflow-hidden bg-background">
           <CRMChatWindow
             conversation={activeConversation}
             messages={messages}
@@ -295,7 +295,7 @@ export const WhatsAppLayout = () => {
             onUpdateConversation={handleUpdateConversation}
             isUpdatingConversation={false}
           />
-        </section>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/features/chat/components/ChatInput.module.css
+++ b/frontend/src/features/chat/components/ChatInput.module.css
@@ -1,7 +1,9 @@
 .container {
-  border-top: 1px solid hsl(var(--border));
-  padding: 0.75rem 1rem 1rem;
+  border-radius: 1.5rem;
+  padding: 0.75rem 1rem 0.85rem;
   background: hsl(var(--background));
+  border: 1px solid hsl(var(--border) / 0.6);
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -11,6 +13,7 @@
   display: flex;
   align-items: center;
   gap: 0.6rem;
+  padding: 0 0.25rem;
 }
 
 .iconButton {
@@ -38,50 +41,53 @@
   display: flex;
   align-items: flex-end;
   gap: 0.75rem;
+  background: hsl(var(--input));
+  border-radius: 1.25rem;
+  padding: 0.65rem 0.75rem 0.65rem 1rem;
 }
 
 .textarea {
   flex: 1;
-  min-height: 3rem;
-  max-height: 8rem;
+  min-height: 2.75rem;
+  max-height: 7.5rem;
   resize: none;
-  border: 1px solid hsl(var(--border));
-  border-radius: 1rem;
-  padding: 0.75rem 1rem;
-  background: hsl(var(--input));
+  border: none;
+  background: transparent;
   color: inherit;
   font-size: 0.95rem;
   line-height: 1.5;
+  padding: 0;
 }
 
 .textarea:focus {
-  outline: 2px solid hsl(var(--primary));
-  border-color: hsl(var(--primary));
+  outline: none;
 }
 
 .sendButton {
   border: none;
-  background: hsl(var(--primary));
+  background: linear-gradient(135deg, hsl(var(--primary-light)), hsl(var(--primary)));
   color: hsl(var(--primary-foreground));
   border-radius: 999px;
-  width: 3rem;
-  height: 3rem;
+  width: 2.75rem;
+  height: 2.75rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   transition: var(--transition-fast);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.15);
 }
 
 .sendButton[disabled] {
   cursor: not-allowed;
   background: hsl(var(--muted));
   color: hsl(var(--muted-foreground));
+  box-shadow: none;
 }
 
 .sendButton:not([disabled]):hover,
 .sendButton:not([disabled]):focus-visible {
-  background: hsl(var(--primary-hover));
+  filter: brightness(1.05);
 }
 
 .popover {

--- a/frontend/src/features/chat/components/ChatSidebar.module.css
+++ b/frontend/src/features/chat/components/ChatSidebar.module.css
@@ -1,9 +1,10 @@
 .sidebar {
-  width: 360px;
-  max-width: 100%;
-  background: hsl(var(--sidebar-background));
+  width: 100%;
+  max-width: none;
+  background: linear-gradient(180deg, hsl(var(--sidebar-background)), hsl(var(--sidebar-background)) 60%, hsl(var(--background)) 100%);
   color: hsl(var(--sidebar-foreground));
   border-right: 1px solid hsl(var(--sidebar-border));
+  box-shadow: inset -1px 0 0 rgba(15, 23, 42, 0.05), 6px 0 24px rgba(15, 23, 42, 0.04);
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -15,6 +16,11 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: linear-gradient(180deg, hsl(var(--sidebar-background)) 0%, hsl(var(--sidebar-background)) 75%, transparent 100%);
+  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.05);
 }
 
 .titleRow {
@@ -98,11 +104,13 @@
 .listContainer {
   flex: 1;
   overflow-y: auto;
-  padding: 0.5rem 0.75rem 1.5rem;
+  padding: 0.5rem 0.75rem 1.75rem;
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
   min-height: 0;
+  background: hsl(var(--background));
+  box-shadow: inset 0 1px 0 rgba(15, 23, 42, 0.04);
 }
 
 .list {
@@ -227,17 +235,20 @@
 }
 
 .footer {
-  padding: 0.75rem 1.25rem 1.5rem;
+  padding: 0.85rem 1.25rem 1.25rem;
   color: hsl(var(--muted-foreground));
   display: flex;
   align-items: center;
   gap: 0.5rem;
   font-size: 0.85rem;
+  background: linear-gradient(0deg, hsl(var(--sidebar-background)) 10%, transparent 100%);
+  border-top: 1px solid hsl(var(--sidebar-border));
 }
 
 @media (max-width: 1200px) {
   .sidebar {
-    width: 320px;
+    width: 100%;
+    max-width: none;
   }
 }
 

--- a/frontend/src/features/chat/components/ChatWindow.module.css
+++ b/frontend/src/features/chat/components/ChatWindow.module.css
@@ -2,7 +2,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  background: hsl(var(--background));
+  background: linear-gradient(180deg, hsl(var(--background)), hsl(var(--muted) / 0.35));
   height: 100%;
   min-height: 0;
   position: relative;
@@ -21,6 +21,8 @@
   min-height: 0;
   transition: margin-right 0.3s ease;
   overflow: hidden;
+  background: linear-gradient(180deg, hsl(var(--background)) 0%, hsl(var(--background)) 55%, hsl(var(--muted) / 0.15) 100%);
+  box-shadow: inset 0 1px 0 rgba(15, 23, 42, 0.04);
 }
 
 .header {
@@ -33,7 +35,8 @@
   position: sticky;
   top: 0;
   z-index: 20;
-  background: hsl(var(--background));
+  background: linear-gradient(180deg, hsl(var(--background)) 0%, hsl(var(--background)) 80%, transparent 100%);
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.05);
 }
 
 .wrapper[data-private="true"] .header {
@@ -610,6 +613,17 @@
   flex: 1;
   display: flex;
   min-height: 0;
+  background: linear-gradient(180deg, hsl(var(--muted) / 0.15), transparent 30%), linear-gradient(90deg, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.9));
+}
+
+.inputContainer {
+  position: sticky;
+  bottom: 0;
+  flex-shrink: 0;
+  width: 100%;
+  background: linear-gradient(0deg, hsl(var(--background)) 40%, hsl(var(--background)) 90%, transparent 100%);
+  padding: 0 1.5rem 1.5rem;
+  box-shadow: 0 -6px 18px rgba(15, 23, 42, 0.08);
 }
 
 @media (max-width: 1100px) {

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -384,7 +384,9 @@ export const ChatWindow = ({
             onStickToBottomChange={setStickToBottom}
           />
         </div>
-        <ChatInput onSend={handleSend} disabled={isLoading} />
+        <div className={styles.inputContainer}>
+          <ChatInput onSend={handleSend} disabled={isLoading} />
+        </div>
         <DeviceLinkModal open={deviceModalOpen} onClose={() => setDeviceModalOpen(false)} />
       </div>
       <aside

--- a/frontend/src/features/chat/components/MessageBubble.module.css
+++ b/frontend/src/features/chat/components/MessageBubble.module.css
@@ -1,8 +1,8 @@
 .row {
   display: flex;
   align-items: flex-end;
-  gap: 0.6rem;
-  margin: 0.35rem 0;
+  gap: 0.5rem;
+  margin: 0.25rem 0;
 }
 
 .outgoing {
@@ -14,20 +14,23 @@
 }
 
 .bubble {
-  max-width: min(75%, 520px);
-  padding: 0.65rem 0.75rem 0.55rem;
+  max-width: min(72%, 480px);
+  padding: 0.65rem 0.85rem 0.6rem;
   border-radius: 1rem;
-  background: hsl(var(--accent));
-  color: hsl(var(--accent-foreground));
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  background: hsl(var(--card));
+  color: hsl(var(--card-foreground));
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
   position: relative;
   display: grid;
   gap: 0.35rem;
 }
 
 .outgoing .bubble {
-  background: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary-hover)));
+  background: linear-gradient(135deg, hsl(var(--primary-light)), hsl(var(--primary)));
   color: hsl(var(--primary-foreground));
+  border: none;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.15);
 }
 
 .text {
@@ -40,9 +43,9 @@
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  gap: 0.4rem;
-  font-size: 0.75rem;
-  opacity: 0.85;
+  gap: 0.35rem;
+  font-size: 0.72rem;
+  opacity: 0.8;
 }
 
 .attachment {
@@ -66,7 +69,7 @@
 }
 
 .grouped {
-  margin-top: 0.1rem;
+  margin-top: 0.15rem;
 }
 
 .statusIcon {


### PR DESCRIPTION
## Summary
- restructure the WhatsApp integration layout to enforce a flex two-column split with defined widths and overflow handling
- restyle the sidebar, chat viewport, and composer to better match WhatsApp Web with sticky header/search and a fixed input bar
- tune message bubble spacing and backgrounds for a clearer separation between incoming and outgoing messages

## Testing
- npm run lint *(fails: existing lint errors in unrelated WAHA API files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1c2226988326bf97aa22f90e1f9f