### PR TITLE
Add WAHA disconnect controls and device modal access

### DIFF
--- a/frontend/src/components/waha/SessionStatus.tsx
+++ b/frontend/src/components/waha/SessionStatus.tsx
@@ -1,16 +1,35 @@
-import { RefreshCw, Wifi, WifiOff, AlertCircle, CheckCircle, Clock } from 'lucide-react';
+import {
+  RefreshCw,
+  Wifi,
+  WifiOff,
+  AlertCircle,
+  CheckCircle,
+  Clock,
+  LogOut,
+  QrCode,
+  Loader2,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { SessionStatus as SessionStatusType } from '@/types/waha';
 
 interface SessionStatusProps {
   status: SessionStatusType | null;
   onRefresh: () => void;
+  onDisconnect?: () => void;
+  isDisconnecting?: boolean;
+  onManageDevice?: () => void;
 }
 
-export const SessionStatus = ({ status, onRefresh }: SessionStatusProps) => {
+export const SessionStatus = ({
+  status,
+  onRefresh,
+  onDisconnect,
+  isDisconnecting = false,
+  onManageDevice,
+}: SessionStatusProps) => {
   const getStatusIcon = () => {
     if (!status) return <WifiOff className="w-4 h-4" />;
-    
+
     switch (status.status) {
       case 'WORKING':
         return <CheckCircle className="w-4 h-4 text-success" />;
@@ -62,21 +81,52 @@ export const SessionStatus = ({ status, onRefresh }: SessionStatusProps) => {
   };
 
   return (
-    <div className="sticky top-0 z-40 flex items-center justify-between gap-3 bg-whatsapp px-4 py-2 text-foreground shadow-soft dark:text-white">
+    <div className="sticky top-0 z-40 flex flex-wrap items-center justify-between gap-3 bg-whatsapp px-4 py-2 text-foreground shadow-soft dark:text-white">
       <div className="flex items-center gap-2 text-sm">
         {getStatusIcon()}
         <span className={`font-semibold tracking-wide ${getStatusColor()}`}>{getStatusText()}</span>
       </div>
 
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={onRefresh}
-        className="h-8 px-3 text-foreground hover:bg-accent/60 hover:text-foreground dark:text-white dark:hover:bg-white/10 dark:hover:text-white"
-      >
-        <RefreshCw className="h-4 w-4" />
-        <span className="text-xs font-medium sm:text-sm">sincronizar conversas</span>
-      </Button>
+      <div className="flex flex-wrap items-center gap-2">
+        {onManageDevice && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onManageDevice}
+            className="h-8 px-3 text-foreground hover:bg-accent/60 hover:text-foreground dark:border-white/30 dark:text-white dark:hover:bg-white/10"
+          >
+            <QrCode className="h-4 w-4" />
+            <span className="text-xs font-medium sm:text-sm">ver QR Code</span>
+          </Button>
+        )}
+
+        {onDisconnect && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onDisconnect}
+            disabled={isDisconnecting}
+            className="h-8 px-3 text-foreground hover:bg-accent/60 hover:text-foreground dark:border-white/30 dark:text-white dark:hover:bg-white/10"
+          >
+            {isDisconnecting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <LogOut className="h-4 w-4" />
+            )}
+            <span className="text-xs font-medium sm:text-sm">desconectar</span>
+          </Button>
+        )}
+
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onRefresh}
+          className="h-8 px-3 text-foreground hover:bg-accent/60 hover:text-foreground dark:text-white dark:hover:bg-white/10 dark:hover:text-white"
+        >
+          <RefreshCw className="h-4 w-4" />
+          <span className="text-xs font-medium sm:text-sm">sincronizar conversas</span>
+        </Button>
+      </div>
     </div>
   );
 };

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -29,7 +29,6 @@ import type {
 } from "../types";
 import { ChatInput } from "./ChatInput";
 import { MessageViewport } from "./MessageViewport";
-import { DeviceLinkModal } from "./DeviceLinkModal";
 import styles from "./ChatWindow.module.css";
 import { fetchChatResponsibles, fetchChatTags, type ChatResponsibleOption } from "../services/chatApi";
 
@@ -82,6 +81,7 @@ interface ChatWindowProps {
   onLoadOlder: () => Promise<Message[]>;
   onUpdateConversation: (conversationId: string, changes: UpdateConversationPayload) => Promise<void>;
   isUpdatingConversation?: boolean;
+  onOpenDeviceLinkModal?: () => void;
 }
 
 export const ChatWindow = ({
@@ -94,10 +94,10 @@ export const ChatWindow = ({
   onLoadOlder,
   onUpdateConversation,
   isUpdatingConversation = false,
+  onOpenDeviceLinkModal,
 }: ChatWindowProps) => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [detailsOpen, setDetailsOpen] = useState(false);
-  const [deviceModalOpen, setDeviceModalOpen] = useState(false);
   const [stickToBottom, setStickToBottom] = useState(true);
   const [availableTags, setAvailableTags] = useState<string[]>([]);
   const [isLoadingTags, setIsLoadingTags] = useState(false);
@@ -558,7 +558,7 @@ export const ChatWindow = ({
                   <button
                     type="button"
                     onClick={() => {
-                      setDeviceModalOpen(true);
+                      onOpenDeviceLinkModal?.();
                       setMenuOpen(false);
                     }}
                     role="menuitem"
@@ -593,7 +593,6 @@ export const ChatWindow = ({
         <div className={styles.inputContainer}>
           <ChatInput onSend={handleSend} disabled={isLoading} />
         </div>
-        <DeviceLinkModal open={deviceModalOpen} onClose={() => setDeviceModalOpen(false)} />
       </div>
       <aside
         id={detailsPanelId}

--- a/frontend/src/features/chat/components/DeviceLinkModal.tsx
+++ b/frontend/src/features/chat/components/DeviceLinkModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import clsx from "clsx";
 import { Smartphone, QrCode, ShieldCheck, RefreshCw, LogOut } from "lucide-react";
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -117,7 +117,7 @@ export const DeviceLinkModal = ({ open, onClose }: DeviceLinkModalProps) => {
     isError: isQrError,
     error: qrError,
     refetch: refetchQr,
-    remove: clearQr,
+    remove: removeQr,
     dataUpdatedAt: qrUpdatedAt,
   } = useQuery({
     queryKey: ["waha", "session", sessionName, "qr"],
@@ -126,6 +126,12 @@ export const DeviceLinkModal = ({ open, onClose }: DeviceLinkModalProps) => {
     staleTime: 0,
     gcTime: 0,
   });
+
+  const clearQr = useCallback(() => {
+    if (typeof removeQr === "function") {
+      removeQr();
+    }
+  }, [removeQr]);
 
   const logoutMutation = useMutation({
     mutationFn: async () => {


### PR DESCRIPTION
## Summary
- add WAHA session toolbar controls to disconnect the device and open the QR modal globally
- centralize DeviceLinkModal state in the layout so it can be opened from the session controls or chat menu
- refresh chats when the session reconnects and harden QR cleanup to avoid runtime errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc8a708b408326bd07431d5a8380f7