### PR TITLE
Adjust chat placeholder layout to match flex split

### DIFF
--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -284,7 +284,7 @@ export const ChatWindow = ({
     });
   };
 
-  const placeholder = useMemo(
+  const placeholderContent = useMemo(
     () => (
       <div className={styles.placeholder}>
         <div>
@@ -300,7 +300,13 @@ export const ChatWindow = ({
   );
 
   if (!conversation) {
-    return <div className={styles.wrapper}>{placeholder}</div>;
+    return (
+      <div className={styles.wrapper}>
+        <div className={styles.mainColumn}>
+          <div className={styles.viewportWrapper}>{placeholderContent}</div>
+        </div>
+      </div>
+    );
   }
 
   const detailsPanelId = `chat-details-${conversation.id}`;


### PR DESCRIPTION
## Summary
- wrap the conversation placeholder in the same flex column structure used by the active chat view
- ensure the message area container keeps ownership of the placeholder content so the message pane occupies the primary space

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated WAHA files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb42119fec8326a79269b8b289d37a