### PR TITLE
Reset CNJ sync state when switching process detail page

### DIFF
--- a/frontend/src/pages/VisualizarProcesso.tsx
+++ b/frontend/src/pages/VisualizarProcesso.tsx
@@ -343,6 +343,14 @@ export default function VisualizarProcesso() {
   const [autoSyncAttempted, setAutoSyncAttempted] = useState(false);
 
   useEffect(() => {
+    setMovimentacoes([]);
+    setMovimentacoesError(null);
+    setMovimentacoesLoading(false);
+    setLastSync(null);
+    setAutoSyncAttempted(false);
+  }, [processoId]);
+
+  useEffect(() => {
     let cancelled = false;
 
     const fetchProcesso = async () => {


### PR DESCRIPTION
## Summary
- reset the CNJ movement synchronization state when navigating between process details so each view triggers a fresh DataJud fetch

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc8fb47c38832680a2d62d38d4fea6