### PR TITLE
feat: add modern loading experience to conversations

### DIFF
--- a/frontend/src/components/waha/ConversationLoadingScreen.tsx
+++ b/frontend/src/components/waha/ConversationLoadingScreen.tsx
@@ -1,0 +1,48 @@
+import { MessageCircle } from "lucide-react";
+
+const shimmerItems = [0, 1, 2, 3];
+
+export const ConversationLoadingScreen = () => {
+  return (
+    <div className="relative flex h-full min-h-[420px] w-full flex-1 items-center justify-center overflow-hidden bg-slate-950 text-slate-100">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.28),_transparent_55%),radial-gradient(circle_at_bottom,_rgba(14,165,233,0.22),_transparent_60%)]" />
+
+      <div className="relative flex w-full max-w-3xl flex-col items-center gap-10 px-6 text-center">
+        <div className="relative h-28 w-28 animate-float">
+          <div className="absolute inset-4 rounded-full bg-sky-500/20 blur-xl" />
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="flex h-24 w-24 items-center justify-center rounded-full bg-slate-900/80 shadow-[0_0_30px_rgba(59,130,246,0.35)] backdrop-blur-sm">
+              <MessageCircle className="h-10 w-10 text-sky-300" />
+            </div>
+            <div className="absolute h-24 w-24 rounded-full border-2 border-sky-400/40 border-t-transparent animate-spin-slow" />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-2xl font-semibold tracking-tight">Carregando suas conversas</p>
+          <p className="text-sm text-slate-300">
+            Estamos sincronizando seus atendimentos com o WhatsApp Business.
+          </p>
+        </div>
+
+        <div className="flex w-full max-w-lg flex-col gap-4">
+          {shimmerItems.map((item) => (
+            <div
+              key={item}
+              className="relative flex h-16 items-center gap-4 overflow-hidden rounded-2xl border border-slate-800/60 bg-slate-900/70 px-5"
+            >
+              <div className="h-10 w-10 flex-shrink-0 rounded-full bg-slate-800/80" />
+              <div className="flex flex-1 flex-col gap-2">
+                <div className="h-3 w-2/3 rounded-full bg-slate-800/70" />
+                <div className="h-3 w-1/2 rounded-full bg-slate-800/50" />
+              </div>
+              <div className="absolute inset-0 -translate-x-full animate-shimmer bg-[linear-gradient(110deg,transparent,rgba(148,163,184,0.45),transparent)]" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConversationLoadingScreen;

--- a/frontend/src/components/waha/WhatsAppLayout.tsx
+++ b/frontend/src/components/waha/WhatsAppLayout.tsx
@@ -4,6 +4,7 @@ import { SessionStatus } from "./SessionStatus";
 import { ChatSidebar as CRMChatSidebar } from "@/features/chat/components/ChatSidebar";
 import { ChatWindow as CRMChatWindow } from "@/features/chat/components/ChatWindow";
 import { NewConversationModal } from "@/features/chat/components/NewConversationModal";
+import { ConversationLoadingScreen } from "./ConversationLoadingScreen";
 import type {
   ConversationSummary,
   Message as CRMMessage,
@@ -260,6 +261,13 @@ export const WhatsAppLayout = ({
 
   const handleSelectConversation = useCallback(
     async (conversationId: string, options?: { skipNavigation?: boolean }) => {
+      if (conversationId === activeConversationId && messageMap[conversationId]) {
+        if (!options?.skipNavigation) {
+          onConversationRouteChange?.(conversationId);
+        }
+        return;
+      }
+
       setMessagesLoading(true);
       try {
         await selectChat(conversationId);
@@ -270,7 +278,7 @@ export const WhatsAppLayout = ({
         setMessagesLoading(false);
       }
     },
-    [onConversationRouteChange, selectChat],
+    [activeConversationId, messageMap, onConversationRouteChange, selectChat],
   );
 
   useEffect(() => {
@@ -354,6 +362,19 @@ export const WhatsAppLayout = ({
       void loadMessages(activeConversationId);
     }
   }, [activeConversationId, checkSessionStatus, loadChats, loadMessages]);
+
+  const isInitialLoading = loading && conversations.length === 0;
+
+  if (isInitialLoading) {
+    return (
+      <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+        <SessionStatus status={wahaState.sessionStatus} onRefresh={handleReload} />
+        <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
+          <ConversationLoadingScreen />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">

--- a/frontend/src/hooks/useWAHA.ts
+++ b/frontend/src/hooks/useWAHA.ts
@@ -382,14 +382,12 @@ export const useWAHA = () => {
   // Select active chat
   const selectChat = useCallback(async (chatId: string) => {
     setActiveChatId(chatId);
-    
-    // Load messages if not already loaded
+
     if (!messages[chatId]) {
       await loadMessages(chatId);
     }
-    
-    // Mark as read
-    await markAsRead(chatId);
+
+    void markAsRead(chatId);
   }, [messages, loadMessages, markAsRead]);
 
   // Add a new message (for webhook integration)

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -93,10 +93,29 @@ export default {
             height: "0",
           },
         },
+        shimmer: {
+          "0%": {
+            transform: "translateX(-100%)",
+          },
+          "100%": {
+            transform: "translateX(100%)",
+          },
+        },
+        float: {
+          "0%, 100%": {
+            transform: "translateY(0px)",
+          },
+          "50%": {
+            transform: "translateY(-6px)",
+          },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        shimmer: "shimmer 1.8s ease-in-out infinite",
+        float: "float 3s ease-in-out infinite",
+        "spin-slow": "spin 2.4s linear infinite",
       },
     },
   },


### PR DESCRIPTION
## Summary
- add a dedicated loading screen with animated skeletons for the conversations area
- delay rendering the chat layout until the initial conversations list is ready and skip redundant selections
- speed up conversation opening by marking chats as read asynchronously and add Tailwind helpers for the new animation effects

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb8076d6288326a6da18360e33a56b