### PR TITLE
Add loading spinner to chat conversation overlay

### DIFF
--- a/frontend/src/features/chat/components/ChatWindow.module.css
+++ b/frontend/src/features/chat/components/ChatWindow.module.css
@@ -644,6 +644,29 @@
   font-weight: 600;
 }
 
+.loadingOverlayContent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  color: hsl(var(--foreground));
+}
+
+.loadingSpinner {
+  width: 2.75rem;
+  aspect-ratio: 1;
+  border-radius: 999px;
+  border: 3px solid hsl(var(--muted-foreground) / 0.35);
+  border-top-color: hsl(var(--primary));
+  animation: chatWindowLoadingSpin 0.8s linear infinite;
+}
+
+@keyframes chatWindowLoadingSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .viewportWrapper {
   position: relative;
   flex: 1;

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -515,7 +515,14 @@ export const ChatWindow = ({
         </header>
 
         <div className={styles.viewportWrapper}>
-          {isLoading && <div className={styles.loadingOverlay}>Carregando conversa...</div>}
+          {isLoading && (
+            <div className={styles.loadingOverlay}>
+              <div className={styles.loadingOverlayContent} role="status" aria-live="polite" aria-busy="true">
+                <span className={styles.loadingSpinner} aria-hidden="true" />
+                <span>Carregando conversa...</span>
+              </div>
+            </div>
+          )}
           <MessageViewport
             messages={messages}
             avatarUrl={conversation.avatar}


### PR DESCRIPTION
## Summary
- replace the static conversation loading text with an accessible loading overlay that includes a spinner
- add supporting styles and animation for the chat loading spinner

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0192b50c8326ace3dfd619f79322