### PR TITLE
Tighten chat layout without page overflow

### DIFF
--- a/frontend/src/features/chat/components/ChatWindow.module.css
+++ b/frontend/src/features/chat/components/ChatWindow.module.css
@@ -3,10 +3,8 @@
     display: flex;
     flex-direction: column;
     background: linear-gradient(180deg, hsl(var(--background)), hsl(var(--muted) / 0.35));
-    height: 88%;
-    max-height: 100%;
     min-height: 0;
-    position: absolute;
+    position: relative;
     overflow: hidden;
     --details-panel-width: min(420px, 32vw);
 }
@@ -624,7 +622,8 @@
   flex-shrink: 0;
   width: 100%;
   background: linear-gradient(0deg, hsl(var(--background)) 40%, hsl(var(--background)) 90%, transparent 100%);
-  padding: 0 1.5rem 1.5rem;
+  padding: 1rem 1.5rem 0;
+  padding-bottom: env(safe-area-inset-bottom);
   box-shadow: 0 -6px 18px rgba(15, 23, 42, 0.08);
 }
 


### PR DESCRIPTION
## Summary
- rely on the flex layout for the chat window wrapper without forcing explicit width/height values that introduced page scrolling
- tighten the sticky input container padding so the composer sits flush with the bottom while still respecting safe-area insets

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4ac15b508326bd634236dbedfe9e