### PR TITLE
Normalize module identifiers for authorization

### DIFF
--- a/backend/src/constants/modules.ts
+++ b/backend/src/constants/modules.ts
@@ -48,6 +48,30 @@ export const SYSTEM_MODULE_SET = new Set<string>(
   SYSTEM_MODULES.map((module) => module.id)
 );
 
+export function normalizeModuleId(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  if (SYSTEM_MODULE_SET.has(trimmed)) {
+    return trimmed;
+  }
+
+  const lowerCased = trimmed.toLowerCase();
+
+  if (SYSTEM_MODULE_SET.has(lowerCased)) {
+    return lowerCased;
+  }
+
+  return null;
+}
+
 export function sanitizeModuleIds(values: unknown): string[] {
   if (values == null) {
     return [];
@@ -65,14 +89,15 @@ export function sanitizeModuleIds(values: unknown): string[] {
       throw new Error('modulos deve conter apenas strings válidas');
     }
 
-    const trimmed = value.trim();
-    if (!SYSTEM_MODULE_SET.has(trimmed)) {
+    const normalized = normalizeModuleId(value);
+
+    if (!normalized) {
       throw new Error(`Módulo desconhecido: ${value}`);
     }
 
-    if (!unique.has(trimmed)) {
-      unique.add(trimmed);
-      sanitized.push(trimmed);
+    if (!unique.has(normalized)) {
+      unique.add(normalized);
+      sanitized.push(normalized);
     }
   }
 

--- a/backend/src/services/moduleService.ts
+++ b/backend/src/services/moduleService.ts
@@ -1,5 +1,5 @@
 import pool from './db';
-import { sortModules } from '../constants/modules';
+import { normalizeModuleId, sortModules } from '../constants/modules';
 
 const normalizePerfilId = (value: unknown): number | null => {
   if (value == null) {
@@ -33,9 +33,22 @@ export const fetchPerfilModules = async (perfilId: number | null): Promise<strin
   const uniqueModules = new Set<string>();
 
   for (const row of result.rows as Array<{ modulo?: unknown }>) {
-    if (typeof row.modulo === 'string') {
-      uniqueModules.add(row.modulo);
+    if (typeof row.modulo !== 'string') {
+      continue;
     }
+
+    const trimmed = row.modulo.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    const normalized = normalizeModuleId(trimmed);
+    if (normalized) {
+      uniqueModules.add(normalized);
+      continue;
+    }
+
+    uniqueModules.add(trimmed);
   }
 
   return sortModules(Array.from(uniqueModules));


### PR DESCRIPTION
## Summary
- add a helper to normalize module identifiers before comparison
- ensure module permissions fetched from the database and enforced middleware use normalized IDs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc7412ac58832689681908f7d5d256