### PR TITLE
Align chat message column with conversation list

### DIFF
--- a/frontend/src/features/chat/components/ChatWindow.module.css
+++ b/frontend/src/features/chat/components/ChatWindow.module.css
@@ -622,7 +622,7 @@
   flex-shrink: 0;
   width: 100%;
   background: linear-gradient(0deg, hsl(var(--background)) 40%, hsl(var(--background)) 90%, transparent 100%);
-  padding: 0 1.5rem 1.5rem;
+  padding: 0 1.5rem 1.5rem 0;
   box-shadow: 0 -6px 18px rgba(15, 23, 42, 0.08);
 }
 
@@ -644,6 +644,10 @@
   .headerInfo img {
     width: 2.5rem;
     height: 2.5rem;
+  }
+
+  .inputContainer {
+    padding: 0 1rem 1rem;
   }
 
   .detailsPanel {

--- a/frontend/src/features/chat/components/MessageViewport.module.css
+++ b/frontend/src/features/chat/components/MessageViewport.module.css
@@ -1,7 +1,7 @@
 .container {
   flex: 1;
   overflow-y: auto;
-  padding: 1.5rem 1.75rem;
+  padding: 1.5rem 1.75rem 1.5rem 0;
   display: flex;
   flex-direction: column;
   min-height: 0;


### PR DESCRIPTION
## Summary
- remove the left padding from the chat message viewport so the conversation column and message list sit flush
- adjust the chat input container padding and add a mobile override to keep spacing consistent when stacked

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3d8004048326923a26ca228e0a86