### PR TITLE
Add bearer token authentication API

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -50,6 +50,12 @@ Para cenários específicos é possível liberar todas as origens definindo `COR
 ## Documentação
 Após iniciar o servidor, acesse [http://localhost:3001/api-docs](http://localhost:3001/api-docs) para visualizar a documentação Swagger.
 
+## Autenticação
+
+Os endpoints `POST /api/auth/login` e `GET /api/auth/me` permitem autenticar usuários e recuperar os dados do usuário logado.
+Defina a variável `AUTH_TOKEN_SECRET` com um valor seguro em produção. Opcionalmente, utilize `AUTH_TOKEN_EXPIRATION` para
+customizar o tempo de expiração (em segundos ou usando sufixos como `15m`, `2h` ou `7d`).
+
 ## Produção
 
 Para gerar o build e executar o servidor em produção:

--- a/backend/src/constants/auth.ts
+++ b/backend/src/constants/auth.ts
@@ -1,0 +1,21 @@
+import { parseExpiration } from '../utils/tokenUtils';
+
+const FALLBACK_SECRET = 'change-me-in-production';
+const FALLBACK_EXPIRATION_SECONDS = 60 * 60; // 1 hora
+
+const secretFromEnv =
+  process.env.AUTH_TOKEN_SECRET || process.env.JWT_SECRET || process.env.TOKEN_SECRET;
+
+if (!secretFromEnv) {
+  console.warn(
+    'AUTH_TOKEN_SECRET não definido. Um valor padrão inseguro está sendo utilizado apenas para desenvolvimento.'
+  );
+}
+
+export const authConfig = {
+  secret: secretFromEnv ?? FALLBACK_SECRET,
+  expirationSeconds: parseExpiration(
+    process.env.AUTH_TOKEN_EXPIRATION || process.env.JWT_EXPIRATION,
+    FALLBACK_EXPIRATION_SECONDS
+  ),
+};

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -1,0 +1,107 @@
+import { Request, Response } from 'express';
+import pool from '../services/db';
+import { verifyPassword } from '../utils/passwordUtils';
+import { signToken } from '../utils/tokenUtils';
+import { authConfig } from '../constants/auth';
+
+const normalizeEmail = (email: string): string => email.trim().toLowerCase();
+
+export const login = async (req: Request, res: Response) => {
+  const { email, senha } = req.body as { email?: unknown; senha?: unknown };
+
+  if (typeof email !== 'string' || typeof senha !== 'string') {
+    res.status(400).json({ error: 'Credenciais inválidas.' });
+    return;
+  }
+
+  try {
+    const normalizedEmail = normalizeEmail(email);
+
+    const userResult = await pool.query(
+      'SELECT id, nome_completo, email, senha, status, perfil FROM public.usuarios WHERE LOWER(email) = $1 LIMIT 1',
+      [normalizedEmail]
+    );
+
+    if (userResult.rowCount === 0) {
+      res.status(401).json({ error: 'E-mail ou senha incorretos.' });
+      return;
+    }
+
+    const user = userResult.rows[0] as {
+      id: number;
+      nome_completo: string;
+      email: string;
+      senha: string | null;
+      status: boolean | null;
+      perfil: number | null;
+    };
+
+    if (user.status === false) {
+      res.status(403).json({ error: 'Usuário inativo.' });
+      return;
+    }
+
+    const passwordMatches = await verifyPassword(senha, user.senha);
+
+    if (!passwordMatches) {
+      res.status(401).json({ error: 'E-mail ou senha incorretos.' });
+      return;
+    }
+
+    const token = signToken(
+      {
+        sub: user.id,
+        email: user.email,
+        name: user.nome_completo,
+      },
+      authConfig.secret,
+      authConfig.expirationSeconds
+    );
+
+    res.json({
+      token,
+      expiresIn: authConfig.expirationSeconds,
+      user: {
+        id: user.id,
+        nome_completo: user.nome_completo,
+        email: user.email,
+        perfil: user.perfil,
+      },
+    });
+  } catch (error) {
+    console.error('Erro ao realizar login', error);
+    res.status(500).json({ error: 'Não foi possível concluir a autenticação.' });
+  }
+};
+
+export const getCurrentUser = async (req: Request, res: Response) => {
+  if (!req.auth) {
+    res.status(401).json({ error: 'Token inválido.' });
+    return;
+  }
+
+  try {
+    const result = await pool.query(
+      'SELECT id, nome_completo, email, perfil, status FROM public."vw.usuarios" WHERE id = $1',
+      [req.auth.userId]
+    );
+
+    if (result.rowCount === 0) {
+      res.status(404).json({ error: 'Usuário não encontrado.' });
+      return;
+    }
+
+    const user = result.rows[0];
+
+    res.json({
+      id: user.id,
+      nome_completo: user.nome_completo,
+      email: user.email,
+      perfil: user.perfil,
+      status: user.status,
+    });
+  } catch (error) {
+    console.error('Erro ao carregar usuário autenticado', error);
+    res.status(500).json({ error: 'Não foi possível carregar os dados do usuário.' });
+  }
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -31,6 +31,7 @@ import notificationRoutes from './routes/notificationRoutes';
 import integrationApiKeyRoutes from './routes/integrationApiKeyRoutes';
 import chatRoutes from './routes/chatRoutes';
 import wahaWebhookRoutes from './routes/wahaWebhookRoutes';
+import authRoutes from './routes/authRoutes';
 import swaggerUi from 'swagger-ui-express';
 import swaggerJsdoc from 'swagger-jsdoc';
 import swaggerOptions from './swagger';
@@ -121,6 +122,7 @@ app.use('/api', notificationRoutes);
 app.use('/api', integrationApiKeyRoutes);
 app.use('/api', chatRoutes);
 app.use('/api', wahaWebhookRoutes);
+app.use('/api', authRoutes);
 
 // Background jobs
 cronJobs.startProjudiSyncJob();

--- a/backend/src/middlewares/authMiddleware.ts
+++ b/backend/src/middlewares/authMiddleware.ts
@@ -1,0 +1,64 @@
+import { NextFunction, Request, Response } from 'express';
+import { authConfig } from '../constants/auth';
+import { verifyToken } from '../utils/tokenUtils';
+
+const extractBearerToken = (authorizationHeader: string | undefined): string | null => {
+  if (!authorizationHeader) {
+    return null;
+  }
+
+  const [scheme, token] = authorizationHeader.split(' ');
+
+  if (!scheme || !token) {
+    return null;
+  }
+
+  if (scheme.toLowerCase() !== 'bearer') {
+    return null;
+  }
+
+  return token.trim() || null;
+};
+
+export const authenticateRequest = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  const token = extractBearerToken(req.headers.authorization);
+
+  if (!token) {
+    res.status(401).json({ error: 'Token de autenticação ausente.' });
+    return;
+  }
+
+  try {
+    const payload = verifyToken(token, authConfig.secret);
+
+    if (typeof payload.sub !== 'string' && typeof payload.sub !== 'number') {
+      res.status(401).json({ error: 'Token inválido.' });
+      return;
+    }
+
+    const userId =
+      typeof payload.sub === 'number'
+        ? payload.sub
+        : Number.parseInt(payload.sub, 10);
+
+    if (!Number.isFinite(userId)) {
+      res.status(401).json({ error: 'Token inválido.' });
+      return;
+    }
+
+    req.auth = {
+      userId,
+      email: typeof payload.email === 'string' ? payload.email : undefined,
+      payload,
+    };
+
+    next();
+  } catch (error) {
+    console.error('Falha ao validar token de autenticação', error);
+    res.status(401).json({ error: 'Token inválido ou expirado.' });
+  }
+};

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -1,0 +1,99 @@
+import { Router } from 'express';
+import { getCurrentUser, login } from '../controllers/authController';
+import { authenticateRequest } from '../middlewares/authMiddleware';
+
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   - name: Autenticação
+ *     description: Endpoints para autenticação de usuários
+ */
+
+/**
+ * @swagger
+ * /api/auth/login:
+ *   post:
+ *     summary: Autentica um usuário e retorna um token Bearer
+ *     tags: [Autenticação]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - email
+ *               - senha
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 format: email
+ *               senha:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Token de acesso gerado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 token:
+ *                   type: string
+ *                 expiresIn:
+ *                   type: integer
+ *                   description: Expiração do token em segundos
+ *                 user:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: integer
+ *                     nome_completo:
+ *                       type: string
+ *                     email:
+ *                       type: string
+ *                     perfil:
+ *                       type: integer
+ *       400:
+ *         description: Requisição inválida
+ *       401:
+ *         description: Credenciais inválidas
+ */
+router.post('/auth/login', login);
+
+/**
+ * @swagger
+ * /api/auth/me:
+ *   get:
+ *     summary: Retorna os dados do usuário autenticado
+ *     tags: [Autenticação]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Dados do usuário autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: integer
+ *                 nome_completo:
+ *                   type: string
+ *                 email:
+ *                   type: string
+ *                 perfil:
+ *                   type: integer
+ *                 status:
+ *                   type: boolean
+ *       401:
+ *         description: Token ausente ou inválido
+ *       404:
+ *         description: Usuário não encontrado
+ */
+router.get('/auth/me', authenticateRequest, getCurrentUser);
+
+export default router;

--- a/backend/src/swagger.ts
+++ b/backend/src/swagger.ts
@@ -7,6 +7,15 @@ const swaggerOptions = {
       title: 'Jus Connect API',
       version: '1.0.0',
     },
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+      },
+    },
   },
   apis: [
     path.join(__dirname, 'routes/*.{ts,js}'),

--- a/backend/src/types/express/index.d.ts
+++ b/backend/src/types/express/index.d.ts
@@ -1,0 +1,12 @@
+import 'express-serve-static-core';
+import { TokenPayload } from '../../utils/tokenUtils';
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    auth?: {
+      userId: number;
+      email?: string;
+      payload: TokenPayload;
+    };
+  }
+}

--- a/backend/src/utils/passwordUtils.ts
+++ b/backend/src/utils/passwordUtils.ts
@@ -1,0 +1,46 @@
+import crypto from 'crypto';
+
+const safeCompare = (a: string, b: string): boolean => {
+  const bufferA = Buffer.from(a, 'utf8');
+  const bufferB = Buffer.from(b, 'utf8');
+
+  if (bufferA.length !== bufferB.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(bufferA, bufferB);
+};
+
+const SHA256_PREFIX = 'sha256:';
+
+const verifySha256Password = (password: string, storedValue: string): boolean => {
+  const parts = storedValue.split(':');
+
+  if (parts.length !== 3) {
+    return false;
+  }
+
+  const [, salt, digest] = parts;
+
+  const computedDigest = crypto
+    .createHash('sha256')
+    .update(`${salt}:${password}`)
+    .digest('hex');
+
+  return safeCompare(digest, computedDigest);
+};
+
+export const verifyPassword = async (
+  providedPassword: string,
+  storedValue: unknown
+): Promise<boolean> => {
+  if (typeof storedValue !== 'string' || storedValue.length === 0) {
+    return false;
+  }
+
+  if (storedValue.startsWith(SHA256_PREFIX)) {
+    return verifySha256Password(providedPassword, storedValue);
+  }
+
+  return safeCompare(providedPassword, storedValue);
+};

--- a/backend/src/utils/tokenUtils.ts
+++ b/backend/src/utils/tokenUtils.ts
@@ -1,0 +1,138 @@
+import crypto from 'crypto';
+
+export interface TokenPayload extends Record<string, unknown> {
+  sub: string | number;
+  iat: number;
+  exp: number;
+}
+
+const base64UrlEncode = (input: string): string =>
+  Buffer.from(input, 'utf8').toString('base64url');
+
+const base64UrlDecode = (input: string): string =>
+  Buffer.from(input, 'base64url').toString('utf8');
+
+const createSignature = (
+  header: string,
+  payload: string,
+  secret: string
+): string =>
+  crypto
+    .createHmac('sha256', secret)
+    .update(`${header}.${payload}`)
+    .digest('base64url');
+
+const timingSafeStringCompare = (a: string, b: string): boolean => {
+  const bufferA = Buffer.from(a, 'utf8');
+  const bufferB = Buffer.from(b, 'utf8');
+
+  if (bufferA.length !== bufferB.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(bufferA, bufferB);
+};
+
+export const signToken = (
+  payload: Record<string, unknown>,
+  secret: string,
+  expiresInSeconds: number
+): string => {
+  if (!Number.isFinite(expiresInSeconds) || expiresInSeconds <= 0) {
+    throw new Error('Token expiration must be a positive number of seconds.');
+  }
+
+  const header = {
+    alg: 'HS256',
+    typ: 'JWT',
+  } satisfies Record<string, string>;
+
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const tokenPayload: TokenPayload = {
+    ...payload,
+    iat: issuedAt,
+    exp: issuedAt + expiresInSeconds,
+  } as TokenPayload;
+
+  const encodedHeader = base64UrlEncode(JSON.stringify(header));
+  const encodedPayload = base64UrlEncode(JSON.stringify(tokenPayload));
+  const signature = createSignature(encodedHeader, encodedPayload, secret);
+
+  return `${encodedHeader}.${encodedPayload}.${signature}`;
+};
+
+export const verifyToken = (token: string, secret: string): TokenPayload => {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    throw new Error('Invalid token format');
+  }
+
+  const [encodedHeader, encodedPayload, providedSignature] = parts;
+
+  const expectedSignature = createSignature(encodedHeader, encodedPayload, secret);
+
+  if (!timingSafeStringCompare(providedSignature, expectedSignature)) {
+    throw new Error('Invalid token signature');
+  }
+
+  const header = JSON.parse(base64UrlDecode(encodedHeader)) as Record<string, unknown>;
+
+  if (header.alg !== 'HS256') {
+    throw new Error('Unsupported token algorithm');
+  }
+
+  const payload = JSON.parse(base64UrlDecode(encodedPayload)) as TokenPayload;
+
+  if (typeof payload.exp !== 'number') {
+    throw new Error('Token payload missing expiration');
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (payload.exp < now) {
+    throw new Error('Token expired');
+  }
+
+  return payload;
+};
+
+const durationRegex = /^(\d+)([smhd])$/i;
+
+const durationMultipliers: Record<string, number> = {
+  s: 1,
+  m: 60,
+  h: 60 * 60,
+  d: 60 * 60 * 24,
+};
+
+export const parseExpiration = (value: string | undefined, fallbackSeconds = 60 * 60): number => {
+  if (!value) {
+    return fallbackSeconds;
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed === '') {
+    return fallbackSeconds;
+  }
+
+  if (/^\d+$/.test(trimmed)) {
+    return Number.parseInt(trimmed, 10);
+  }
+
+  const match = trimmed.match(durationRegex);
+
+  if (!match) {
+    return fallbackSeconds;
+  }
+
+  const amount = Number.parseInt(match[1], 10);
+  const unit = match[2].toLowerCase();
+
+  const multiplier = durationMultipliers[unit];
+
+  if (!Number.isFinite(amount) || amount <= 0 || !multiplier) {
+    return fallbackSeconds;
+  }
+
+  return amount * multiplier;
+};


### PR DESCRIPTION
## Summary
- implement a reusable HS256 token signer/verifier and password helper for authentication
- add login and current-user endpoints protected by a bearer-token middleware and document them in Swagger
- expose token configuration defaults and document the new authentication workflow in the backend README

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb541f7b9483268b640a9658e927c7