### PR TITLE
Handle perfil names and optional Datajud columns

### DIFF
--- a/backend/dist/constants/modules.js
+++ b/backend/dist/constants/modules.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SYSTEM_MODULE_SET = exports.SYSTEM_MODULES = void 0;
+exports.normalizeModuleId = normalizeModuleId;
 exports.sanitizeModuleIds = sanitizeModuleIds;
 exports.sortModules = sortModules;
 exports.SYSTEM_MODULES = [
@@ -39,6 +40,23 @@ exports.SYSTEM_MODULES = [
 ];
 const SYSTEM_MODULE_INDEX = new Map(exports.SYSTEM_MODULES.map((module, index) => [module.id, index]));
 exports.SYSTEM_MODULE_SET = new Set(exports.SYSTEM_MODULES.map((module) => module.id));
+function normalizeModuleId(value) {
+    if (typeof value !== 'string') {
+        return null;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return null;
+    }
+    if (exports.SYSTEM_MODULE_SET.has(trimmed)) {
+        return trimmed;
+    }
+    const lowerCased = trimmed.toLowerCase();
+    if (exports.SYSTEM_MODULE_SET.has(lowerCased)) {
+        return lowerCased;
+    }
+    return null;
+}
 function sanitizeModuleIds(values) {
     if (values == null) {
         return [];
@@ -52,13 +70,13 @@ function sanitizeModuleIds(values) {
         if (typeof value !== 'string') {
             throw new Error('modulos deve conter apenas strings válidas');
         }
-        const trimmed = value.trim();
-        if (!exports.SYSTEM_MODULE_SET.has(trimmed)) {
+        const normalized = normalizeModuleId(value);
+        if (!normalized) {
             throw new Error(`Módulo desconhecido: ${value}`);
         }
-        if (!unique.has(trimmed)) {
-            unique.add(trimmed);
-            sanitized.push(trimmed);
+        if (!unique.has(normalized)) {
+            unique.add(normalized);
+            sanitized.push(normalized);
         }
     }
     return sanitized;

--- a/backend/dist/routes/processoRoutes.js
+++ b/backend/dist/routes/processoRoutes.js
@@ -40,6 +40,12 @@ const router = (0, express_1.Router)();
  *         data_distribuicao:
  *           type: string
  *           format: date
+ *         datajud_tipo_justica:
+ *           type: string
+ *           nullable: true
+ *         datajud_alias:
+ *           type: string
+ *           nullable: true
  *         criado_em:
  *           type: string
  *           format: date-time
@@ -155,6 +161,10 @@ router.get('/processos/:id', processoController_1.getProcessoById);
  *                 type: string
  *               orgao_julgador:
  *                 type: string
+ *               datajud_tipo_justica:
+ *                 type: string
+ *               datajud_alias:
+ *                 type: string
  *               tipo:
  *                 type: string
  *               status:
@@ -183,6 +193,47 @@ router.get('/processos/:id', processoController_1.getProcessoById);
  *         description: Número de processo já cadastrado
  */
 router.post('/processos', processoController_1.createProcesso);
+/**
+ * @swagger
+ * /api/processos/{id}/movimentacoes:
+ *   get:
+ *     summary: Lista as movimentações do processo via Datajud
+ *     tags: [Processos]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *     responses:
+ *       200:
+ *         description: Movimentações obtidas com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   codigo:
+ *                     type: integer
+ *                     nullable: true
+ *                   nome:
+ *                     type: string
+ *                   descricao:
+ *                     type: string
+ *                   dataHora:
+ *                     type: string
+ *                     format: date-time
+ *                     nullable: true
+ *       400:
+ *         description: Identificador inválido
+ *       404:
+ *         description: Processo não encontrado
+ *       502:
+ *         description: Erro ao consultar a API pública do Datajud
+ */
+router.get('/processos/:id/movimentacoes', processoController_1.getProcessoMovimentacoes);
 /**
  * @swagger
  * /api/processos/{id}:

--- a/backend/dist/services/datajudService.js
+++ b/backend/dist/services/datajudService.js
@@ -1,0 +1,119 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.fetchDatajudMovimentacoes = void 0;
+const DATAJUD_BASE_URL = 'https://api-publica.datajud.cnj.jus.br';
+const DATAJUD_TIMEOUT_MS = 15000;
+const isNonEmptyString = (value) => typeof value === 'string' && value.trim() !== '';
+const resolveFetch = () => {
+    const fetchImpl = globalThis.fetch;
+    if (typeof fetchImpl !== 'function') {
+        throw new Error('Fetch API não disponível no ambiente atual');
+    }
+    return fetchImpl;
+};
+const formatComplemento = (complemento) => {
+    const nome = isNonEmptyString(complemento?.nome) ? complemento.nome.trim() : '';
+    const descricao = isNonEmptyString(complemento?.descricao)
+        ? complemento.descricao.trim()
+        : '';
+    if (nome && descricao) {
+        return `${nome} (${descricao})`;
+    }
+    if (nome) {
+        return nome;
+    }
+    if (descricao) {
+        return descricao;
+    }
+    return null;
+};
+const mapMovimento = (movimento) => {
+    const codigoRaw = movimento?.codigo;
+    let codigo = null;
+    if (typeof codigoRaw === 'number' && Number.isFinite(codigoRaw)) {
+        codigo = codigoRaw;
+    }
+    else if (typeof codigoRaw === 'string') {
+        const parsed = Number.parseInt(codigoRaw, 10);
+        codigo = Number.isNaN(parsed) ? null : parsed;
+    }
+    const nome = isNonEmptyString(movimento?.nome)
+        ? movimento.nome.trim()
+        : 'Movimentação';
+    const descricaoPreferida = isNonEmptyString(movimento?.descricao)
+        ? movimento.descricao.trim()
+        : null;
+    const complementos = Array.isArray(movimento?.complementosTabelados)
+        ? movimento.complementosTabelados
+            .map((item) => formatComplemento(item))
+            .filter((value) => Boolean(value))
+        : [];
+    const descricao = descricaoPreferida
+        ? descricaoPreferida
+        : complementos.length > 0
+            ? `${nome} · ${complementos.join(', ')}`
+            : nome;
+    const dataHora = isNonEmptyString(movimento?.dataHora)
+        ? movimento.dataHora
+        : null;
+    return {
+        codigo,
+        nome,
+        descricao,
+        dataHora,
+    };
+};
+const fetchDatajudMovimentacoes = async (alias, numeroProcesso) => {
+    const apiKey = process.env.DATAJUD_API_KEY;
+    if (!apiKey) {
+        throw new Error('DATAJUD_API_KEY não configurada');
+    }
+    const normalizedAlias = alias.replace(/^\/+|\/+$/g, '');
+    const url = `${DATAJUD_BASE_URL}/${normalizedAlias}/_search`;
+    const fetchImpl = resolveFetch();
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), DATAJUD_TIMEOUT_MS);
+    try {
+        const response = await fetchImpl(url, {
+            method: 'POST',
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+                Authorization: `APIKey ${apiKey}`,
+            },
+            body: JSON.stringify({
+                query: { match: { numeroProcesso } },
+                size: 1,
+            }),
+            signal: controller.signal,
+        });
+        if (!response.ok) {
+            throw new Error(`Falha ao consultar Datajud (HTTP ${response.status})`);
+        }
+        const json = (await response.json());
+        const hits = Array.isArray(json?.hits?.hits) ? json.hits?.hits : [];
+        const movimentos = hits
+            ?.map((hit) => hit?._source?.movimentos)
+            .find((collection) => Array.isArray(collection));
+        if (!Array.isArray(movimentos)) {
+            return [];
+        }
+        return movimentos
+            .map((movimento) => mapMovimento(movimento))
+            .sort((a, b) => {
+            const timeA = a.dataHora ? new Date(a.dataHora).getTime() : 0;
+            const timeB = b.dataHora ? new Date(b.dataHora).getTime() : 0;
+            return timeB - timeA;
+        });
+    }
+    catch (error) {
+        if (error?.name === 'AbortError') {
+            throw new Error('Tempo excedido ao consultar a API pública do Datajud');
+        }
+        throw error;
+    }
+    finally {
+        clearTimeout(timeout);
+    }
+};
+exports.fetchDatajudMovimentacoes = fetchDatajudMovimentacoes;

--- a/backend/dist/services/moduleService.js
+++ b/backend/dist/services/moduleService.js
@@ -21,8 +21,34 @@ const normalizePerfilId = (value) => {
     }
     return null;
 };
+const resolvePerfilId = async (perfil) => {
+    const normalizedId = normalizePerfilId(perfil);
+    if (normalizedId != null) {
+        return normalizedId;
+    }
+    if (typeof perfil !== 'string') {
+        return null;
+    }
+    const trimmedPerfil = perfil.trim();
+    if (!trimmedPerfil) {
+        return null;
+    }
+    const result = await db_1.default.query('SELECT id FROM public.perfis WHERE LOWER(nome) = LOWER($1) LIMIT 1', [trimmedPerfil]);
+    if (result.rowCount === 0) {
+        return null;
+    }
+    const value = result.rows[0]?.id;
+    if (typeof value === 'number' && Number.isInteger(value)) {
+        return value;
+    }
+    if (value == null) {
+        return null;
+    }
+    const parsed = Number.parseInt(String(value), 10);
+    return Number.isFinite(parsed) ? parsed : null;
+};
 const fetchPerfilModules = async (perfil) => {
-    const perfilId = normalizePerfilId(perfil);
+    const perfilId = await resolvePerfilId(perfil);
     if (perfilId == null) {
         return [];
     }

--- a/backend/dist/sql/processos.sql
+++ b/backend/dist/sql/processos.sql
@@ -12,6 +12,8 @@ CREATE TABLE IF NOT EXISTS public.processos (
   jurisdicao TEXT,
   advogado_responsavel TEXT,
   data_distribuicao TIMESTAMP WITHOUT TIME ZONE,
+  datajud_tipo_justica VARCHAR(100),
+  datajud_alias VARCHAR(100),
   criado_em TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
   atualizado_em TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW()
 );


### PR DESCRIPTION
## Summary
- allow module authorization to resolve perfil names when only the textual label is stored on usuarios
- guard processo queries, inserts and updates so they only reference Datajud columns when those columns exist in the database
- fall back to null Datajud fields and updated swagger definitions to avoid runtime errors on older schemas

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc7bb941988326975130cf630da1f8