### PR TITLE
Adjust WhatsApp QR code modal layout

### DIFF
--- a/frontend/src/features/chat/components/DeviceLinkModal.module.css
+++ b/frontend/src/features/chat/components/DeviceLinkModal.module.css
@@ -6,6 +6,13 @@
   align-items: start;
 }
 
+.modalContent {
+  max-width: min(1100px, calc(100vw - 3rem));
+  width: min(1100px, calc(100vw - 3rem));
+  max-height: min(92vh, 880px);
+  overflow: auto;
+}
+
 .integrationPanel {
   display: flex;
   flex-direction: column;
@@ -332,6 +339,10 @@
 @media (max-width: 900px) {
   .container {
     grid-template-columns: 1fr;
+  }
+
+  .modalContent {
+    width: min(100%, calc(100vw - 3rem));
   }
 
   .integrationPanel {

--- a/frontend/src/features/chat/components/DeviceLinkModal.tsx
+++ b/frontend/src/features/chat/components/DeviceLinkModal.tsx
@@ -207,7 +207,12 @@ export const DeviceLinkModal = ({ open, onClose }: DeviceLinkModalProps) => {
       : "O QR Code será exibido aqui quando a sessão estiver aguardando uma nova autenticação.";
 
   return (
-    <Modal open={open} onClose={onClose} ariaLabel="Conectar um novo dispositivo">
+    <Modal
+      open={open}
+      onClose={onClose}
+      ariaLabel="Conectar um novo dispositivo"
+      contentClassName={styles.modalContent}
+    >
       <div className={styles.container}>
         <section className={styles.integrationPanel} aria-labelledby="waha-integration-title">
           <header className={styles.integrationHeader}>

--- a/frontend/src/features/chat/components/Modal.module.css
+++ b/frontend/src/features/chat/components/Modal.module.css
@@ -18,6 +18,8 @@
   max-width: min(640px, 100%);
   width: 100%;
   outline: none;
+  max-height: min(92vh, 720px);
+  overflow-y: auto;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/features/chat/components/Modal.tsx
+++ b/frontend/src/features/chat/components/Modal.tsx
@@ -1,5 +1,6 @@
 import type { MouseEvent, PropsWithChildren } from "react";
 import { useEffect, useRef } from "react";
+import clsx from "clsx";
 import { createPortal } from "react-dom";
 import styles from "./Modal.module.css";
 
@@ -7,6 +8,7 @@ interface ModalProps {
   open: boolean;
   ariaLabel: string;
   onClose: () => void;
+  contentClassName?: string;
 }
 
 const focusableSelectors = [
@@ -18,7 +20,13 @@ const focusableSelectors = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(",");
 
-export const Modal = ({ open, ariaLabel, onClose, children }: PropsWithChildren<ModalProps>) => {
+export const Modal = ({
+  open,
+  ariaLabel,
+  onClose,
+  contentClassName,
+  children,
+}: PropsWithChildren<ModalProps>) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const lastFocusedElementRef = useRef<HTMLElement | null>(null);
 
@@ -79,7 +87,7 @@ export const Modal = ({ open, ariaLabel, onClose, children }: PropsWithChildren<
     <div className={styles.overlay} role="presentation" onMouseDown={handleBackdropClick}>
       <div
         ref={containerRef}
-        className={styles.content}
+        className={clsx(styles.content, contentClassName)}
         role="dialog"
         aria-modal="true"
         aria-label={ariaLabel}


### PR DESCRIPTION
## Summary
- allow the shared Modal component to accept a custom content class and ensure tall dialogs scroll
- expand the WhatsApp device link modal so the QR code section and instructions fit within the viewport

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc8edc2dfc8326914fca764795cc20