### PR TITLE
Add financial insights to reports

### DIFF
--- a/frontend/src/data/mockData.ts
+++ b/frontend/src/data/mockData.ts
@@ -33,6 +33,15 @@ export const mockRevenueByPlan = [
   { name: "Enterprise", revenue: 2793, customers: 7 },
 ];
 
+export const mockMonthlyFinancials = [
+  { month: "Jan", receita: 18500, despesas: 11200 },
+  { month: "Feb", receita: 19600, despesas: 11800 },
+  { month: "Mar", receita: 20500, despesas: 12000 },
+  { month: "Apr", receita: 21300, despesas: 12500 },
+  { month: "May", receita: 22150, despesas: 12950 },
+  { month: "Jun", receita: 22800, despesas: 13200 },
+];
+
 export const mockAreaDistribution = [
   { name: "Cível", value: 40 },
   { name: "Trabalhista", value: 32 },

--- a/frontend/src/pages/Relatorios.tsx
+++ b/frontend/src/pages/Relatorios.tsx
@@ -5,8 +5,17 @@ import {
   mockCohortData,
   mockAreaDistribution,
   mockConversionFunnel,
+  mockRevenueByPlan,
+  mockMonthlyFinancials,
 } from "@/data/mockData";
-import { TrendingUp, Users, CheckCircle, Gavel } from "lucide-react";
+import {
+  TrendingUp,
+  Users,
+  CheckCircle,
+  Gavel,
+  Wallet,
+  CircleDollarSign,
+} from "lucide-react";
 import {
   LineChart,
   Line,
@@ -37,6 +46,15 @@ export default function Relatorios() {
     taxaConversao,
     crescimentoMensal,
   } = mockAnalytics;
+
+  const totalRevenue = mockRevenueByPlan.reduce((acc, plan) => acc + plan.revenue, 0);
+  const payingClients = mockRevenueByPlan.reduce((acc, plan) => acc + plan.customers, 0);
+  const averageTicket = payingClients > 0 ? totalRevenue / payingClients : 0;
+  const currentMonth = mockMonthlyFinancials.at(-1);
+  const previousMonth = mockMonthlyFinancials.at(-2);
+  const revenueGrowth = previousMonth && previousMonth.receita > 0 && currentMonth
+    ? ((currentMonth.receita - previousMonth.receita) / previousMonth.receita) * 100
+    : 0;
 
   return (
     <div className="space-y-6">
@@ -90,6 +108,59 @@ export default function Relatorios() {
           <CardContent>
             <div className="text-2xl font-bold">{taxaConversao}%</div>
             <p className="text-xs text-muted-foreground">De prospects para clientes</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Faturamento Total</CardTitle>
+            <Wallet className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              R$ {totalRevenue.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}
+            </div>
+            <p className="text-xs text-muted-foreground">Receita acumulada por planos</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Ticket Médio</CardTitle>
+            <CircleDollarSign className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              R$ {averageTicket.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}
+            </div>
+            <p className="text-xs text-muted-foreground">Faturamento médio por cliente</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Clientes Pagantes</CardTitle>
+            <Users className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{payingClients}</div>
+            <p className="text-xs text-muted-foreground">Distribuídos entre todos os planos</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Crescimento do Faturamento</CardTitle>
+            <TrendingUp className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {revenueGrowth >= 0 ? "+" : ""}
+              {revenueGrowth.toFixed(1)}%
+            </div>
+            <p className="text-xs text-muted-foreground">Comparação com o mês anterior</p>
           </CardContent>
         </Card>
       </div>
@@ -152,6 +223,75 @@ export default function Relatorios() {
                 </Pie>
                 <Tooltip formatter={(value) => [`${value}%`, "Percentual"]} />
               </PieChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Composição do Faturamento</CardTitle>
+            <CardDescription>Receita gerada por cada plano</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={300}>
+              <BarChart data={mockRevenueByPlan}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis />
+                <Tooltip
+                  formatter={(value: number | string) => [
+                    Number(value).toLocaleString("pt-BR", {
+                      style: "currency",
+                      currency: "BRL",
+                    }),
+                    "Faturamento",
+                  ]}
+                />
+                <Bar dataKey="revenue" fill="hsl(var(--primary))" name="Receita" />
+              </BarChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Fluxo Financeiro Mensal</CardTitle>
+            <CardDescription>Receitas e despesas consolidadas</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={300}>
+              <AreaChart data={mockMonthlyFinancials}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="month" />
+                <YAxis />
+                <Tooltip
+                  formatter={(value: number | string, name) => [
+                    Number(value).toLocaleString("pt-BR", {
+                      style: "currency",
+                      currency: "BRL",
+                    }),
+                    name === "receita" ? "Receita" : "Despesas",
+                  ]}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="receita"
+                  stroke="hsl(var(--primary))"
+                  fill="hsl(var(--primary))"
+                  fillOpacity={0.3}
+                  name="Receita"
+                />
+                <Area
+                  type="monotone"
+                  dataKey="despesas"
+                  stroke="hsl(var(--secondary))"
+                  fill="hsl(var(--secondary))"
+                  fillOpacity={0.3}
+                  name="Despesas"
+                />
+              </AreaChart>
             </ResponsiveContainer>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- add mock monthly financial dataset for revenue and expenses tracking
- extend reports dashboard with financial KPIs and visualizations for billing

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb7f62ec5883268239d35656d14825