### PR TITLE
Implement authentication flow for protected modules

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,6 +59,8 @@ import Login from "./pages/Login";
 import Register from "./pages/Register";
 import RecuperarSenha from "./pages/RecuperarSenha";
 import NotFound from "./pages/NotFound";
+import { AuthProvider } from "@/features/auth/AuthProvider";
+import { ProtectedRoute } from "@/features/auth/ProtectedRoute";
 
 const CRMLayout = lazy(() =>
   import("@/components/layout/CRMLayout").then((module) => ({ default: module.CRMLayout })),
@@ -72,13 +74,20 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
-        <Suspense fallback={<LandingFallback />}>
-          <Routes>
-            <Route path={routes.login} element={<Login />} />
-            <Route path={routes.register} element={<Register />} />
-            <Route path={routes.forgotPassword} element={<RecuperarSenha />} />
-            <Route element={<CRMLayout />}>
+      <AuthProvider>
+        <BrowserRouter>
+          <Suspense fallback={<LandingFallback />}>
+            <Routes>
+              <Route path={routes.login} element={<Login />} />
+              <Route path={routes.register} element={<Register />} />
+              <Route path={routes.forgotPassword} element={<RecuperarSenha />} />
+              <Route
+                element={(
+                  <ProtectedRoute>
+                    <CRMLayout />
+                  </ProtectedRoute>
+                )}
+              >
               <Route path="/" element={<Dashboard />} />
               <Route path="/conversas" element={<Conversas />} />
               <Route path="/conversas/:conversationId" element={<Conversas />} />
@@ -184,11 +193,12 @@ const App = () => (
                 element={<FluxoTrabalho />}
               />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-              <Route path="*" element={<NotFound />} />
-            </Route>
-          </Routes>
-        </Suspense>
-      </BrowserRouter>
+                <Route path="*" element={<NotFound />} />
+              </Route>
+            </Routes>
+          </Suspense>
+        </BrowserRouter>
+      </AuthProvider>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/frontend/src/components/layout/CRMLayout.tsx
+++ b/frontend/src/components/layout/CRMLayout.tsx
@@ -7,19 +7,22 @@ import { useToast } from "@/hooks/use-toast";
 import { useAutoLogout } from "@/hooks/useAutoLogout";
 import { useCallback } from "react";
 import { routes } from "@/config/routes";
+import { useAuth } from "@/features/auth/AuthProvider";
 
 export function CRMLayout() {
   const location = useLocation();
   const navigate = useNavigate();
   const { toast } = useToast();
+  const { logout } = useAuth();
   const handleAutoLogout = useCallback(() => {
     toast({
       title: "Sessão encerrada",
       description: "Você foi desconectado por inatividade. Faça login novamente para continuar.",
       variant: "destructive",
     });
+    logout();
     navigate(routes.login, { replace: true });
-  }, [navigate, toast]);
+  }, [logout, navigate, toast]);
 
   useAutoLogout(handleAutoLogout);
   const isConversationsRoute = location.pathname.startsWith("/conversas");

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,4 +1,5 @@
-import { Search, User } from "lucide-react";
+import { Search, User, LogOut } from "lucide-react";
+import { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -14,9 +15,36 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { IntimacaoMenu } from "@/components/notifications/IntimacaoMenu";
+import { useAuth } from "@/features/auth/AuthProvider";
+import { routes } from "@/config/routes";
+
+const getInitials = (name: string | undefined) => {
+  if (!name) {
+    return "--";
+  }
+
+  const parts = name
+    .split(/\s+/u)
+    .filter(Boolean)
+    .slice(0, 2);
+
+  if (parts.length === 0) {
+    return name.slice(0, 2).toUpperCase();
+  }
+
+  return parts
+    .map((part) => part.charAt(0).toUpperCase())
+    .join("");
+};
 
 export function Header() {
   const navigate = useNavigate();
+  const { user, logout } = useAuth();
+
+  const handleLogout = useCallback(() => {
+    logout();
+    navigate(routes.login, { replace: true });
+  }, [logout, navigate]);
 
   return (
     <header className="h-16 bg-card border-b border-border px-6 flex items-center justify-between gap-4">
@@ -46,12 +74,16 @@ export function Header() {
             <Button variant="ghost" className="flex items-center gap-2">
               <Avatar className="h-8 w-8">
                 <AvatarFallback className="bg-primary text-primary-foreground">
-                  AB
+                  {getInitials(user?.nome_completo)}
                 </AvatarFallback>
               </Avatar>
               <div className="text-left">
-                <p className="text-sm font-medium">Dr. Diego Armond</p>
-                <p className="text-xs text-muted-foreground">Advogado Sênior</p>
+                <p className="text-sm font-medium truncate max-w-[160px]">
+                  {user?.nome_completo ?? "Usuário"}
+                </p>
+                <p className="text-xs text-muted-foreground truncate max-w-[160px]">
+                  {user?.email ?? "Conta"}
+                </p>
               </div>
             </Button>
           </DropdownMenuTrigger>
@@ -76,7 +108,15 @@ export function Header() {
               Configurações
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuItem>Sair</DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={(event) => {
+                event.preventDefault();
+                handleLogout();
+              }}
+            >
+              <LogOut className="mr-2 h-4 w-4" />
+              Sair
+            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/frontend/src/features/auth/AuthProvider.tsx
+++ b/frontend/src/features/auth/AuthProvider.tsx
@@ -1,0 +1,237 @@
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { getApiBaseUrl } from "@/lib/api";
+import { fetchCurrentUser, loginRequest } from "./api";
+import type { AuthUser, LoginCredentials, LoginResponse } from "./types";
+
+interface StoredAuthData {
+  token: string;
+  user?: AuthUser;
+  timestamp: number;
+}
+
+interface AuthContextValue {
+  user: AuthUser | null;
+  token: string | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login: (credentials: LoginCredentials) => Promise<LoginResponse>;
+  logout: () => void;
+  refreshUser: () => Promise<AuthUser>;
+}
+
+const STORAGE_KEY = "jus-connect:auth";
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+const readStoredAuth = (): StoredAuthData | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as StoredAuthData;
+    if (!parsed?.token) {
+      return null;
+    }
+
+    return parsed;
+  } catch (error) {
+    console.warn("Failed to parse stored auth data", error);
+    return null;
+  }
+};
+
+const writeStoredAuth = (data: StoredAuthData | null) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (!data) {
+    window.localStorage.removeItem(STORAGE_KEY);
+    return;
+  }
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+};
+
+const shouldAttachAuthHeader = (requestUrl: string, apiBaseUrl: string): boolean => {
+  if (!requestUrl) {
+    return false;
+  }
+
+  if (requestUrl.startsWith("/api")) {
+    return true;
+  }
+
+  if (requestUrl.startsWith("http://") || requestUrl.startsWith("https://")) {
+    const normalizedBase = apiBaseUrl.replace(/\/+$/, "");
+    const normalizedUrl = requestUrl.replace(/\/+$/, "");
+    if (normalizedUrl.startsWith(`${normalizedBase}/api`) || normalizedUrl === `${normalizedBase}/api`) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const tokenRef = useRef<string | null>(null);
+  const hasUnauthorizedErrorRef = useRef(false);
+  const apiBaseUrlRef = useRef(getApiBaseUrl());
+
+  useEffect(() => {
+    tokenRef.current = token;
+  }, [token]);
+
+  const handleLogout = useCallback(() => {
+    setUser(null);
+    setToken(null);
+    setIsLoading(false);
+    hasUnauthorizedErrorRef.current = false;
+    tokenRef.current = null;
+    writeStoredAuth(null);
+  }, []);
+
+  const logoutRef = useRef(handleLogout);
+  useEffect(() => {
+    logoutRef.current = handleLogout;
+  }, [handleLogout]);
+
+  useEffect(() => {
+    const stored = readStoredAuth();
+    if (!stored) {
+      setIsLoading(false);
+      return;
+    }
+
+    setToken(stored.token);
+    tokenRef.current = stored.token;
+    if (stored.user) {
+      setUser(stored.user);
+    }
+
+    const validateToken = async () => {
+      try {
+        const currentUser = await fetchCurrentUser();
+        setUser(currentUser);
+        writeStoredAuth({ token: stored.token, user: currentUser, timestamp: Date.now() });
+      } catch (error) {
+        console.warn("Failed to validate stored token", error);
+        handleLogout();
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void validateToken();
+  }, [handleLogout]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.fetch !== "function") {
+      return;
+    }
+
+    const originalFetch = window.fetch.bind(window);
+    const apiBaseUrl = apiBaseUrlRef.current;
+
+    const enhancedFetch: typeof window.fetch = async (input, init) => {
+      const request = new Request(input as RequestInfo, init);
+      const requestUrl = request.url;
+      const shouldAttach = tokenRef.current && shouldAttachAuthHeader(requestUrl, apiBaseUrl);
+
+      let finalRequest = request;
+
+      if (shouldAttach && tokenRef.current) {
+        const headers = new Headers(request.headers);
+        headers.set("Authorization", `Bearer ${tokenRef.current}`);
+        finalRequest = new Request(request, { headers });
+      }
+
+      const response = await originalFetch(finalRequest);
+
+      if (
+        response.status === 401 &&
+        shouldAttachAuthHeader(response.url, apiBaseUrl) &&
+        tokenRef.current &&
+        !response.url.endsWith("/auth/login")
+      ) {
+        if (!hasUnauthorizedErrorRef.current) {
+          hasUnauthorizedErrorRef.current = true;
+          window.setTimeout(() => {
+            logoutRef.current();
+          }, 0);
+        }
+      }
+
+      return response;
+    };
+
+    window.fetch = enhancedFetch;
+
+    return () => {
+      window.fetch = originalFetch;
+    };
+  }, []);
+
+  const login = useCallback(async (credentials: LoginCredentials) => {
+    const response = await loginRequest(credentials);
+    setToken(response.token);
+    setUser(response.user);
+    tokenRef.current = response.token;
+    writeStoredAuth({ token: response.token, user: response.user, timestamp: Date.now() });
+    return response;
+  }, []);
+
+  const logout = useCallback(() => {
+    handleLogout();
+  }, [handleLogout]);
+
+  const refreshUser = useCallback(async () => {
+    const currentUser = await fetchCurrentUser();
+    setUser(currentUser);
+    if (tokenRef.current) {
+      writeStoredAuth({ token: tokenRef.current, user: currentUser, timestamp: Date.now() });
+    }
+    return currentUser;
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user,
+      token,
+      isAuthenticated: Boolean(token),
+      isLoading,
+      login,
+      logout,
+      refreshUser,
+    }),
+    [user, token, isLoading, login, logout, refreshUser],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+};

--- a/frontend/src/features/auth/ProtectedRoute.tsx
+++ b/frontend/src/features/auth/ProtectedRoute.tsx
@@ -1,0 +1,31 @@
+import { ReactElement } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { Loader2 } from "lucide-react";
+import { routes } from "@/config/routes";
+import { useAuth } from "./AuthProvider";
+
+interface ProtectedRouteProps {
+  children: ReactElement;
+}
+
+export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
+  const { isAuthenticated, isLoading } = useAuth();
+  const location = useLocation();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <div className="flex flex-col items-center gap-2 text-muted-foreground">
+          <Loader2 className="h-6 w-6 animate-spin" />
+          <span>Verificando sessão...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to={routes.login} replace state={{ from: location }} />;
+  }
+
+  return children;
+};

--- a/frontend/src/features/auth/api.ts
+++ b/frontend/src/features/auth/api.ts
@@ -1,0 +1,63 @@
+import { getApiUrl } from "@/lib/api";
+import type { AuthUser, LoginCredentials, LoginResponse } from "./types";
+
+const parseErrorMessage = async (response: Response) => {
+  try {
+    const data = await response.json();
+    if (typeof data?.error === "string" && data.error.trim().length > 0) {
+      return data.error;
+    }
+    if (typeof data?.message === "string" && data.message.trim().length > 0) {
+      return data.message;
+    }
+  } catch (error) {
+    console.warn("Failed to parse error response", error);
+  }
+
+  return response.status === 401
+    ? "Credenciais inválidas. Verifique seu e-mail e senha."
+    : "Não foi possível concluir a solicitação. Tente novamente.";
+};
+
+export const loginRequest = async (
+  credentials: LoginCredentials,
+): Promise<LoginResponse> => {
+  const response = await fetch(getApiUrl("auth/login"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(credentials),
+  });
+
+  if (!response.ok) {
+    throw new Error(await parseErrorMessage(response));
+  }
+
+  const data = (await response.json()) as LoginResponse;
+  if (!data?.token || !data?.user) {
+    throw new Error("Resposta de autenticação inválida.");
+  }
+
+  return data;
+};
+
+export const fetchCurrentUser = async (): Promise<AuthUser> => {
+  const response = await fetch(getApiUrl("auth/me"), {
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(await parseErrorMessage(response));
+  }
+
+  const data = (await response.json()) as AuthUser;
+  if (typeof data?.id !== "number") {
+    throw new Error("Não foi possível carregar os dados do usuário.");
+  }
+
+  return data;
+};

--- a/frontend/src/features/auth/types.ts
+++ b/frontend/src/features/auth/types.ts
@@ -1,0 +1,18 @@
+export interface AuthUser {
+  id: number;
+  nome_completo: string;
+  email: string;
+  perfil: number | null;
+  status?: boolean | null;
+}
+
+export interface LoginCredentials {
+  email: string;
+  senha: string;
+}
+
+export interface LoginResponse {
+  token: string;
+  expiresIn?: number;
+  user: AuthUser;
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -3,134 +3,173 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
-import { Eye, EyeOff } from "lucide-react";
-import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Eye, EyeOff, Loader2 } from "lucide-react";
+import { FormEvent, useCallback, useEffect, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import quantumLogo from "@/assets/quantum-logo.png";
 import { routes } from "@/config/routes";
 import { appConfig } from "@/config/app-config";
+import { useAuth } from "@/features/auth/AuthProvider";
 
 const Login = () => {
-    const [showPassword, setShowPassword] = useState(false);
-    const [email, setEmail] = useState("");
-    const [password, setPassword] = useState("");
-    const navigate = useNavigate();
+  const [showPassword, setShowPassword] = useState(false);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { login, isAuthenticated, isLoading } = useAuth();
+  const resolveRedirectPath = useCallback(
+    () =>
+      ((location.state as { from?: { pathname?: string } } | undefined)?.from?.pathname) ?? routes.home,
+    [location],
+  );
 
-    const handleLogin = (e: React.FormEvent) => {
-        e.preventDefault();
-        // Simulate login - in real app, this would call an API
-        if (email && password) {
-            navigate(routes.admin.dashboard);
-        }
-    };
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      navigate(resolveRedirectPath(), { replace: true });
+    }
+  }, [isAuthenticated, isLoading, navigate, resolveRedirectPath]);
 
-    return (
-        <div className="min-h-screen bg-gradient-to-br from-background via-primary/5 to-accent/10 flex items-center justify-center p-4">
-            <div className="w-full max-w-md">
-                {/* Logo and Title */}
-                <div className="text-center mb-8">
-                    <Link to={routes.home} className="inline-flex items-center gap-3 mb-4 hover:opacity-80 transition-opacity">
-                        <img src={quantumLogo} alt={appConfig.appName} className="h-12 w-12" />
-                        <h1 className="text-3xl font-bold text-primary">{appConfig.appName}</h1>
-                    </Link>
-                    <p className="text-muted-foreground">Entre na sua conta</p>
-                </div>
+  const handleLogin = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setErrorMessage(null);
+    setIsSubmitting(true);
 
-                <Card className="border-0 bg-background/80 backdrop-blur-sm shadow-lg">
-                    <CardHeader className="space-y-1">
-                        <CardTitle className="text-2xl text-center">Login</CardTitle>
-                        <CardDescription className="text-center">
-                            Digite suas credenciais para acessar o sistema
-                        </CardDescription>
-                    </CardHeader>
-                    <CardContent>
-                        <form onSubmit={handleLogin} className="space-y-4">
-                            <div className="space-y-2">
-                                <Label htmlFor="email">Email</Label>
-                                <Input
-                                    id="email"
-                                    type="email"
-                                    placeholder="seu@email.com"
-                                    value={email}
-                                    onChange={(e) => setEmail(e.target.value)}
-                                    required
-                                />
-                            </div>
+    try {
+      await login({ email, senha: password });
+      navigate(resolveRedirectPath(), { replace: true });
+    } catch (error) {
+      if (error instanceof Error) {
+        setErrorMessage(error.message);
+      } else {
+        setErrorMessage("Não foi possível realizar o login. Tente novamente.");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
-                            <div className="space-y-2">
-                                <Label htmlFor="password">Senha</Label>
-                                <div className="relative">
-                                    <Input
-                                        id="password"
-                                        type={showPassword ? "text" : "password"}
-                                        placeholder="Sua senha"
-                                        value={password}
-                                        onChange={(e) => setPassword(e.target.value)}
-                                        required
-                                    />
-                                    <Button
-                                        type="button"
-                                        variant="ghost"
-                                        size="sm"
-                                        className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-                                        onClick={() => setShowPassword(!showPassword)}
-                                    >
-                                        {showPassword ? (
-                                            <EyeOff className="h-4 w-4" />
-                                        ) : (
-                                            <Eye className="h-4 w-4" />
-                                        )}
-                                    </Button>
-                                </div>
-                            </div>
-
-                            <div className="flex items-center justify-between">
-                                <label className="flex items-center space-x-2 text-sm">
-                                    <input type="checkbox" className="rounded border-gray-300" />
-                                    <span>Lembrar de mim</span>
-                                </label>
-                                <Link to={routes.forgotPassword} className="text-sm text-primary hover:underline">
-                                    Esqueceu a senha?
-                                </Link>
-                            </div>
-
-                            <Button type="submit" className="w-full">
-                                Entrar
-                            </Button>
-                        </form>
-
-                        <Separator className="my-6" />
-
-                        <div className="text-center text-sm text-muted-foreground">
-                            Não tem uma conta?{" "}
-                            <Link to={routes.register} className="text-primary hover:underline">
-                                Cadastre-se
-                            </Link>
-                        </div>
-
-                        <div className="text-center mt-4">
-                            <Link to={routes.home} className="text-sm text-muted-foreground hover:text-primary transition-colors">
-                                ← Voltar para o site
-                            </Link>
-                        </div>
-                    </CardContent>
-                </Card>
-
-                {/* Demo credentials */}
-                <Card className="mt-4 border-primary/20 bg-primary/5">
-                    <CardContent className="pt-4">
-                        <p className="text-sm text-center text-muted-foreground mb-2">
-                            <strong>Credenciais de demonstração:</strong>
-                        </p>
-                        <p className="text-xs text-center text-muted-foreground">
-                            Email: admin@quantumjud.com<br />
-                            Senha: demo123
-                        </p>
-                    </CardContent>
-                </Card>
-            </div>
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-background via-primary/5 to-accent/10 flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        {/* Logo and Title */}
+        <div className="text-center mb-8">
+          <Link to={routes.home} className="inline-flex items-center gap-3 mb-4 hover:opacity-80 transition-opacity">
+            <img src={quantumLogo} alt={appConfig.appName} className="h-12 w-12" />
+            <h1 className="text-3xl font-bold text-primary">{appConfig.appName}</h1>
+          </Link>
+          <p className="text-muted-foreground">Entre na sua conta</p>
         </div>
-    );
+
+        <Card className="border-0 bg-background/80 backdrop-blur-sm shadow-lg">
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-2xl text-center">Login</CardTitle>
+            <CardDescription className="text-center">
+              Digite suas credenciais para acessar o sistema
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleLogin} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="seu@email.com"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  autoComplete="email"
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="password">Senha</Label>
+                <div className="relative">
+                  <Input
+                    id="password"
+                    type={showPassword ? "text" : "password"}
+                    placeholder="Sua senha"
+                    value={password}
+                    onChange={(event) => setPassword(event.target.value)}
+                    autoComplete="current-password"
+                    required
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                    onClick={() => setShowPassword((prev) => !prev)}
+                    aria-label={showPassword ? "Ocultar senha" : "Mostrar senha"}
+                  >
+                    {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </Button>
+                </div>
+              </div>
+
+              {errorMessage ? (
+                <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                  {errorMessage}
+                </div>
+              ) : null}
+
+              <div className="flex items-center justify-between">
+                <label className="flex items-center space-x-2 text-sm">
+                  <input type="checkbox" className="rounded border-gray-300" />
+                  <span>Lembrar de mim</span>
+                </label>
+                <Link to={routes.forgotPassword} className="text-sm text-primary hover:underline">
+                  Esqueceu a senha?
+                </Link>
+              </div>
+
+              <Button type="submit" className="w-full" disabled={isSubmitting}>
+                {isSubmitting ? (
+                  <span className="flex items-center justify-center gap-2">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Entrando...
+                  </span>
+                ) : (
+                  "Entrar"
+                )}
+              </Button>
+            </form>
+
+            <Separator className="my-6" />
+
+            <div className="text-center text-sm text-muted-foreground">
+              Não tem uma conta?{" "}
+              <Link to={routes.register} className="text-primary hover:underline">
+                Cadastre-se
+              </Link>
+            </div>
+
+            <div className="text-center mt-4">
+              <Link to={routes.home} className="text-sm text-muted-foreground hover:text-primary transition-colors">
+                ← Voltar para o site
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Demo credentials */}
+        <Card className="mt-4 border-primary/20 bg-primary/5">
+          <CardContent className="pt-4">
+            <p className="text-sm text-center text-muted-foreground mb-2">
+              <strong>Credenciais de demonstração:</strong>
+            </p>
+            <p className="text-xs text-center text-muted-foreground">
+              Email: admin@quantumjud.com<br />
+              Senha: demo123
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
 };
 
 export default Login;


### PR DESCRIPTION
## Summary
- add an authentication context with API helpers and a protected route wrapper to enforce valid sessions
- wrap application routes with the new provider/guard and update layout/header to surface the signed user and logout
- wire the login form to the backend credentials endpoint with error handling and redirects

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files such as src/api/webhook.ts and src/services/waha.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cb868503c083268aaf2b3e11d7d702