### PR TITLE
Fix conversations layout height handling

### DIFF
--- a/frontend/src/components/layout/CRMLayout.tsx
+++ b/frontend/src/components/layout/CRMLayout.tsx
@@ -6,13 +6,13 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 export function CRMLayout() {
   const location = useLocation();
   const isConversationsRoute = location.pathname.startsWith("/conversas");
-  const mainClassName = `flex-1 bg-background ${isConversationsRoute ? "overflow-hidden" : "overflow-auto"}`;
+  const mainClassName = `flex-1 bg-background flex flex-col min-h-0 ${isConversationsRoute ? "overflow-hidden" : "overflow-auto"}`;
 
   return (
     <SidebarProvider>
       <div className="min-h-screen bg-background flex w-full">
         <Sidebar />
-        <div className="flex-1 flex flex-col">
+        <div className="flex-1 flex min-h-0 flex-col">
           <Header />
           <main className={mainClassName}>
             <Outlet />

--- a/frontend/src/components/waha/WhatsAppLayout.tsx
+++ b/frontend/src/components/waha/WhatsAppLayout.tsx
@@ -357,7 +357,7 @@ export const WhatsAppLayout = ({
 
   return (
     <div
-      className="flex min-h-screen flex-col overflow-hidden"
+      className="flex flex-1 min-h-0 flex-col overflow-hidden"
       style={{
         background:
           "radial-gradient(circle at -20% -20%, rgba(59,130,246,0.16), transparent 55%)," +

--- a/frontend/src/pages/Conversas.tsx
+++ b/frontend/src/pages/Conversas.tsx
@@ -25,7 +25,7 @@ const Conversas = () => {
   );
 
   return (
-    <div className="h-full min-h-0 bg-background flex flex-col overflow-hidden">
+    <div className="h-full min-h-0 flex flex-1 flex-col overflow-hidden bg-background">
       <WhatsAppLayout
         conversationIdFromRoute={conversationId}
         onConversationRouteChange={handleRouteChange}


### PR DESCRIPTION
## Summary
- ensure CRM layout and conversations page flex containers preserve viewport height without stretching
- update WhatsApp layout wrapper to respect the available height and enable internal scrolling

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb76fa8cdc8326ba9bbde3c7998939