### PR TITLE
Ensure chat layout columns manage their own scroll

### DIFF
--- a/frontend/src/components/layout/CRMLayout.tsx
+++ b/frontend/src/components/layout/CRMLayout.tsx
@@ -6,7 +6,9 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 export function CRMLayout() {
   const location = useLocation();
   const isConversationsRoute = location.pathname.startsWith("/conversas");
-  const mainClassName = `flex-1 bg-background ${isConversationsRoute ? "overflow-hidden" : "overflow-auto"}`;
+  const mainClassName = `flex-1 min-h-0 bg-background ${
+    isConversationsRoute ? "overflow-hidden" : "overflow-auto"
+  }`;
 
   return (
     <SidebarProvider>

--- a/frontend/src/features/chat/ChatPage.module.css
+++ b/frontend/src/features/chat/ChatPage.module.css
@@ -1,12 +1,21 @@
-.layout {
+.page {
   display: flex;
-  width: 100%;
-  height: calc(100vh - 4rem);
-  max-height: calc(100vh - 4rem);
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
   background: hsl(var(--background));
   color: hsl(var(--foreground));
-  overflow: hidden;
+}
+
+.layout {
+  display: flex;
+  flex: 1;
+  width: 100%;
   min-height: 0;
+  overflow: hidden;
+  background: inherit;
+  color: inherit;
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -249,31 +249,33 @@ export const ChatPage = () => {
   ]);
 
   return (
-    <div className={styles.layout}>
-      <ChatSidebar
-        conversations={conversations}
-        activeConversationId={selectedConversationId}
-        searchValue={searchValue}
-        onSearchChange={setSearchValue}
-        responsibleFilter={responsibleFilter}
-        responsibleOptions={responsibleOptions}
-        onResponsibleFilterChange={setResponsibleFilter}
-        onSelectConversation={handleSelectConversation}
-        onNewConversation={() => setNewConversationOpen(true)}
-        searchInputRef={searchInputRef}
-        loading={conversationsQuery.isLoading}
-      />
-      <ChatWindow
-        conversation={selectedConversation}
-        messages={messages}
-        hasMore={hasMore}
-        isLoading={messagesLoading}
-        isLoadingMore={isLoadingMore}
-        onSendMessage={handleSendMessage}
-        onLoadOlder={loadOlder}
-        onUpdateConversation={handleUpdateConversation}
-        isUpdatingConversation={updateConversationMutation.isPending}
-      />
+    <div className={styles.page}>
+      <div className={styles.layout}>
+        <ChatSidebar
+          conversations={conversations}
+          activeConversationId={selectedConversationId}
+          searchValue={searchValue}
+          onSearchChange={setSearchValue}
+          responsibleFilter={responsibleFilter}
+          responsibleOptions={responsibleOptions}
+          onResponsibleFilterChange={setResponsibleFilter}
+          onSelectConversation={handleSelectConversation}
+          onNewConversation={() => setNewConversationOpen(true)}
+          searchInputRef={searchInputRef}
+          loading={conversationsQuery.isLoading}
+        />
+        <ChatWindow
+          conversation={selectedConversation}
+          messages={messages}
+          hasMore={hasMore}
+          isLoading={messagesLoading}
+          isLoadingMore={isLoadingMore}
+          onSendMessage={handleSendMessage}
+          onLoadOlder={loadOlder}
+          onUpdateConversation={handleUpdateConversation}
+          isUpdatingConversation={updateConversationMutation.isPending}
+        />
+      </div>
       <NewConversationModal
         open={newConversationOpen}
         suggestions={conversations}

--- a/frontend/src/features/chat/components/ChatSidebar.module.css
+++ b/frontend/src/features/chat/components/ChatSidebar.module.css
@@ -7,8 +7,9 @@
   box-shadow: inset -1px 0 0 rgba(15, 23, 42, 0.05), 6px 0 24px rgba(15, 23, 42, 0.04);
   display: flex;
   flex-direction: column;
-  height: 35%;
+  height: 100%;
   min-height: 0;
+  overflow: hidden;
 }
 
 .header {
@@ -257,6 +258,6 @@
   .sidebar {
     width: 100%;
     max-width: none;
-    height: 50vh;
+    height: auto;
   }
 }

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -166,6 +166,15 @@ export const ChatWindow = ({
     previousLastMessageRef.current = lastMessageId;
   }, [conversation?.id, messages, stickToBottom]);
 
+  const conversationId = conversation?.id;
+
+  useEffect(() => {
+    if (!conversationId) return;
+    const node = scrollRef.current;
+    if (!node) return;
+    node.scrollTop = node.scrollHeight;
+  }, [conversationId]);
+
   const runUpdate = async (changes: UpdateConversationPayload) => {
     if (!conversation) return;
     try {


### PR DESCRIPTION
## Summary
- allow the CRM layout main area to shrink within the flex column so the conversations route keeps its scroll containers inside the viewport
- let the chat sidebar stretch to the full column height and hide overflow so the conversation list scrolls independently without expanding the page

## Testing
- npx eslint src/components/layout/CRMLayout.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cb33b68ae88326b2f97dcb57d3ac95