### PR TITLE
Adjust chat layout scroll handling

### DIFF
--- a/frontend/src/features/chat/ChatPage.module.css
+++ b/frontend/src/features/chat/ChatPage.module.css
@@ -1,12 +1,21 @@
-.layout {
+.page {
   display: flex;
-  width: 100%;
-  height: calc(100vh - 4rem);
-  max-height: calc(100vh - 4rem);
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
   background: hsl(var(--background));
   color: hsl(var(--foreground));
-  overflow: hidden;
+}
+
+.layout {
+  display: flex;
+  flex: 1;
+  width: 100%;
   min-height: 0;
+  overflow: hidden;
+  background: inherit;
+  color: inherit;
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -249,31 +249,33 @@ export const ChatPage = () => {
   ]);
 
   return (
-    <div className={styles.layout}>
-      <ChatSidebar
-        conversations={conversations}
-        activeConversationId={selectedConversationId}
-        searchValue={searchValue}
-        onSearchChange={setSearchValue}
-        responsibleFilter={responsibleFilter}
-        responsibleOptions={responsibleOptions}
-        onResponsibleFilterChange={setResponsibleFilter}
-        onSelectConversation={handleSelectConversation}
-        onNewConversation={() => setNewConversationOpen(true)}
-        searchInputRef={searchInputRef}
-        loading={conversationsQuery.isLoading}
-      />
-      <ChatWindow
-        conversation={selectedConversation}
-        messages={messages}
-        hasMore={hasMore}
-        isLoading={messagesLoading}
-        isLoadingMore={isLoadingMore}
-        onSendMessage={handleSendMessage}
-        onLoadOlder={loadOlder}
-        onUpdateConversation={handleUpdateConversation}
-        isUpdatingConversation={updateConversationMutation.isPending}
-      />
+    <div className={styles.page}>
+      <div className={styles.layout}>
+        <ChatSidebar
+          conversations={conversations}
+          activeConversationId={selectedConversationId}
+          searchValue={searchValue}
+          onSearchChange={setSearchValue}
+          responsibleFilter={responsibleFilter}
+          responsibleOptions={responsibleOptions}
+          onResponsibleFilterChange={setResponsibleFilter}
+          onSelectConversation={handleSelectConversation}
+          onNewConversation={() => setNewConversationOpen(true)}
+          searchInputRef={searchInputRef}
+          loading={conversationsQuery.isLoading}
+        />
+        <ChatWindow
+          conversation={selectedConversation}
+          messages={messages}
+          hasMore={hasMore}
+          isLoading={messagesLoading}
+          isLoadingMore={isLoadingMore}
+          onSendMessage={handleSendMessage}
+          onLoadOlder={loadOlder}
+          onUpdateConversation={handleUpdateConversation}
+          isUpdatingConversation={updateConversationMutation.isPending}
+        />
+      </div>
       <NewConversationModal
         open={newConversationOpen}
         suggestions={conversations}

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -166,6 +166,15 @@ export const ChatWindow = ({
     previousLastMessageRef.current = lastMessageId;
   }, [conversation?.id, messages, stickToBottom]);
 
+  const conversationId = conversation?.id;
+
+  useEffect(() => {
+    if (!conversationId) return;
+    const node = scrollRef.current;
+    if (!node) return;
+    node.scrollTop = node.scrollHeight;
+  }, [conversationId]);
+
   const runUpdate = async (changes: UpdateConversationPayload) => {
     if (!conversation) return;
     try {


### PR DESCRIPTION
## Summary
- wrap the chat page content with a full-height flex column container so the conversation area fits between header and footer without overflow
- update chat page styles to rely on flex growth and inherited colors instead of viewport height calculations
- ensure the chat window scroll container snaps to the newest message whenever a different conversation loads

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*
- npx eslint src/features/chat/components/ChatWindow.tsx src/features/chat/ChatPage.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb33b68ae88326b2f97dcb57d3ac95