### PR TITLE
Add WAHA device logout and QR refresh flow to chat modal

### DIFF
--- a/frontend/src/features/chat/components/DeviceLinkModal.module.css
+++ b/frontend/src/features/chat/components/DeviceLinkModal.module.css
@@ -13,6 +13,208 @@
   height: 100%;
 }
 
+.statusCard {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
+  box-shadow: var(--shadow-card);
+}
+
+.statusHeader {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.sessionLabel {
+  margin: 0 0 0.35rem;
+  font-size: 0.9rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.sessionName {
+  color: hsl(var(--foreground));
+  font-weight: 700;
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+}
+
+.statusBadgeConnected {
+  background: hsl(var(--success-light));
+  color: hsl(var(--success));
+}
+
+.statusBadgePending {
+  background: hsl(var(--warning-light));
+  color: hsl(var(--warning));
+}
+
+.statusBadgeError {
+  background: hsl(var(--destructive) / 0.15);
+  color: hsl(var(--destructive));
+}
+
+.sessionActions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.sessionWarning {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  background: hsl(var(--warning-light));
+  color: hsl(var(--warning));
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.sessionWarning strong {
+  font-weight: 700;
+  color: inherit;
+}
+
+.sessionFeedback {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  color: hsl(var(--muted-foreground));
+  font-size: 0.9rem;
+}
+
+.statusSpinner,
+.buttonSpinner {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 999px;
+  border: 2px solid hsl(var(--muted-foreground) / 0.2);
+  border-top-color: hsl(var(--primary));
+  animation: spin 0.8s linear infinite;
+}
+
+.buttonSpinner {
+  border-color: currentColor;
+  border-top-color: transparent;
+  border-right-color: transparent;
+}
+
+.statusDescription {
+  margin: 0;
+  color: hsl(var(--muted-foreground));
+  line-height: 1.6;
+}
+
+.sessionError {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  background: hsl(var(--destructive) / 0.12);
+  color: hsl(var(--destructive));
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.sessionMetaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  margin: 0;
+  font-size: 0.8rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.sessionMetaHighlight {
+  font-weight: 600;
+  color: hsl(var(--foreground));
+}
+
+.qrSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  border: 1px dashed hsl(var(--border));
+  background: hsl(var(--muted));
+}
+
+.qrHeader {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.qrHeader h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.qrActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.qrContent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  min-height: 220px;
+  text-align: center;
+}
+
+.qrImage {
+  width: 220px;
+  height: 220px;
+  object-fit: contain;
+  background: #fff;
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  box-shadow: var(--shadow-card);
+}
+
+.qrPlaceholder {
+  margin: 0;
+  color: hsl(var(--muted-foreground));
+  line-height: 1.5;
+  font-size: 0.9rem;
+}
+
+.refreshIconSpinning {
+  animation: spin 0.9s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .integrationHeader h2 {
   margin: 0 0 0.5rem;
   font-size: 1.35rem;
@@ -139,6 +341,27 @@
   .instructions {
     order: 1;
     text-align: center;
+  }
+
+  .sessionActions {
+    justify-content: center;
+  }
+
+  .statusHeader {
+    align-items: center;
+  }
+
+  .sessionMetaRow {
+    justify-content: center;
+    text-align: center;
+  }
+
+  .qrHeader {
+    justify-content: center;
+  }
+
+  .qrActions {
+    justify-content: center;
   }
 
   .stepItem {

--- a/frontend/src/features/chat/components/DeviceLinkModal.tsx
+++ b/frontend/src/features/chat/components/DeviceLinkModal.tsx
@@ -1,7 +1,19 @@
-import { useMemo } from "react";
-import { Smartphone, QrCode, ShieldCheck } from "lucide-react";
+import { useEffect, useMemo } from "react";
+import clsx from "clsx";
+import { Smartphone, QrCode, ShieldCheck, RefreshCw, LogOut } from "lucide-react";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Modal } from "./Modal";
 import { WhatsAppWebEmbed } from "../../../components/waha";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+import {
+  deriveSessionName,
+  ensureDeviceSession,
+  fetchPreferredCompany,
+  fetchSessionQrCode,
+  logoutDeviceSession,
+  type DeviceSessionInfo,
+} from "../services/deviceLinkingApi";
 import styles from "./DeviceLinkModal.module.css";
 
 interface DeviceLinkModalProps {
@@ -9,7 +21,50 @@ interface DeviceLinkModalProps {
   onClose: () => void;
 }
 
+type SessionStatusTone = "connected" | "pending" | "error" | "unknown";
+
+const STATUS_INFO: Record<string, { label: string; description: string; tone: SessionStatusTone }> = {
+  WORKING: {
+    label: "Conectado",
+    description: "O dispositivo está conectado e sincronizando as conversas normalmente.",
+    tone: "connected",
+  },
+  STARTING: {
+    label: "Inicializando",
+    description: "A sessão está em processo de inicialização. Isso pode levar alguns instantes.",
+    tone: "pending",
+  },
+  SCAN_QR_CODE: {
+    label: "Aguardando leitura do QR Code",
+    description:
+      "Abra o WhatsApp no celular desejado, toque em \"Dispositivos conectados\" e escaneie o QR Code exibido ao lado.",
+    tone: "pending",
+  },
+  FAILED: {
+    label: "Falha na conexão",
+    description:
+      "Não foi possível manter a sessão conectada. Gere um novo QR Code e autentique novamente para restabelecer a comunicação.",
+    tone: "error",
+  },
+  STOPPED: {
+    label: "Sessão desconectada",
+    description: "A sessão foi encerrada. Gere um novo QR Code e escaneie-o para retomar o atendimento pelo WhatsApp.",
+    tone: "error",
+  },
+  UNKNOWN: {
+    label: "Status desconhecido",
+    description: "Não foi possível identificar o status atual da sessão. Tente atualizar o status ou gerar um novo QR Code.",
+    tone: "unknown",
+  },
+};
+
+const timeFormatter = new Intl.DateTimeFormat("pt-BR", {
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
 export const DeviceLinkModal = ({ open, onClose }: DeviceLinkModalProps) => {
+  const { toast } = useToast();
   const steps = useMemo(
     () => [
       {
@@ -30,9 +85,120 @@ export const DeviceLinkModal = ({ open, onClose }: DeviceLinkModalProps) => {
           "Aguarde alguns instantes até que o WAHA sincronize as conversas com o JusConnect.",
         icon: <ShieldCheck size={18} aria-hidden="true" />,
       },
+      {
+        title: "Reconecte quando necessário",
+        description:
+          "Use o botão \"Desconectar dispositivo\" para gerar rapidamente um novo QR Code e autenticar novamente.",
+        icon: <RefreshCw size={18} aria-hidden="true" />,
+      },
     ],
     [],
   );
+
+  const companyQuery = useQuery({
+    queryKey: ["companies", "primary"],
+    queryFn: fetchPreferredCompany,
+    enabled: open,
+  });
+
+  const companyName = companyQuery.data?.name;
+  const sessionName = useMemo(() => deriveSessionName(companyName), [companyName]);
+
+  const sessionQuery = useQuery<DeviceSessionInfo>({
+    queryKey: ["waha", "session", sessionName],
+    queryFn: () => ensureDeviceSession(sessionName, companyName),
+    enabled: open && !companyQuery.isLoading,
+    retry: false,
+  });
+
+  const {
+    data: qrCode,
+    isFetching: isFetchingQr,
+    isError: isQrError,
+    error: qrError,
+    refetch: refetchQr,
+    remove: clearQr,
+    dataUpdatedAt: qrUpdatedAt,
+  } = useQuery({
+    queryKey: ["waha", "session", sessionName, "qr"],
+    queryFn: () => fetchSessionQrCode(sessionName),
+    enabled: false,
+    staleTime: 0,
+    gcTime: 0,
+  });
+
+  const logoutMutation = useMutation({
+    mutationFn: async () => {
+      if (!sessionName) {
+        throw new Error("Sessão não configurada.");
+      }
+      await logoutDeviceSession(sessionName);
+    },
+    onSuccess: async () => {
+      toast({
+        title: "Dispositivo desconectado",
+        description: "Geramos um novo QR Code para que você possa autenticar o WhatsApp novamente.",
+      });
+      await sessionQuery.refetch();
+      await refetchQr();
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : "Não foi possível desconectar o dispositivo.";
+      toast({
+        title: "Falha ao desconectar",
+        description: message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  useEffect(() => {
+    if (!open) {
+      clearQr();
+      return;
+    }
+
+    if (sessionQuery.data?.status === "SCAN_QR_CODE") {
+      void refetchQr();
+    } else if (qrCode) {
+      clearQr();
+    }
+  }, [open, sessionQuery.data?.status, refetchQr, clearQr, qrCode]);
+
+  const handleRefreshStatus = async () => {
+    const result = await sessionQuery.refetch();
+    if (result.data?.status === "SCAN_QR_CODE") {
+      await refetchQr();
+    } else {
+      clearQr();
+    }
+  };
+
+  const handleLogout = () => {
+    if (!sessionName || logoutMutation.isPending) {
+      return;
+    }
+    logoutMutation.mutate();
+  };
+
+  const normalizedStatus = (sessionQuery.data?.status ?? "UNKNOWN").toUpperCase();
+  const statusInfo = STATUS_INFO[normalizedStatus] ?? STATUS_INFO.UNKNOWN;
+  const statusBadgeClass = clsx(styles.statusBadge, {
+    [styles.statusBadgeConnected]: statusInfo.tone === "connected",
+    [styles.statusBadgePending]: statusInfo.tone === "pending",
+    [styles.statusBadgeError]: statusInfo.tone === "error",
+  });
+
+  const sessionUpdatedAt = sessionQuery.dataUpdatedAt
+    ? timeFormatter.format(new Date(sessionQuery.dataUpdatedAt))
+    : null;
+  const qrUpdatedAtLabel = qrUpdatedAt ? timeFormatter.format(new Date(qrUpdatedAt)) : null;
+
+  const qrPlaceholderMessage = sessionQuery.isLoading
+    ? "Carregando status da sessão..."
+    : sessionQuery.data?.status === "WORKING"
+      ? "A sessão está conectada. Gere um novo QR Code apenas se precisar autenticar outro dispositivo."
+      : "O QR Code será exibido aqui quando a sessão estiver aguardando uma nova autenticação.";
 
   return (
     <Modal open={open} onClose={onClose} ariaLabel="Conectar um novo dispositivo">
@@ -45,6 +211,127 @@ export const DeviceLinkModal = ({ open, onClose }: DeviceLinkModalProps) => {
               é atualizado automaticamente para garantir uma conexão segura.
             </p>
           </header>
+          <div className={styles.statusCard}>
+            <div className={styles.statusHeader}>
+              <div>
+                <p className={styles.sessionLabel}>
+                  Sessão vinculada: <span className={styles.sessionName}>{sessionName}</span>
+                </p>
+                <span className={statusBadgeClass}>{statusInfo.label}</span>
+              </div>
+              <div className={styles.sessionActions}>
+                <Button
+                  size="sm"
+                  onClick={handleLogout}
+                  disabled={
+                    sessionQuery.isLoading ||
+                    sessionQuery.isFetching ||
+                    logoutMutation.isPending ||
+                    !sessionName
+                  }
+                >
+                  {logoutMutation.isPending ? (
+                    <span className={styles.buttonSpinner} aria-hidden="true" />
+                  ) : (
+                    <LogOut size={16} aria-hidden="true" />
+                  )}
+                  Desconectar dispositivo
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleRefreshStatus}
+                  disabled={sessionQuery.isLoading || sessionQuery.isFetching}
+                >
+                  <RefreshCw
+                    size={16}
+                    aria-hidden="true"
+                    className={sessionQuery.isFetching ? styles.refreshIconSpinning : undefined}
+                  />
+                  Atualizar status
+                </Button>
+              </div>
+            </div>
+
+            {companyQuery.isError && (
+              <p className={styles.sessionWarning}>
+                Não foi possível carregar as informações da empresa. Utilizando a sessão padrão
+                <strong> {sessionName}</strong>.
+              </p>
+            )}
+
+            {sessionQuery.isLoading ? (
+              <div className={styles.sessionFeedback}>
+                <span className={styles.statusSpinner} aria-hidden="true" />
+                Carregando status da sessão...
+              </div>
+            ) : sessionQuery.isError ? (
+              <div className={styles.sessionError} role="alert">
+                Não foi possível carregar o status da sessão. Tente atualizar novamente ou verifique as
+                credenciais do WAHA.
+              </div>
+            ) : (
+              <p className={styles.statusDescription}>{statusInfo.description}</p>
+            )}
+
+            <div className={styles.sessionMetaRow}>
+              <span>
+                Empresa:{" "}
+                <span className={styles.sessionMetaHighlight}>{companyName ?? "Não informada"}</span>
+              </span>
+              {sessionUpdatedAt && (
+                <span>
+                  Atualizado às <span className={styles.sessionMetaHighlight}>{sessionUpdatedAt}</span>
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div className={styles.qrSection}>
+            <div className={styles.qrHeader}>
+              <h3>QR Code de autenticação</h3>
+              <div className={styles.qrActions}>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void refetchQr()}
+                  disabled={isFetchingQr || sessionQuery.isLoading || sessionQuery.isFetching}
+                >
+                  <QrCode size={16} aria-hidden="true" />
+                  Atualizar QR Code
+                </Button>
+              </div>
+            </div>
+            <div className={styles.qrContent}>
+              {isFetchingQr ? (
+                <div className={styles.sessionFeedback}>
+                  <span className={styles.statusSpinner} aria-hidden="true" />
+                  Gerando QR Code...
+                </div>
+              ) : qrCode ? (
+                <img
+                  src={qrCode}
+                  alt="QR Code do WhatsApp"
+                  className={styles.qrImage}
+                  loading="lazy"
+                />
+              ) : isQrError ? (
+                <div className={styles.sessionError} role="alert">
+                  {qrError instanceof Error
+                    ? qrError.message
+                    : "Não foi possível carregar o QR Code. Tente novamente."}
+                </div>
+              ) : (
+                <p className={styles.qrPlaceholder}>{qrPlaceholderMessage}</p>
+              )}
+            </div>
+            {qrUpdatedAtLabel && (
+              <p className={styles.sessionMetaRow}>
+                Última geração às
+                <span className={styles.sessionMetaHighlight}> {qrUpdatedAtLabel}</span>
+              </p>
+            )}
+          </div>
           <WhatsAppWebEmbed
             className={styles.embedWrapper}
             fallback={

--- a/frontend/src/features/chat/services/deviceLinkingApi.ts
+++ b/frontend/src/features/chat/services/deviceLinkingApi.ts
@@ -1,0 +1,333 @@
+import { wahaService } from "@/services/waha";
+
+export interface DeviceSessionEngineInfo {
+  grpc?: { client?: string | null; stream?: string | null } | null;
+  gows?: { found?: boolean; connected?: boolean } | null;
+}
+
+export interface DeviceSessionInfo {
+  name: string;
+  status: string;
+  config?: Record<string, unknown> | null;
+  engine?: DeviceSessionEngineInfo | null;
+}
+
+interface ApiEmpresa {
+  id?: number | string | null;
+  nome_empresa?: string | null;
+  nome?: string | null;
+  ativo?: boolean | string | number | null;
+}
+
+interface CompanySummary {
+  id: number;
+  name: string;
+  isActive: boolean;
+}
+
+const fallbackSessionName = "Jusconnect";
+
+const normalizeString = (value: unknown): string | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const removeAccents = (value: string): string =>
+  value.normalize("NFD").replace(/[\u0300-\u036f]/g, "").normalize("NFC");
+
+const toNumberOrNull = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim();
+    if (!normalized) {
+      return null;
+    }
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+const toBooleanOrUndefined = (value: unknown): boolean | undefined => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return value !== 0;
+  }
+  if (typeof value === "string") {
+    const normalized = value
+      .trim()
+      .toLowerCase()
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "");
+    if (["1", "true", "sim", "ativo", "yes", "y"].includes(normalized)) {
+      return true;
+    }
+    if (["0", "false", "nao", "não", "inativo", "no", "n"].includes(normalized)) {
+      return false;
+    }
+  }
+  return undefined;
+};
+
+const sanitizeSessionInfo = (value: unknown, fallbackName: string): DeviceSessionInfo => {
+  if (!value || typeof value !== "object") {
+    return { name: fallbackName, status: "UNKNOWN" };
+  }
+  const record = value as Record<string, unknown>;
+  const name = normalizeString(record.name) ?? fallbackName;
+  const status = normalizeString(record.status) ?? "UNKNOWN";
+  return {
+    name,
+    status,
+    config: (record.config as Record<string, unknown> | null | undefined) ?? null,
+    engine: (record.engine as DeviceSessionEngineInfo | null | undefined) ?? null,
+  };
+};
+
+const parseErrorResponse = async (response: Response): Promise<string> => {
+  try {
+    const data = (await response.clone().json()) as Record<string, unknown>;
+    const errorMessage = normalizeString(data?.error) ?? normalizeString(data?.message);
+    if (errorMessage) {
+      return errorMessage;
+    }
+  } catch (error) {
+    // Ignore JSON parse errors and fall back to reading text content below.
+  }
+
+  try {
+    const text = await response.text();
+    const normalized = text.trim();
+    if (normalized) {
+      return normalized;
+    }
+  } catch (error) {
+    // Ignore text parse errors.
+  }
+
+  return `WAHA API respondeu com status ${response.status}`;
+};
+
+const buildWahaUrl = (baseUrl: string, path: string): string => {
+  if (!path.startsWith("/")) {
+    return `${baseUrl}/${path}`;
+  }
+  return `${baseUrl}${path}`;
+};
+
+export const deriveSessionName = (companyName?: string | null): string => {
+  if (!companyName) {
+    return fallbackSessionName;
+  }
+
+  const normalized = removeAccents(companyName)
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join("");
+
+  return normalized.length > 0 ? normalized : fallbackSessionName;
+};
+
+export const fetchPreferredCompany = async (): Promise<CompanySummary | null> => {
+  const response = await fetch("/api/empresas", { headers: { Accept: "application/json" } });
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(await parseErrorResponse(response));
+  }
+
+  const payload = (await response.json()) as unknown;
+  if (!Array.isArray(payload)) {
+    return null;
+  }
+
+  const companies: CompanySummary[] = [];
+
+  for (const item of payload) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+
+    const record = item as ApiEmpresa;
+    const id = toNumberOrNull(record.id);
+    const name = normalizeString(record.nome_empresa) ?? normalizeString(record.nome);
+
+    if (id === null || !name) {
+      continue;
+    }
+
+    const isActive = toBooleanOrUndefined(record.ativo) ?? true;
+    companies.push({ id, name, isActive });
+  }
+
+  if (companies.length === 0) {
+    return null;
+  }
+
+  const activeCompany = companies.find((company) => company.isActive);
+  return activeCompany ?? companies[0]!;
+};
+
+export const fetchDeviceSession = async (sessionName: string): Promise<DeviceSessionInfo | null> => {
+  const config = await wahaService.getResolvedConfig();
+  const url = buildWahaUrl(config.baseUrl, `/api/sessions/${encodeURIComponent(sessionName)}`);
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+      "X-Api-Key": config.apiKey,
+    },
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(await parseErrorResponse(response));
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  const data = await response.json();
+  return sanitizeSessionInfo(data, sessionName);
+};
+
+export const createDeviceSession = async (
+  sessionName: string,
+  companyName?: string,
+): Promise<DeviceSessionInfo> => {
+  const config = await wahaService.getResolvedConfig();
+  const url = buildWahaUrl(config.baseUrl, "/api/sessions");
+  const payload = {
+    name: sessionName,
+    start: true,
+    config: {
+      metadata: {
+        "jusconnect.company": companyName ?? sessionName,
+        "jusconnect.createdAt": new Date().toISOString(),
+      },
+      noweb: {
+        markOnline: true,
+        store: {
+          enabled: true,
+          fullSync: false,
+        },
+      },
+    },
+  };
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "X-Api-Key": config.apiKey,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(await parseErrorResponse(response));
+  }
+
+  const data = await response.json();
+  return sanitizeSessionInfo(data, sessionName);
+};
+
+export const ensureDeviceSession = async (
+  sessionName: string,
+  companyName?: string,
+): Promise<DeviceSessionInfo> => {
+  const existing = await fetchDeviceSession(sessionName);
+  if (existing) {
+    return existing;
+  }
+
+  await createDeviceSession(sessionName, companyName);
+  const created = await fetchDeviceSession(sessionName);
+  if (created) {
+    return created;
+  }
+
+  throw new Error("Sessão criada, mas não foi possível confirmar o status.");
+};
+
+export const logoutDeviceSession = async (sessionName: string): Promise<void> => {
+  const config = await wahaService.getResolvedConfig();
+  const url = buildWahaUrl(
+    config.baseUrl,
+    `/api/sessions/${encodeURIComponent(sessionName)}/logout`,
+  );
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "X-Api-Key": config.apiKey,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(await parseErrorResponse(response));
+  }
+};
+
+const blobToDataUrl = (blob: Blob): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result === "string") {
+        resolve(result);
+      } else {
+        reject(new Error("Não foi possível ler o QR Code."));
+      }
+    };
+    reader.onerror = () => {
+      reject(new Error("Falha ao carregar o QR Code."));
+    };
+    reader.readAsDataURL(blob);
+  });
+
+export const fetchSessionQrCode = async (sessionName: string): Promise<string | null> => {
+  const config = await wahaService.getResolvedConfig();
+  const url = buildWahaUrl(
+    config.baseUrl,
+    `/api/${encodeURIComponent(sessionName)}/auth/qr?format=image`,
+  );
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: "image/png",
+      "X-Api-Key": config.apiKey,
+    },
+  });
+
+  if (response.status === 404 || response.status === 204) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(await parseErrorResponse(response));
+  }
+
+  const blob = await response.blob();
+  if (!blob || blob.size === 0) {
+    return null;
+  }
+
+  return blobToDataUrl(blob);
+};

--- a/frontend/src/services/waha.ts
+++ b/frontend/src/services/waha.ts
@@ -329,6 +329,10 @@ class WAHAService {
     return this.configPromise;
   }
 
+  async getResolvedConfig(): Promise<WAHAConfig> {
+    return this.loadConfig();
+  }
+
   private async fetchRemoteConfig(): Promise<WAHAConfig> {
     const endpoint = getApiUrl(`integrations/api-keys/${WAHA_INTEGRATION_ID}`);
     const response = await fetch(endpoint, {


### PR DESCRIPTION
## Summary
- add a WAHA session management helper that derives company-based session names, ensures the session exists, and fetches logout/QR data
- enhance the device link modal with session status feedback, logout, and QR regeneration controls tied to the new service
- expose the resolved WAHA configuration so the new helper can reuse the existing integration credentials

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc6b7c74908326978d015054fc9071