### PR TITLE
Fix Express Request auth typing

### DIFF
--- a/backend/src/types/express/index.d.ts
+++ b/backend/src/types/express/index.d.ts
@@ -1,12 +1,19 @@
-import 'express-serve-static-core';
-import { TokenPayload } from '../../utils/tokenUtils';
+import type { TokenPayload } from '../../utils/tokenUtils';
 
-declare module 'express-serve-static-core' {
-  interface Request {
-    auth?: {
-      userId: number;
-      email?: string;
-      payload: TokenPayload;
-    };
+declare global {
+  namespace Express {
+    interface Request {
+      auth?: {
+        userId: number;
+        email?: string;
+        payload: TokenPayload;
+      };
+    }
   }
 }
+
+declare module 'express-serve-static-core' {
+  interface Request extends Express.Request {}
+}
+
+export {};


### PR DESCRIPTION
## Summary
- ensure the Express.Request type includes the auth context used by the middleware
- sync the express-serve-static-core Request interface with the augmented Express namespace

## Testing
- npm --prefix backend run build

------
https://chatgpt.com/codex/tasks/task_e_68cb5cef9450832697caa320583726f5