### PR TITLE
Fix conversation route decoding

### DIFF
--- a/frontend/src/pages/Conversas.tsx
+++ b/frontend/src/pages/Conversas.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { WhatsAppLayout } from "../components/waha";
 
@@ -6,10 +6,22 @@ const Conversas = () => {
   const navigate = useNavigate();
   const { conversationId } = useParams<{ conversationId?: string }>();
 
+  const decodedConversationId = useMemo(() => {
+    if (!conversationId) {
+      return undefined;
+    }
+    try {
+      return decodeURIComponent(conversationId);
+    } catch (error) {
+      console.warn("Falha ao decodificar o identificador da conversa", error);
+      return conversationId;
+    }
+  }, [conversationId]);
+
   const handleRouteChange = useCallback(
     (nextConversationId: string | null) => {
       if (nextConversationId) {
-        if (nextConversationId === conversationId) {
+        if (nextConversationId === decodedConversationId) {
           return;
         }
         const encodedId = encodeURIComponent(nextConversationId);
@@ -17,18 +29,18 @@ const Conversas = () => {
         return;
       }
 
-      if (conversationId) {
+      if (decodedConversationId) {
         navigate("/conversas");
       }
     },
-    [conversationId, navigate],
+    [decodedConversationId, navigate],
   );
 
   return (
     <div className="h-full min-h-0 flex flex-1 flex-col overflow-hidden">
 
       <WhatsAppLayout
-        conversationIdFromRoute={conversationId}
+        conversationIdFromRoute={decodedConversationId}
         onConversationRouteChange={handleRouteChange}
       />
     </div>


### PR DESCRIPTION
## Summary
- decode the conversation id from the route before passing it to the WhatsApp layout
- keep the router navigation logic in sync with the decoded identifier to avoid redundant redirects

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc84f51e5c8326b4955d43d81f7295