### PR TITLE
Fix API base URL detection for production logins

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,11 @@
-const rawEnvApiUrl = (import.meta.env.VITE_API_URL as string | undefined)?.trim();
+const envApiUrlCandidates = [
+  import.meta.env.VITE_API_URL as string | undefined,
+  import.meta.env.VITE_API_BASE_URL as string | undefined,
+];
+
+const rawEnvApiUrl = envApiUrlCandidates
+  .map((value) => value?.trim())
+  .find((value): value is string => Boolean(value?.length));
 const isDevEnvironment = Boolean(import.meta.env.DEV);
 
 function normalizeBaseUrl(url: string): string {


### PR DESCRIPTION
## Summary
- include `VITE_API_BASE_URL` when resolving the API base URL used by the frontend
- allow production deployments that only define this variable to reach the backend endpoints

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68cc92010ff88326bc01702f14d49b21