### PR TITLE
feat: registrar faturamento de oportunidade

### DIFF
--- a/backend/sql/oportunidade_faturamentos.sql
+++ b/backend/sql/oportunidade_faturamentos.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS public.oportunidade_faturamentos (
+    id SERIAL PRIMARY KEY,
+    oportunidade_id INTEGER NOT NULL REFERENCES public.oportunidades(id) ON DELETE CASCADE,
+    forma_pagamento TEXT NOT NULL,
+    condicao_pagamento TEXT,
+    valor NUMERIC(14, 2),
+    parcelas INTEGER,
+    observacoes TEXT,
+    data_faturamento TIMESTAMPTZ DEFAULT NOW(),
+    criado_em TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_oportunidade_faturamentos_oportunidade
+    ON public.oportunidade_faturamentos (oportunidade_id);

--- a/backend/src/routes/oportunidadeRoutes.ts
+++ b/backend/src/routes/oportunidadeRoutes.ts
@@ -9,6 +9,8 @@ import {
   updateOportunidadeStatus,
   updateOportunidadeEtapa,
   deleteOportunidade,
+  listOportunidadeFaturamentos,
+  createOportunidadeFaturamento,
 } from '../controllers/oportunidadeController';
 
 const router = Router();
@@ -186,6 +188,115 @@ router.get('/oportunidades/:id', getOportunidadeById);
  *                 $ref: '#/components/schemas/OportunidadeEnvolvido'
  */
 router.get('/oportunidades/:id/envolvidos', listEnvolvidosByOportunidade);
+
+/**
+ * @swagger
+ * /api/oportunidades/{id}/faturamentos:
+ *   get:
+ *     summary: Lista os faturamentos registrados para uma oportunidade
+ *     tags: [Oportunidades]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *     responses:
+ *       200:
+ *         description: Lista de faturamentos registrados
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                   oportunidade_id:
+ *                     type: integer
+ *                   forma_pagamento:
+ *                     type: string
+ *                   condicao_pagamento:
+ *                     type: string
+ *                   valor:
+ *                     type: number
+ *                   parcelas:
+ *                     type: integer
+ *                   observacoes:
+ *                     type: string
+ *                   data_faturamento:
+ *                     type: string
+ *                     format: date-time
+ *                   criado_em:
+ *                     type: string
+ *                     format: date-time
+ */
+router.get('/oportunidades/:id/faturamentos', listOportunidadeFaturamentos);
+
+/**
+ * @swagger
+ * /api/oportunidades/{id}/faturamentos:
+ *   post:
+ *     summary: Registra um faturamento para a oportunidade
+ *     tags: [Oportunidades]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               forma_pagamento:
+ *                 type: string
+ *               condicao_pagamento:
+ *                 type: string
+ *                 enum: ["À vista", "Parcelado"]
+ *               valor:
+ *                 type: number
+ *               parcelas:
+ *                 type: integer
+ *               observacoes:
+ *                 type: string
+ *               data_faturamento:
+ *                 type: string
+ *                 format: date
+ *     responses:
+ *       201:
+ *         description: Faturamento registrado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: integer
+ *                 oportunidade_id:
+ *                   type: integer
+ *                 forma_pagamento:
+ *                   type: string
+ *                 condicao_pagamento:
+ *                   type: string
+ *                 valor:
+ *                   type: number
+ *                 parcelas:
+ *                   type: integer
+ *                 observacoes:
+ *                   type: string
+ *                 data_faturamento:
+ *                   type: string
+ *                   format: date-time
+ *                 criado_em:
+ *                   type: string
+ *                   format: date-time
+ */
+router.post('/oportunidades/:id/faturamentos', createOportunidadeFaturamento);
 
 /**
  * @swagger


### PR DESCRIPTION
## Summary
- add schema and API handlers to persist faturamentos vinculados a oportunidades
- reorganize ações de cabeçalho/rodapé na tela de Visualizar Proposta, com dropdown para documentos/tarefas
- incluir fluxo de faturamento com modal, formulário validado e histórico exibido na página

## Testing
- `npm run build` (backend)
- `npm run lint` *(fails: existing lint errors in src/api/webhook.ts, src/services/waha.ts, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68cb7791495c8326875a1d95a425c5b2