### PR TITLE
Improve module normalization for limited profiles

### DIFF
--- a/backend/dist/constants/modules.js
+++ b/backend/dist/constants/modules.js
@@ -55,6 +55,15 @@ function normalizeModuleId(value) {
     if (exports.SYSTEM_MODULE_SET.has(lowerCased)) {
         return lowerCased;
     }
+    const sanitized = trimmed
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[^\p{L}\p{N}]+/gu, '-')
+        .replace(/^-+|-+$/g, '')
+        .toLowerCase();
+    if (sanitized && exports.SYSTEM_MODULE_SET.has(sanitized)) {
+        return sanitized;
+    }
     return null;
 }
 function sanitizeModuleIds(values) {

--- a/backend/src/constants/modules.ts
+++ b/backend/src/constants/modules.ts
@@ -69,6 +69,17 @@ export function normalizeModuleId(value: unknown): string | null {
     return lowerCased;
   }
 
+  const sanitized = trimmed
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^\p{L}\p{N}]+/gu, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+
+  if (sanitized && SYSTEM_MODULE_SET.has(sanitized)) {
+    return sanitized;
+  }
+
   return null;
 }
 

--- a/backend/tests/moduleConstants.test.ts
+++ b/backend/tests/moduleConstants.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { normalizeModuleId } from '../src/constants/modules';
+
+test('normalizeModuleId reconhece identificadores com acentos e espaços', () => {
+  assert.equal(
+    normalizeModuleId('Configurações - Parâmetros'),
+    'configuracoes-parametros'
+  );
+});
+
+test('normalizeModuleId reconhece identificadores com múltiplos separadores', () => {
+  assert.equal(
+    normalizeModuleId('Configurações__Parâmetros'),
+    'configuracoes-parametros'
+  );
+});
+
+test('normalizeModuleId mantém valores já normalizados', () => {
+  assert.equal(normalizeModuleId('tarefas'), 'tarefas');
+});
+
+test('normalizeModuleId retorna null para módulos desconhecidos', () => {
+  assert.equal(normalizeModuleId('modulo-inexistente'), null);
+});


### PR DESCRIPTION
## Summary
- expand module normalization to strip accents and symbols before matching known modules so user permissions stored with display names are recognized
- add regression tests covering normalization of accented values and unexpected separators

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68cc8bac0e6c832685fb78f2a4f5c26d