### PR TITLE
Fetch client processes in VisualizarCliente

### DIFF
--- a/frontend/src/types/client.ts
+++ b/frontend/src/types/client.ts
@@ -15,6 +15,12 @@ export interface Process {
   valorCausa?: string;
   descricaoFatos?: string;
   pedidos?: string;
+  distributionDate?: string;
+  subject?: string;
+  responsibleLawyer?: string;
+  lastMovement?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export interface Client {


### PR DESCRIPTION
## Summary
- fetch and normalize the client's processes from the backend when loading the visualizar cliente page, merging them into the page state so the process tab is populated
- extend the client process typings and table mapping to surface distribution date, subject, responsible lawyer, and last movement information with localized formatting

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb60ded4808326b277abb7bbc67d0e