### PR TITLE
Fix async document creation handler

### DIFF
--- a/frontend/src/pages/VisualizarOportunidade.tsx
+++ b/frontend/src/pages/VisualizarOportunidade.tsx
@@ -1147,7 +1147,7 @@ export default function VisualizarOportunidade() {
     patchOpportunity,
   ]);
 
-  const handleDocumentConfirm = () => {
+  const handleDocumentConfirm = async () => {
     if (!documentType) return;
 
     const params = new URLSearchParams();


### PR DESCRIPTION
## Summary
- mark the document confirmation handler as async so it can await fetch requests without build errors

## Testing
- pnpm lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb84cec6408326a2179f1c8f37a375