### PR TITLE
Remove gradient from light theme chat bubbles

### DIFF
--- a/frontend/src/features/chat/components/MessageBubble.module.css
+++ b/frontend/src/features/chat/components/MessageBubble.module.css
@@ -28,10 +28,14 @@
 }
 
 .outgoing .bubble {
-  background: linear-gradient(135deg, hsl(var(--primary-light)), hsl(var(--primary)));
+  background: hsl(var(--primary));
   color: hsl(var(--primary-foreground));
   border: none;
   box-shadow: 0 12px 24px rgba(15, 23, 42, 0.15);
+}
+
+:global(.dark) .outgoing .bubble {
+  background: linear-gradient(135deg, hsl(var(--primary-light)), hsl(var(--primary)));
 }
 
 .text {


### PR DESCRIPTION
## Summary
- update the chat message bubble styles so that outgoing messages use a solid primary color in the light theme
- keep the gradient styling scoped to the dark theme to maintain its intended appearance there

## Testing
- npm run lint *(fails: existing lint errors in files unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4d7f86448326ace41a063b1c6355