### PR TITLE
Fix opportunity client selection and align section headings

### DIFF
--- a/frontend/src/pages/EditarOportunidade.tsx
+++ b/frontend/src/pages/EditarOportunidade.tsx
@@ -503,7 +503,7 @@ export default function EditarOportunidade() {
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
               <Accordion type="single" collapsible className="w-full">
                 <AccordionItem value="dados-processo">
-                  <AccordionTrigger>Dados do Processo</AccordionTrigger>
+                  <AccordionTrigger>DADOS DO PROCESSO</AccordionTrigger>
                   <AccordionContent>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                       <FormField
@@ -696,7 +696,7 @@ export default function EditarOportunidade() {
                 </AccordionItem>
 
                 <AccordionItem value="fluxo-processo">
-                  <AccordionTrigger>Fluxo do Processo</AccordionTrigger>
+                  <AccordionTrigger>DADOS DA PROPOSTA</AccordionTrigger>
                   <AccordionContent>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                       <FormField
@@ -792,7 +792,7 @@ export default function EditarOportunidade() {
                 </AccordionItem>
 
                 <AccordionItem value="dados-solicitante">
-                  <AccordionTrigger>Dados do Solicitante</AccordionTrigger>
+                  <AccordionTrigger>CLIENTE SOLICITANTE</AccordionTrigger>
                   <AccordionContent>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                       <FormField
@@ -882,7 +882,7 @@ export default function EditarOportunidade() {
                 </AccordionItem>
 
                 <AccordionItem value="dados-promovido">
-                  <AccordionTrigger>Dados dos Envolvidos</AccordionTrigger>
+                  <AccordionTrigger>ENVOLVIDOS COM O PROCESSO</AccordionTrigger>
                   <AccordionContent>
                     {envolvidosFields.map((item, index) => (
                       <div
@@ -1000,7 +1000,7 @@ export default function EditarOportunidade() {
                
 
                 <AccordionItem value="detalhes">
-                  <AccordionTrigger>Detalhes</AccordionTrigger>
+                  <AccordionTrigger>DETALHES</AccordionTrigger>
                   <AccordionContent>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                       <FormField
@@ -1038,8 +1038,8 @@ export default function EditarOportunidade() {
                   </AccordionContent>
                 </AccordionItem>
 
-                 <AccordionItem value="honorarios">
-                  <AccordionTrigger>Honorários</AccordionTrigger>
+                <AccordionItem value="honorarios">
+                  <AccordionTrigger>HONORÁRIOS</AccordionTrigger>
                   <AccordionContent>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                       <FormField
@@ -1180,7 +1180,7 @@ export default function EditarOportunidade() {
                 </AccordionItem>
 
                 <AccordionItem value="metadados">
-                  <AccordionTrigger>Metadados</AccordionTrigger>
+                  <AccordionTrigger>SISTEMA</AccordionTrigger>
                   <AccordionContent>
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                       <FormField

--- a/frontend/src/pages/NovaOportunidade.tsx
+++ b/frontend/src/pages/NovaOportunidade.tsx
@@ -49,6 +49,7 @@ const formSchema = z.object({
   etapa: z.string().optional(),
   prazo_proximo: z.string().optional(),
   status: z.string().optional(),
+  solicitante_id: z.string().optional(),
   solicitante_nome: z.string().optional(),
   solicitante_cpf_cnpj: z.string().optional(),
   solicitante_email: z.string().optional(),
@@ -120,6 +121,7 @@ export default function NovaOportunidade() {
       etapa: "",
       prazo_proximo: "",
       status: "",
+      solicitante_id: "",
       solicitante_nome: "",
       solicitante_cpf_cnpj: "",
       solicitante_email: "",
@@ -294,6 +296,11 @@ export default function NovaOportunidade() {
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     try {
       const isProcessoDistribuido = values.processo_distribuido === "sim";
+      const solicitanteIdRaw = values.solicitante_id?.trim();
+      const solicitanteId =
+        solicitanteIdRaw && !Number.isNaN(Number(solicitanteIdRaw))
+          ? Number(solicitanteIdRaw)
+          : null;
 
       const payload = {
         tipo_processo_id: Number(values.tipo_processo),
@@ -313,7 +320,7 @@ export default function NovaOportunidade() {
         etapa_id: values.etapa ? Number(values.etapa) : null,
         prazo_proximo: values.prazo_proximo || null,
         status_id: values.status ? Number(values.status) : null,
-        solicitante_id: null,
+        solicitante_id: solicitanteId,
         valor_causa: parseCurrency(values.valor_causa || ""),
         valor_honorarios: parseCurrency(values.valor_honorarios || ""),
         percentual_honorarios: parsePercent(values.percentual_honorarios || ""),
@@ -347,12 +354,36 @@ export default function NovaOportunidade() {
   };
 
   const handleSelectClient = (name: string) => {
-    const client = clients.find((c) => c.name === name);
+    const normalizedName = name.trim();
+    const client = clients.find((c) => c.name === normalizedName);
     if (client) {
+      form.setValue("solicitante_id", client.id, {
+        shouldDirty: true,
+        shouldTouch: true,
+      });
       form.setValue("solicitante_cpf_cnpj", client.cpf_cnpj || "");
       form.setValue("solicitante_email", client.email || "");
       form.setValue("solicitante_telefone", client.telefone || "");
       form.setValue("cliente_tipo", client.tipo || "");
+      form.setValue("solicitante_nome", client.name, {
+        shouldDirty: true,
+        shouldTouch: true,
+      });
+    } else {
+      form.setValue("solicitante_id", "", {
+        shouldDirty: true,
+        shouldTouch: true,
+      });
+      if (normalizedName.length === 0) {
+        form.setValue("solicitante_nome", "", {
+          shouldDirty: true,
+          shouldTouch: true,
+        });
+      }
+      form.setValue("solicitante_cpf_cnpj", "");
+      form.setValue("solicitante_email", "");
+      form.setValue("solicitante_telefone", "");
+      form.setValue("cliente_tipo", "");
     }
   };
 

--- a/frontend/src/pages/VisualizarOportunidade.tsx
+++ b/frontend/src/pages/VisualizarOportunidade.tsx
@@ -573,33 +573,33 @@ export default function VisualizarOportunidade() {
   const sectionsDef: { key: string; label: string; fields: string[] }[] = [
     {
       key: "processo",
-      label: "Dados do Processo",
+      label: "DADOS DO PROCESSO",
       fields: ["numero_processo_cnj", "numero_protocolo", "tipo_processo_nome", "vara_ou_orgao", "comarca"],
     },
     {
       key: "fluxo",
-      label: "Fluxo do Processo",
+      label: "DADOS DA PROPOSTA",
       fields: ["fase", "etapa_nome", "prazo_proximo", "status"],
     },
     {
       key: "solicitante",
-      label: "Dados do Solicitante",
+      label: "CLIENTE SOLICITANTE",
       fields: ["solicitante_nome", "solicitante_cpf_cnpj", "solicitante_email", "solicitante_telefone", "cliente_tipo"],
     },
 
     {
       key: "detalhes",
-      label: "Detalhes",
+      label: "DETALHES",
       fields: ["detalhes"],
     },
     {
       key: "honorarios",
-      label: "Honorários",
-        fields: ["valor_causa", "valor_honorarios", "percentual_honorarios", "forma_pagamento", "qtde_parcelas", "contingenciamento"],
+      label: "HONORÁRIOS",
+      fields: ["valor_causa", "valor_honorarios", "percentual_honorarios", "forma_pagamento", "qtde_parcelas", "contingenciamento"],
     },
     {
       key: "metadados",
-      label: "Metadados",
+      label: "SISTEMA",
       fields: ["data_criacao", "ultima_atualizacao", "criado_por", "id", "title"],
     },
   ];
@@ -1059,7 +1059,7 @@ export default function VisualizarOportunidade() {
                     id="heading-envolvidos"
                     className={sectionTitleClass}
                   >
-                    Dados dos Envolvidos
+                    ENVOLVIDOS COM O PROCESSO
                   </h2>
                   <div className="space-y-4">
                     {participants.map((p, idx) => (


### PR DESCRIPTION
## Summary
- ensure nova oportunidade envia o solicitante selecionado e mantém os dados em sincronia
- alinhar os títulos das seções de edição e visualização com os da criação para consistência

## Testing
- npm run lint *(falha: já existiam erros em arquivos não relacionados)*

------
https://chatgpt.com/codex/tasks/task_e_68cb66ef6118832684a95b77f9c2cb6e