### PR TITLE
Fix API base URL fallback for dev environment

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
 const rawEnvApiUrl = (import.meta.env.VITE_API_URL as string | undefined)?.trim();
+const isDevEnvironment = Boolean(import.meta.env.DEV);
 
 function normalizeBaseUrl(url: string): string {
   return url.replace(/\/+$/, '');
@@ -14,6 +15,13 @@ function stripApiSuffix(url: string): string {
 function resolveFallbackBaseUrl(): string {
   if (rawEnvApiUrl && rawEnvApiUrl.length > 0) {
     return stripApiSuffix(rawEnvApiUrl);
+  }
+
+  if (isDevEnvironment) {
+    // Durante o desenvolvimento o frontend roda em uma porta distinta do backend
+    // (por padrão 5173), portanto precisamos garantir que as requisições sejam
+    // direcionadas ao servidor de API local.
+    return 'http://localhost:3001';
   }
 
   if (typeof window !== 'undefined' && window.location?.origin) {


### PR DESCRIPTION
## Summary
- ensure the API helper falls back to the backend URL during Vite development when no environment override is provided
- document the reasoning behind the development fallback to aid future maintenance

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb5bb1d6f883269d9e998c5cf2d4e7