### PR TITLE
Adjust conversations layout height

### DIFF
--- a/frontend/src/components/layout/CRMLayout.tsx
+++ b/frontend/src/components/layout/CRMLayout.tsx
@@ -2,17 +2,29 @@ import { Outlet, useLocation } from "react-router-dom";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
 import { SidebarProvider } from "@/components/ui/sidebar";
+import { cn } from "@/lib/utils";
 
 export function CRMLayout() {
   const location = useLocation();
   const isConversationsRoute = location.pathname.startsWith("/conversas");
-  const mainClassName = `flex-1 bg-background ${isConversationsRoute ? "overflow-hidden" : "overflow-auto"}`;
+  const rootClassName = cn(
+    "flex w-full",
+    isConversationsRoute ? "h-dvh overflow-hidden" : "min-h-screen bg-background",
+  );
+  const containerClassName = cn(
+    "flex-1 flex min-h-0 flex-col",
+    isConversationsRoute && "h-full",
+  );
+  const mainClassName = cn(
+    "flex-1 flex flex-col min-h-0",
+    isConversationsRoute ? "h-full overflow-hidden" : "overflow-auto",
+  );
 
   return (
     <SidebarProvider>
-      <div className="min-h-screen bg-background flex w-full">
+      <div className={rootClassName}>
         <Sidebar />
-        <div className="flex-1 flex flex-col">
+        <div className={containerClassName}>
           <Header />
           <main className={mainClassName}>
             <Outlet />

--- a/frontend/src/components/waha/WhatsAppLayout.tsx
+++ b/frontend/src/components/waha/WhatsAppLayout.tsx
@@ -356,15 +356,7 @@ export const WhatsAppLayout = ({
   }, [activeConversationId, checkSessionStatus, loadChats, loadMessages]);
 
   return (
-    <div
-      className="flex min-h-screen flex-col overflow-hidden"
-      style={{
-        background:
-          "radial-gradient(circle at -20% -20%, rgba(59,130,246,0.16), transparent 55%)," +
-          "radial-gradient(circle at 110% -10%, rgba(14,165,233,0.18), transparent 50%)," +
-          "linear-gradient(180deg, rgba(241,245,249,0.92) 0%, rgba(226,232,240,0.75) 45%, rgba(226,232,240,0.55) 100%)",
-      }}
-    >
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <SessionStatus status={wahaState.sessionStatus} onRefresh={handleReload} />
 
       <div className="flex flex-1 min-h-0 flex-col overflow-hidden lg:flex-row">

--- a/frontend/src/pages/Conversas.tsx
+++ b/frontend/src/pages/Conversas.tsx
@@ -25,7 +25,7 @@ const Conversas = () => {
   );
 
   return (
-    <div className="h-full min-h-0 bg-background flex flex-col overflow-hidden">
+    <div className="h-full min-h-0 flex flex-1 flex-col overflow-hidden">
       <WhatsAppLayout
         conversationIdFromRoute={conversationId}
         onConversationRouteChange={handleRouteChange}


### PR DESCRIPTION
## Summary
- limit the CRM layout to the viewport height on the conversations route to prevent body scrolling
- remove background treatments from the conversations wrappers and WhatsApp layout
- ensure the WhatsApp layout stretches to fill the available height without introducing page scroll

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb76fa8cdc8326ba9bbde3c7998939