### PR TITLE
Add distributed process toggle to opportunity forms

### DIFF
--- a/frontend/src/pages/EditarOportunidade.tsx
+++ b/frontend/src/pages/EditarOportunidade.tsx
@@ -23,6 +23,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   Accordion,
   AccordionContent,
@@ -36,6 +37,7 @@ const formSchema = z.object({
   tipo_processo: z.string().min(1, "Tipo de Processo é obrigatório"),
   area_atuacao: z.string().optional(),
   responsavel_interno: z.string().optional(),
+  processo_distribuido: z.string().optional(),
   numero_processo_cnj: z.string().optional(),
   numero_protocolo: z.string().optional(),
   vara_ou_orgao: z.string().optional(),
@@ -108,6 +110,7 @@ export default function EditarOportunidade() {
       tipo_processo: "",
       area_atuacao: "",
       responsavel_interno: "",
+      processo_distribuido: "",
       numero_processo_cnj: "",
       numero_protocolo: "",
       vara_ou_orgao: "",
@@ -239,10 +242,17 @@ export default function EditarOportunidade() {
         const res = await fetch(`${apiUrl}/api/oportunidades/${id}`);
         if (!res.ok) throw new Error();
         const data = await res.json();
+        const hasProcessDistribution = Boolean(
+          data.numero_processo_cnj ||
+            data.numero_protocolo ||
+            data.vara_ou_orgao ||
+            data.comarca
+        );
         form.reset({
           tipo_processo: data.tipo_processo_id ? String(data.tipo_processo_id) : "",
           area_atuacao: data.area_atuacao_id ? String(data.area_atuacao_id) : "",
           responsavel_interno: data.responsavel_id ? String(data.responsavel_id) : "",
+          processo_distribuido: hasProcessDistribution ? "sim" : "nao",
           numero_processo_cnj: data.numero_processo_cnj || "",
           numero_protocolo: data.numero_protocolo || "",
           vara_ou_orgao: data.vara_ou_orgao || "",
@@ -334,6 +344,7 @@ export default function EditarOportunidade() {
 
   const faseValue = form.watch("fase");
   const formaPagamento = form.watch("forma_pagamento");
+  const processoDistribuido = form.watch("processo_distribuido");
   useEffect(() => {
     if (!faseValue) return;
     const loadEtapas = async () => {
@@ -351,6 +362,23 @@ export default function EditarOportunidade() {
     };
     loadEtapas();
   }, [faseValue, apiUrl]);
+
+  useEffect(() => {
+    if (processoDistribuido === "sim") return;
+
+    const fieldsToClear: Array<
+      | "numero_processo_cnj"
+      | "numero_protocolo"
+      | "vara_ou_orgao"
+      | "comarca"
+    > = ["numero_processo_cnj", "numero_protocolo", "vara_ou_orgao", "comarca"];
+
+    fieldsToClear.forEach((fieldName) => {
+      if (form.getValues(fieldName)) {
+        form.setValue(fieldName, "");
+      }
+    });
+  }, [processoDistribuido, form]);
 
   const parseCurrency = (value: string) => {
     const digits = value.replace(/\D/g, "");
@@ -375,16 +403,22 @@ export default function EditarOportunidade() {
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     try {
+      const isProcessoDistribuido = values.processo_distribuido === "sim";
+
       const payload = {
         tipo_processo_id: Number(values.tipo_processo),
         area_atuacao_id: values.area_atuacao ? Number(values.area_atuacao) : null,
         responsavel_id: values.responsavel_interno
           ? Number(values.responsavel_interno)
           : null,
-        numero_processo_cnj: values.numero_processo_cnj || null,
-        numero_protocolo: values.numero_protocolo || null,
-        vara_ou_orgao: values.vara_ou_orgao || null,
-        comarca: values.comarca || null,
+        numero_processo_cnj: isProcessoDistribuido
+          ? values.numero_processo_cnj || null
+          : null,
+        numero_protocolo: isProcessoDistribuido
+          ? values.numero_protocolo || null
+          : null,
+        vara_ou_orgao: isProcessoDistribuido ? values.vara_ou_orgao || null : null,
+        comarca: isProcessoDistribuido ? values.comarca || null : null,
         fase_id: values.fase ? Number(values.fase) : null,
         etapa_id: values.etapa ? Number(values.etapa) : null,
         prazo_proximo: values.prazo_proximo || null,
@@ -549,59 +583,113 @@ export default function EditarOportunidade() {
 
                       <FormField
                         control={form.control}
-                        name="numero_processo_cnj"
+                        name="processo_distribuido"
                         render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Número do Processo (CNJ)</FormLabel>
+                          <FormItem className="space-y-3">
+                            <FormLabel>Processo já foi distribuído?</FormLabel>
                             <FormControl>
-                              <Input placeholder="0000000-00.0000.0.00.0000" {...field} />
+                              <RadioGroup
+                                className="flex flex-col sm:flex-row gap-4"
+                                onValueChange={field.onChange}
+                                value={field.value || ""}
+                              >
+                                <FormItem className="flex items-center space-x-2 space-y-0">
+                                  <FormControl>
+                                    <RadioGroupItem
+                                      value="sim"
+                                      id="processo-distribuido-sim"
+                                    />
+                                  </FormControl>
+                                  <FormLabel
+                                    className="font-normal"
+                                    htmlFor="processo-distribuido-sim"
+                                  >
+                                    Sim
+                                  </FormLabel>
+                                </FormItem>
+                                <FormItem className="flex items-center space-x-2 space-y-0">
+                                  <FormControl>
+                                    <RadioGroupItem
+                                      value="nao"
+                                      id="processo-distribuido-nao"
+                                    />
+                                  </FormControl>
+                                  <FormLabel
+                                    className="font-normal"
+                                    htmlFor="processo-distribuido-nao"
+                                  >
+                                    Não
+                                  </FormLabel>
+                                </FormItem>
+                              </RadioGroup>
                             </FormControl>
                             <FormMessage />
                           </FormItem>
                         )}
                       />
 
-                      <FormField
-                        control={form.control}
-                        name="numero_protocolo"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Número do Protocolo/Requerimento</FormLabel>
-                            <FormControl>
-                              <Input {...field} />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
+                      {processoDistribuido === "sim" && (
+                        <>
+                          <FormField
+                            control={form.control}
+                            name="numero_processo_cnj"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel>Número do Processo (CNJ)</FormLabel>
+                                <FormControl>
+                                  <Input
+                                    placeholder="0000000-00.0000.0.00.0000"
+                                    {...field}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
 
-                      <FormField
-                        control={form.control}
-                        name="vara_ou_orgao"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Vara/Órgão</FormLabel>
-                            <FormControl>
-                              <Input {...field} />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
+                          <FormField
+                            control={form.control}
+                            name="numero_protocolo"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel>Número do Protocolo/Requerimento</FormLabel>
+                                <FormControl>
+                                  <Input {...field} />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
 
-                      <FormField
-                        control={form.control}
-                        name="comarca"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Comarca</FormLabel>
-                            <FormControl>
-                              <Input {...field} />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
+                          <FormField
+                            control={form.control}
+                            name="vara_ou_orgao"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel>Vara/Órgão</FormLabel>
+                                <FormControl>
+                                  <Input {...field} />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+
+                          <FormField
+                            control={form.control}
+                            name="comarca"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel>Comarca</FormLabel>
+                                <FormControl>
+                                  <Input {...field} />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+                        </>
+                      )}
 
                 </div>
                   </AccordionContent>

--- a/frontend/src/pages/NovaOportunidade.tsx
+++ b/frontend/src/pages/NovaOportunidade.tsx
@@ -23,6 +23,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   Accordion,
   AccordionContent,
@@ -36,6 +37,7 @@ const formSchema = z.object({
   tipo_processo: z.string().min(1, "Tipo de Processo é obrigatório"),
   area_atuacao: z.string().optional(),
   responsavel_interno: z.string().optional(),
+  processo_distribuido: z.string().optional(),
   numero_processo_cnj: z.string().optional(),
   numero_protocolo: z.string().optional(),
   vara_ou_orgao: z.string().optional(),
@@ -106,6 +108,7 @@ export default function NovaOportunidade() {
       tipo_processo: "",
       area_atuacao: "",
       responsavel_interno: "",
+      processo_distribuido: "",
       numero_processo_cnj: "",
       numero_protocolo: "",
       vara_ou_orgao: "",
@@ -231,6 +234,7 @@ export default function NovaOportunidade() {
 
   const faseValue = form.watch("fase");
   const formaPagamento = form.watch("forma_pagamento");
+  const processoDistribuido = form.watch("processo_distribuido");
   useEffect(() => {
     if (!faseValue) return;
     const loadEtapas = async () => {
@@ -270,18 +274,41 @@ export default function NovaOportunidade() {
     }
   }, [valorCausaWatch, valorHonorariosWatch, form]);
 
+  useEffect(() => {
+    if (processoDistribuido === "sim") return;
+
+    const fieldsToClear: Array<
+      | "numero_processo_cnj"
+      | "numero_protocolo"
+      | "vara_ou_orgao"
+      | "comarca"
+    > = ["numero_processo_cnj", "numero_protocolo", "vara_ou_orgao", "comarca"];
+
+    fieldsToClear.forEach((fieldName) => {
+      if (form.getValues(fieldName)) {
+        form.setValue(fieldName, "");
+      }
+    });
+  }, [processoDistribuido, form]);
+
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     try {
+      const isProcessoDistribuido = values.processo_distribuido === "sim";
+
       const payload = {
         tipo_processo_id: Number(values.tipo_processo),
         area_atuacao_id: values.area_atuacao ? Number(values.area_atuacao) : null,
         responsavel_id: values.responsavel_interno
           ? Number(values.responsavel_interno)
           : null,
-        numero_processo_cnj: values.numero_processo_cnj || null,
-        numero_protocolo: values.numero_protocolo || null,
-        vara_ou_orgao: values.vara_ou_orgao || null,
-        comarca: values.comarca || null,
+        numero_processo_cnj: isProcessoDistribuido
+          ? values.numero_processo_cnj || null
+          : null,
+        numero_protocolo: isProcessoDistribuido
+          ? values.numero_protocolo || null
+          : null,
+        vara_ou_orgao: isProcessoDistribuido ? values.vara_ou_orgao || null : null,
+        comarca: isProcessoDistribuido ? values.comarca || null : null,
         fase_id: values.fase ? Number(values.fase) : null,
         etapa_id: values.etapa ? Number(values.etapa) : null,
         prazo_proximo: values.prazo_proximo || null,
@@ -428,73 +455,127 @@ export default function NovaOportunidade() {
                                 </SelectTrigger>
                               </FormControl>
                               <SelectContent>
-                                {users.map((u) => (
-                                  <SelectItem key={u.id} value={u.id}>
-                                    {u.name}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
+                {users.map((u) => (
+                  <SelectItem key={u.id} value={u.id}>
+                    {u.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
 
                       <FormField
                         control={form.control}
-                        name="numero_processo_cnj"
+                        name="processo_distribuido"
                         render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Número do Processo (CNJ)</FormLabel>
+                          <FormItem className="space-y-3">
+                            <FormLabel>Processo já foi distribuído?</FormLabel>
                             <FormControl>
-                              <Input placeholder="0000000-00.0000.0.00.0000" {...field} />
+                              <RadioGroup
+                                className="flex flex-col sm:flex-row gap-4"
+                                onValueChange={field.onChange}
+                                value={field.value || ""}
+                              >
+                                <FormItem className="flex items-center space-x-2 space-y-0">
+                                  <FormControl>
+                                    <RadioGroupItem
+                                      value="sim"
+                                      id="processo-distribuido-sim"
+                                    />
+                                  </FormControl>
+                                  <FormLabel
+                                    className="font-normal"
+                                    htmlFor="processo-distribuido-sim"
+                                  >
+                                    Sim
+                                  </FormLabel>
+                                </FormItem>
+                                <FormItem className="flex items-center space-x-2 space-y-0">
+                                  <FormControl>
+                                    <RadioGroupItem
+                                      value="nao"
+                                      id="processo-distribuido-nao"
+                                    />
+                                  </FormControl>
+                                  <FormLabel
+                                    className="font-normal"
+                                    htmlFor="processo-distribuido-nao"
+                                  >
+                                    Não
+                                  </FormLabel>
+                                </FormItem>
+                              </RadioGroup>
                             </FormControl>
                             <FormMessage />
                           </FormItem>
                         )}
                       />
 
-                      <FormField
-                        control={form.control}
-                        name="numero_protocolo"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Número do Protocolo/Requerimento</FormLabel>
-                            <FormControl>
-                              <Input {...field} />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
+                      {processoDistribuido === "sim" && (
+                        <>
+                          <FormField
+                            control={form.control}
+                            name="numero_processo_cnj"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel>Número do Processo (CNJ)</FormLabel>
+                                <FormControl>
+                                  <Input
+                                    placeholder="0000000-00.0000.0.00.0000"
+                                    {...field}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
 
-                      <FormField
-                        control={form.control}
-                        name="vara_ou_orgao"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Vara/Órgão</FormLabel>
-                            <FormControl>
-                              <Input {...field} />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
+                          <FormField
+                            control={form.control}
+                            name="numero_protocolo"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel>Número do Protocolo/Requerimento</FormLabel>
+                                <FormControl>
+                                  <Input {...field} />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
 
-                      <FormField
-                        control={form.control}
-                        name="comarca"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Comarca</FormLabel>
-                            <FormControl>
-                              <Input {...field} />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
+                          <FormField
+                            control={form.control}
+                            name="vara_ou_orgao"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel>Vara/Órgão</FormLabel>
+                                <FormControl>
+                                  <Input {...field} />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+
+                          <FormField
+                            control={form.control}
+                            name="comarca"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel>Comarca</FormLabel>
+                                <FormControl>
+                                  <Input {...field} />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+                        </>
+                      )}
 
                 </div>
                   </AccordionContent>


### PR DESCRIPTION
## Summary
- ask whether the process has already been distributed after selecting the responsável in the create and edit opportunity forms
- show CNJ, protocolo, vara/órgão and comarca inputs only when the answer is yes
- clear hidden process fields and ensure the submission payload excludes distributed data when the answer is no

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb61571e5483268a798e59655abc67