### PR TITLE
Persist chat conversation metadata and update details UI

### DIFF
--- a/backend/sql/chat.sql
+++ b/backend/sql/chat.sql
@@ -7,6 +7,15 @@ CREATE TABLE IF NOT EXISTS chat_conversations (
   short_status TEXT,
   description TEXT,
   pinned BOOLEAN NOT NULL DEFAULT FALSE,
+  phone_number TEXT,
+  responsible_id INTEGER,
+  responsible_snapshot JSONB,
+  tags JSONB,
+  client_name TEXT,
+  is_linked_to_client BOOLEAN NOT NULL DEFAULT FALSE,
+  custom_attributes JSONB,
+  is_private BOOLEAN NOT NULL DEFAULT FALSE,
+  internal_notes JSONB,
   unread_count INTEGER NOT NULL DEFAULT 0,
   last_message_id TEXT,
   last_message_preview TEXT,
@@ -51,3 +60,15 @@ CREATE TRIGGER trg_chat_conversations_updated_at
   BEFORE UPDATE ON chat_conversations
   FOR EACH ROW
   EXECUTE FUNCTION set_chat_conversations_updated_at();
+
+-- Ensure legacy databases receive the new metadata columns used by the CRM
+ALTER TABLE chat_conversations
+  ADD COLUMN IF NOT EXISTS phone_number TEXT,
+  ADD COLUMN IF NOT EXISTS responsible_id INTEGER,
+  ADD COLUMN IF NOT EXISTS responsible_snapshot JSONB,
+  ADD COLUMN IF NOT EXISTS tags JSONB,
+  ADD COLUMN IF NOT EXISTS client_name TEXT,
+  ADD COLUMN IF NOT EXISTS is_linked_to_client BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS custom_attributes JSONB,
+  ADD COLUMN IF NOT EXISTS is_private BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS internal_notes JSONB;

--- a/backend/src/routes/chatRoutes.ts
+++ b/backend/src/routes/chatRoutes.ts
@@ -5,6 +5,7 @@ import {
   listConversationsHandler,
   markConversationReadHandler,
   sendConversationMessageHandler,
+  updateConversationHandler,
 } from '../controllers/chatController';
 
 const router = Router();
@@ -235,6 +236,70 @@ router.get('/conversations', listConversationsHandler);
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 router.post('/conversations', createConversationHandler);
+
+/**
+ * @swagger
+ * /api/conversations/{conversationId}:
+ *   patch:
+ *     summary: Atualiza metadados de uma conversa existente
+ *     tags: [Conversas]
+ *     parameters:
+ *       - in: path
+ *         name: conversationId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identificador da conversa que será atualizada
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               responsibleId:
+ *                 type: integer
+ *                 nullable: true
+ *               tags:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *               clientName:
+ *                 type: string
+ *                 nullable: true
+ *               isLinkedToClient:
+ *                 type: boolean
+ *               customAttributes:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *               internalNotes:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *               isPrivate:
+ *                 type: boolean
+ *     responses:
+ *       200:
+ *         description: Conversa atualizada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ConversationSummary'
+ *       400:
+ *         description: Dados inválidos enviados para atualização da conversa
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Conversa não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+router.patch('/conversations/:conversationId', updateConversationHandler);
 
 /**
  * @swagger

--- a/frontend/src/features/chat/components/ChatWindow.module.css
+++ b/frontend/src/features/chat/components/ChatWindow.module.css
@@ -363,6 +363,38 @@
   gap: 0.65rem;
 }
 
+.tagsSelector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.tagsSelectorText {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: hsl(var(--muted-foreground));
+}
+
+.tagsSelect {
+  width: 100%;
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: hsl(var(--background));
+  color: inherit;
+  font-size: 0.9rem;
+}
+
+.tagsSelect:focus-visible {
+  outline: 2px solid hsl(var(--primary));
+  outline-offset: 2px;
+}
+
+.tagsLoading {
+  font-size: 0.75rem;
+  color: hsl(var(--muted-foreground));
+}
+
 .tagsList {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/features/chat/services/chatApi.ts
+++ b/frontend/src/features/chat/services/chatApi.ts
@@ -78,3 +78,73 @@ export const updateConversation = async (
   });
   return parseJson<ConversationSummary>(response);
 };
+
+interface ApiUser {
+  id: number | string;
+  nome_completo?: string | null;
+  perfil?: string | number | null;
+}
+
+export interface ChatResponsibleOption {
+  id: string;
+  name: string;
+  role?: string;
+}
+
+export const fetchChatResponsibles = async (): Promise<ChatResponsibleOption[]> => {
+  const response = await fetch(`/api/usuarios`);
+  const data = await parseJson<ApiUser[]>(response);
+  const options: ChatResponsibleOption[] = [];
+  const seen = new Set<string>();
+
+  for (const user of data) {
+    if (!user || user.id === undefined || user.id === null) {
+      continue;
+    }
+    const id = String(user.id);
+    if (!id || seen.has(id)) {
+      continue;
+    }
+    const name = typeof user.nome_completo === 'string' ? user.nome_completo.trim() : '';
+    if (!name) {
+      continue;
+    }
+
+    const roleValue = user.perfil;
+    const role =
+      typeof roleValue === 'string' && roleValue.trim()
+        ? roleValue.trim()
+        : typeof roleValue === 'number' && Number.isFinite(roleValue)
+          ? String(roleValue)
+          : undefined;
+
+    seen.add(id);
+    options.push({ id, name, role });
+  }
+
+  return options.sort((a, b) => a.name.localeCompare(b.name, 'pt-BR'));
+};
+
+interface ApiEtiqueta {
+  id: number | string;
+  nome?: string | null;
+}
+
+export const fetchChatTags = async (): Promise<string[]> => {
+  const response = await fetch(`/api/etiquetas`);
+  const data = await parseJson<ApiEtiqueta[]>(response);
+  const tags = new Set<string>();
+
+  for (const item of data) {
+    if (!item) {
+      continue;
+    }
+    const name = typeof item.nome === 'string' ? item.nome.trim() : '';
+    if (!name) {
+      continue;
+    }
+    tags.add(name);
+  }
+
+  return Array.from(tags).sort((a, b) => a.localeCompare(b, 'pt-BR'));
+};


### PR DESCRIPTION
## Summary
- extend chat persistence to store responsible, tags, client linkage, custom attributes, internal notes and privacy flags
- expose a PATCH endpoint for updating conversations and cover it with service tests
- update the chat details panel to fetch system users, use a multi-select tag control and restrict closing to the close button

## Testing
- npm test (backend)
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68cb52e524848326ab47ef48592609d2