### PR TITLE
Normalize Datajud aliases when syncing movimentações

### DIFF
--- a/backend/dist/controllers/processoController.js
+++ b/backend/dist/controllers/processoController.js
@@ -21,6 +21,21 @@ const normalizeLowercase = (value) => {
     const normalized = normalizeString(value);
     return normalized ? normalized.toLowerCase() : null;
 };
+const normalizeDatajudAliasValue = (value) => {
+    const normalized = normalizeLowercase(value);
+    if (!normalized) {
+        return null;
+    }
+    const sanitized = normalized.replace(/^\/+/g, '').replace(/\/+$/g, '').replace(/\s+/g, '_');
+    if (!sanitized) {
+        return null;
+    }
+    if (sanitized.startsWith('api_publica_')) {
+        return sanitized;
+    }
+    const withoutPrefix = sanitized.replace(/^api_publica_/, '');
+    return `api_publica_${withoutPrefix}`;
+};
 const normalizeDate = (value) => {
     if (value === null || value === undefined) {
         return null;
@@ -118,7 +133,7 @@ const mapProcessoRow = (row) => ({
     advogado_responsavel: row.advogado_responsavel,
     data_distribuicao: row.data_distribuicao,
     datajud_tipo_justica: row.datajud_tipo_justica ?? null,
-    datajud_alias: row.datajud_alias ?? null,
+    datajud_alias: normalizeDatajudAliasValue(row.datajud_alias),
     criado_em: row.criado_em,
     atualizado_em: row.atualizado_em,
     cliente: row.cliente_id
@@ -278,7 +293,7 @@ const createProcesso = async (req, res) => {
         ? normalizeLowercase(datajud_tipo_justica)
         : null;
     const datajudAliasValue = columnInfo.hasDatajudAlias
-        ? normalizeLowercase(datajud_alias)
+        ? normalizeDatajudAliasValue(datajud_alias)
         : null;
     const missingDatajudFields = [];
     if (columnInfo.hasDatajudTipoJustica && !datajudTipoJusticaValue) {
@@ -390,7 +405,7 @@ const updateProcesso = async (req, res) => {
         ? normalizeLowercase(datajud_tipo_justica)
         : null;
     const datajudAliasValue = columnInfo.hasDatajudAlias
-        ? normalizeLowercase(datajud_alias)
+        ? normalizeDatajudAliasValue(datajud_alias)
         : null;
     const missingDatajudFields = [];
     if (columnInfo.hasDatajudTipoJustica && !datajudTipoJusticaValue) {
@@ -496,7 +511,7 @@ const getProcessoMovimentacoes = async (req, res) => {
         }
         const row = result.rows[0];
         const numeroProcesso = normalizeString(row.numero);
-        const datajudAlias = normalizeString(row.datajud_alias);
+        const datajudAlias = normalizeDatajudAliasValue(row.datajud_alias);
         if (!numeroProcesso || !datajudAlias) {
             return res.json([]);
         }

--- a/backend/dist/services/datajudService.js
+++ b/backend/dist/services/datajudService.js
@@ -68,8 +68,18 @@ const fetchDatajudMovimentacoes = async (alias, numeroProcesso) => {
     if (!apiKey) {
         throw new Error('DATAJUD_API_KEY não configurada');
     }
-    const normalizedAlias = alias.replace(/^\/+|\/+$/g, '');
-    const url = `${DATAJUD_BASE_URL}/${normalizedAlias}/_search`;
+    const normalizedAlias = alias
+        .trim()
+        .toLowerCase()
+        .replace(/^\/+|\/+$/g, '')
+        .replace(/\s+/g, '_');
+    if (!normalizedAlias) {
+        throw new Error('Alias do Datajud inválido para consulta');
+    }
+    const aliasWithPrefix = normalizedAlias.startsWith('api_publica_')
+        ? normalizedAlias
+        : `api_publica_${normalizedAlias.replace(/^api_publica_/, '')}`;
+    const url = `${DATAJUD_BASE_URL}/${aliasWithPrefix}/_search`;
     const fetchImpl = resolveFetch();
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), DATAJUD_TIMEOUT_MS);

--- a/backend/src/controllers/processoController.ts
+++ b/backend/src/controllers/processoController.ts
@@ -22,6 +22,25 @@ const normalizeLowercase = (value: unknown): string | null => {
   return normalized ? normalized.toLowerCase() : null;
 };
 
+const normalizeDatajudAliasValue = (value: unknown): string | null => {
+  const normalized = normalizeLowercase(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const sanitized = normalized.replace(/^\/+/g, '').replace(/\/+$/g, '').replace(/\s+/g, '_');
+  if (!sanitized) {
+    return null;
+  }
+
+  if (sanitized.startsWith('api_publica_')) {
+    return sanitized;
+  }
+
+  const withoutPrefix = sanitized.replace(/^api_publica_/, '');
+  return `api_publica_${withoutPrefix}`;
+};
+
 const normalizeDate = (value: unknown): string | null => {
   if (value === null || value === undefined) {
     return null;
@@ -146,7 +165,7 @@ const mapProcessoRow = (row: any): Processo => ({
   advogado_responsavel: row.advogado_responsavel,
   data_distribuicao: row.data_distribuicao,
   datajud_tipo_justica: row.datajud_tipo_justica ?? null,
-  datajud_alias: row.datajud_alias ?? null,
+  datajud_alias: normalizeDatajudAliasValue(row.datajud_alias),
   criado_em: row.criado_em,
   atualizado_em: row.atualizado_em,
   cliente: row.cliente_id
@@ -345,7 +364,7 @@ export const createProcesso = async (req: Request, res: Response) => {
     ? normalizeLowercase(datajud_tipo_justica)
     : null;
   const datajudAliasValue = columnInfo.hasDatajudAlias
-    ? normalizeLowercase(datajud_alias)
+    ? normalizeDatajudAliasValue(datajud_alias)
     : null;
 
   const missingDatajudFields: string[] = [];
@@ -498,7 +517,7 @@ export const updateProcesso = async (req: Request, res: Response) => {
     ? normalizeLowercase(datajud_tipo_justica)
     : null;
   const datajudAliasValue = columnInfo.hasDatajudAlias
-    ? normalizeLowercase(datajud_alias)
+    ? normalizeDatajudAliasValue(datajud_alias)
     : null;
 
   const missingDatajudFields: string[] = [];
@@ -638,7 +657,7 @@ export const getProcessoMovimentacoes = async (req: Request, res: Response) => {
     const row = result.rows[0] as { numero: string | null; datajud_alias: string | null };
 
     const numeroProcesso = normalizeString(row.numero);
-    const datajudAlias = normalizeString(row.datajud_alias);
+    const datajudAlias = normalizeDatajudAliasValue(row.datajud_alias);
 
     if (!numeroProcesso || !datajudAlias) {
       return res.json([]);

--- a/backend/src/services/datajudService.ts
+++ b/backend/src/services/datajudService.ts
@@ -120,8 +120,21 @@ export const fetchDatajudMovimentacoes = async (
     throw new Error('DATAJUD_API_KEY não configurada');
   }
 
-  const normalizedAlias = alias.replace(/^\/+|\/+$/g, '');
-  const url = `${DATAJUD_BASE_URL}/${normalizedAlias}/_search`;
+  const normalizedAlias = alias
+    .trim()
+    .toLowerCase()
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/\s+/g, '_');
+
+  if (!normalizedAlias) {
+    throw new Error('Alias do Datajud inválido para consulta');
+  }
+
+  const aliasWithPrefix = normalizedAlias.startsWith('api_publica_')
+    ? normalizedAlias
+    : `api_publica_${normalizedAlias.replace(/^api_publica_/, '')}`;
+
+  const url = `${DATAJUD_BASE_URL}/${aliasWithPrefix}/_search`;
 
   const fetchImpl = resolveFetch();
   const controller = new AbortController();

--- a/frontend/src/data/datajud.ts
+++ b/frontend/src/data/datajud.ts
@@ -138,12 +138,38 @@ export const DATAJUD_CATEGORIA_MAP = new Map(
   DATAJUD_CATEGORIAS.map((categoria) => [categoria.id, categoria.nome] as const),
 );
 
-export const getDatajudTribunalLabel = (alias: string | null | undefined) => {
+export const normalizeDatajudAlias = (
+  alias: string | null | undefined,
+): string | null => {
   if (!alias) {
     return null;
   }
 
-  const tribunal = DATAJUD_TRIBUNAL_MAP.get(alias);
+  const sanitized = alias
+    .trim()
+    .toLowerCase()
+    .replace(/^\/+|\/+$/g, "")
+    .replace(/\s+/g, "_");
+
+  if (!sanitized) {
+    return null;
+  }
+
+  if (sanitized.startsWith("api_publica_")) {
+    return sanitized;
+  }
+
+  const withoutPrefix = sanitized.replace(/^api_publica_/, "");
+  return `api_publica_${withoutPrefix}`;
+};
+
+export const getDatajudTribunalLabel = (alias: string | null | undefined) => {
+  const normalizedAlias = normalizeDatajudAlias(alias);
+  if (!normalizedAlias) {
+    return null;
+  }
+
+  const tribunal = DATAJUD_TRIBUNAL_MAP.get(normalizedAlias);
   return tribunal ? tribunal.nome : null;
 };
 

--- a/frontend/src/pages/Processos.tsx
+++ b/frontend/src/pages/Processos.tsx
@@ -52,6 +52,7 @@ import {
   DATAJUD_TRIBUNAIS_BY_CATEGORIA,
   getDatajudCategoriaLabel,
   getDatajudTribunalLabel,
+  normalizeDatajudAlias,
 } from "@/data/datajud";
 
 interface ProcessoCliente {
@@ -257,7 +258,7 @@ const mapApiProcessoToProcesso = (processo: ApiProcesso): Processo => {
     "Não informado";
   const rawCategoria = processo.datajud_tipo_justica?.trim() || null;
   const categoriaLabel = getDatajudCategoriaLabel(rawCategoria);
-  const datajudAlias = processo.datajud_alias?.trim() || null;
+  const datajudAlias = normalizeDatajudAlias(processo.datajud_alias);
   const datajudTribunal = getDatajudTribunalLabel(datajudAlias);
 
   return {

--- a/frontend/src/pages/VisualizarProcesso.tsx
+++ b/frontend/src/pages/VisualizarProcesso.tsx
@@ -30,6 +30,7 @@ import { getApiUrl } from "@/lib/api";
 import {
   getDatajudCategoriaLabel,
   getDatajudTribunalLabel,
+  normalizeDatajudAlias,
 } from "@/data/datajud";
 
 interface ApiProcessoCliente {
@@ -226,7 +227,7 @@ const mapApiProcessoToDetalhes = (processo: ApiProcessoResponse): ProcessoDetalh
     "Não informado";
   const dataDistribuicao = normalizeString(processo.data_distribuicao) || null;
   const datajudTipoJustica = normalizeString(processo.datajud_tipo_justica) || null;
-  const datajudAlias = normalizeString(processo.datajud_alias) || null;
+  const datajudAlias = normalizeDatajudAlias(processo.datajud_alias);
   const datajudCategoriaLabel = getDatajudCategoriaLabel(datajudTipoJustica);
   const datajudTribunal = getDatajudTribunalLabel(datajudAlias);
   const clienteResumo = processo.cliente ?? null;


### PR DESCRIPTION
## Summary
- normalize Datajud aliases on the server before persisting, serializing or syncing movimentações
- harden the Datajud service by lowercasing, trimming and prefixing aliases prior to calling the CNJ API
- expose a shared alias normalizer on the frontend so existing processos display the correct tribunal label and allow synchronization

## Testing
- npm run build (backend)
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68cc89eb95948326976cf0af9dc1b04d