### PR TITLE
Fix auth validation to persist session after reload

### DIFF
--- a/frontend/src/features/auth/AuthProvider.tsx
+++ b/frontend/src/features/auth/AuthProvider.tsx
@@ -159,7 +159,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
     const validateToken = async () => {
       try {
-        const currentUser = await fetchCurrentUser();
+        const currentUser = await fetchCurrentUser(stored.token);
         setUser(currentUser);
         writeStoredAuth({ token: stored.token, user: currentUser, timestamp: Date.now() });
       } catch (error) {
@@ -234,7 +234,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   }, [handleLogout]);
 
   const refreshUser = useCallback(async () => {
-    const currentUser = await fetchCurrentUser();
+    const currentUser = await fetchCurrentUser(tokenRef.current ?? undefined);
     setUser(currentUser);
     if (tokenRef.current) {
       writeStoredAuth({ token: tokenRef.current, user: currentUser, timestamp: Date.now() });

--- a/frontend/src/features/auth/api.ts
+++ b/frontend/src/features/auth/api.ts
@@ -58,11 +58,17 @@ export const loginRequest = async (
   };
 };
 
-export const fetchCurrentUser = async (): Promise<AuthUser> => {
+export const fetchCurrentUser = async (token?: string): Promise<AuthUser> => {
+  const headers = new Headers({
+    Accept: "application/json",
+  });
+
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+
   const response = await fetch(getApiUrl("auth/me"), {
-    headers: {
-      Accept: "application/json",
-    },
+    headers,
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- ensure the current-user request can accept an explicit token so it always sends authorization headers
- use the stored token during startup validation and refreshes to avoid clearing the session on page reload

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc756948048326a35636bbc7d1c103