### PR TITLE
Render device linking flow in empty chat state

### DIFF
--- a/frontend/src/features/chat/components/ChatWindow.module.css
+++ b/frontend/src/features/chat/components/ChatWindow.module.css
@@ -697,19 +697,17 @@
   background: hsl(var(--primary-hover));
 }
 
-.placeholder {
+.deviceLinkPlaceholder {
   flex: 1;
-  display: grid;
-  place-items: center;
-  text-align: center;
-  color: hsl(var(--muted-foreground));
-  padding: 2rem;
-  gap: 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  overflow: auto;
+  padding: clamp(1.5rem, 4vw, 3rem);
 }
 
-.placeholder h3 {
-  font-size: 1.5rem;
-  font-weight: 700;
+.deviceLinkContent {
+  width: 100%;
 }
 
 .loadingOverlay {

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -30,6 +30,7 @@ import type {
 import { ChatInput } from "./ChatInput";
 import { MessageViewport } from "./MessageViewport";
 import styles from "./ChatWindow.module.css";
+import { DeviceLinkContent } from "./DeviceLinkModal";
 import { fetchChatResponsibles, fetchChatTags, type ChatResponsibleOption } from "../services/chatApi";
 
 const CLIENT_SUGGESTIONS = [
@@ -416,26 +417,19 @@ export const ChatWindow = ({
     });
   };
 
-  const placeholderContent = useMemo(
-    () => (
-      <div className={styles.placeholder}>
-        <div>
-          <h3>Selecione uma conversa</h3>
-          <p>
-            Utilize a barra lateral para escolher um contato, iniciar um novo chat ou pesquisar processos.
-            Os atalhos Ctrl+K e Ctrl+N aceleram sua navegação.
-          </p>
-        </div>
-      </div>
-    ),
-    [],
-  );
-
   if (!conversation) {
     return (
       <div className={styles.wrapper}>
         <div className={styles.mainColumn}>
-          <div className={styles.viewportWrapper}>{placeholderContent}</div>
+          <div className={styles.viewportWrapper}>
+            <div className={styles.deviceLinkPlaceholder}>
+              <DeviceLinkContent
+                isActive
+                layout="inline"
+                className={styles.deviceLinkContent}
+              />
+            </div>
+          </div>
         </div>
       </div>
     );

--- a/frontend/src/features/chat/components/DeviceLinkModal.module.css
+++ b/frontend/src/features/chat/components/DeviceLinkModal.module.css
@@ -6,6 +6,19 @@
   align-items: start;
 }
 
+.modalContent {
+  max-width: min(1100px, calc(100vw - 3rem));
+  width: min(1100px, calc(100vw - 3rem));
+  max-height: min(92vh, 880px);
+  overflow: auto;
+}
+
+.inlineContainer {
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+}
+
 .integrationPanel {
   display: flex;
   flex-direction: column;
@@ -332,6 +345,10 @@
 @media (max-width: 900px) {
   .container {
     grid-template-columns: 1fr;
+  }
+
+  .modalContent {
+    width: min(100%, calc(100vw - 3rem));
   }
 
   .integrationPanel {

--- a/frontend/src/features/chat/components/DeviceLinkModal.tsx
+++ b/frontend/src/features/chat/components/DeviceLinkModal.tsx
@@ -16,11 +16,6 @@ import {
 } from "../services/deviceLinkingApi";
 import styles from "./DeviceLinkModal.module.css";
 
-interface DeviceLinkModalProps {
-  open: boolean;
-  onClose: () => void;
-}
-
 type SessionStatusTone = "connected" | "pending" | "error" | "unknown";
 
 const STATUS_INFO: Record<string, { label: string; description: string; tone: SessionStatusTone }> = {
@@ -63,7 +58,17 @@ const timeFormatter = new Intl.DateTimeFormat("pt-BR", {
   minute: "2-digit",
 });
 
-export const DeviceLinkModal = ({ open, onClose }: DeviceLinkModalProps) => {
+interface DeviceLinkContentProps {
+  isActive: boolean;
+  layout?: "modal" | "inline";
+  className?: string;
+}
+
+export const DeviceLinkContent = ({
+  isActive,
+  layout = "modal",
+  className,
+}: DeviceLinkContentProps) => {
   const { toast } = useToast();
   const steps = useMemo(
     () => [
@@ -75,14 +80,12 @@ export const DeviceLinkModal = ({ open, onClose }: DeviceLinkModalProps) => {
       },
       {
         title: "Escaneie o QR Code",
-        description:
-          "Utilize a câmera do aparelho para ler o código exibido no painel do WAHA.",
+        description: "Utilize a câmera do aparelho para ler o código exibido no painel do WAHA.",
         icon: <QrCode size={18} aria-hidden="true" />,
       },
       {
         title: "Sincronização automática",
-        description:
-          "Aguarde alguns instantes até que o WAHA sincronize as conversas com o JusConnect.",
+        description: "Aguarde alguns instantes até que o WAHA sincronize as conversas com o JusConnect.",
         icon: <ShieldCheck size={18} aria-hidden="true" />,
       },
       {
@@ -98,7 +101,7 @@ export const DeviceLinkModal = ({ open, onClose }: DeviceLinkModalProps) => {
   const companyQuery = useQuery({
     queryKey: ["companies", "primary"],
     queryFn: fetchPreferredCompany,
-    enabled: open,
+    enabled: isActive,
   });
 
   const companyName = companyQuery.data?.name;
@@ -107,7 +110,7 @@ export const DeviceLinkModal = ({ open, onClose }: DeviceLinkModalProps) => {
   const sessionQuery = useQuery<DeviceSessionInfo>({
     queryKey: ["waha", "session", sessionName],
     queryFn: () => ensureDeviceSession(sessionName, companyName),
-    enabled: open && !companyQuery.isLoading,
+    enabled: isActive && !companyQuery.isLoading,
     retry: false,
   });
 
@@ -159,7 +162,7 @@ export const DeviceLinkModal = ({ open, onClose }: DeviceLinkModalProps) => {
   });
 
   useEffect(() => {
-    if (!open) {
+    if (!isActive) {
       clearQr();
       return;
     }
@@ -169,7 +172,13 @@ export const DeviceLinkModal = ({ open, onClose }: DeviceLinkModalProps) => {
     } else if (qrCode) {
       clearQr();
     }
-  }, [open, sessionQuery.data?.status, refetchQr, clearQr, qrCode]);
+  }, [isActive, sessionQuery.data?.status, refetchQr, clearQr, qrCode]);
+
+  useEffect(() => {
+    return () => {
+      clearQr();
+    };
+  }, [clearQr]);
 
   const handleRefreshStatus = async () => {
     const result = await sessionQuery.refetch();
@@ -207,173 +216,195 @@ export const DeviceLinkModal = ({ open, onClose }: DeviceLinkModalProps) => {
       : "O QR Code será exibido aqui quando a sessão estiver aguardando uma nova autenticação.";
 
   return (
-    <Modal open={open} onClose={onClose} ariaLabel="Conectar um novo dispositivo">
-      <div className={styles.container}>
-        <section className={styles.integrationPanel} aria-labelledby="waha-integration-title">
-          <header className={styles.integrationHeader}>
-            <h2 id="waha-integration-title">Conecte o WhatsApp Web</h2>
-            <p>
-              Use o painel integrado do WAHA para autenticar sua conta do WhatsApp Business. O QR Code
-              é atualizado automaticamente para garantir uma conexão segura.
-            </p>
-          </header>
-          <div className={styles.statusCard}>
-            <div className={styles.statusHeader}>
-              <div>
-                <p className={styles.sessionLabel}>
-                  Sessão vinculada: <span className={styles.sessionName}>{sessionName}</span>
-                </p>
-                <span className={statusBadgeClass}>{statusInfo.label}</span>
-              </div>
-              <div className={styles.sessionActions}>
-                <Button
-                  size="sm"
-                  onClick={handleLogout}
-                  disabled={
-                    sessionQuery.isLoading ||
-                    sessionQuery.isFetching ||
-                    logoutMutation.isPending ||
-                    !sessionName
-                  }
-                >
-                  {logoutMutation.isPending ? (
-                    <span className={styles.buttonSpinner} aria-hidden="true" />
-                  ) : (
-                    <LogOut size={16} aria-hidden="true" />
-                  )}
-                  Desconectar dispositivo
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={handleRefreshStatus}
-                  disabled={sessionQuery.isLoading || sessionQuery.isFetching}
-                >
-                  <RefreshCw
-                    size={16}
-                    aria-hidden="true"
-                    className={sessionQuery.isFetching ? styles.refreshIconSpinning : undefined}
-                  />
-                  Atualizar status
-                </Button>
-              </div>
-            </div>
-
-            {companyQuery.isError && (
-              <p className={styles.sessionWarning}>
-                Não foi possível carregar as informações da empresa. Utilizando a sessão padrão
-                <strong> {sessionName}</strong>.
+    <div
+      className={clsx(
+        styles.container,
+        layout === "inline" && styles.inlineContainer,
+        className,
+      )}
+    >
+      <section className={styles.integrationPanel} aria-labelledby="waha-integration-title">
+        <header className={styles.integrationHeader}>
+          <h2 id="waha-integration-title">Conecte o WhatsApp Web</h2>
+          <p>
+            Use o painel integrado do WAHA para autenticar sua conta do WhatsApp Business. O QR Code
+            é atualizado automaticamente para garantir uma conexão segura.
+          </p>
+        </header>
+        <div className={styles.statusCard}>
+          <div className={styles.statusHeader}>
+            <div>
+              <p className={styles.sessionLabel}>
+                Sessão vinculada: <span className={styles.sessionName}>{sessionName}</span>
               </p>
-            )}
+              <span className={statusBadgeClass}>{statusInfo.label}</span>
+            </div>
+            <div className={styles.sessionActions}>
+              <Button
+                size="sm"
+                onClick={handleLogout}
+                disabled={
+                  sessionQuery.isLoading ||
+                  sessionQuery.isFetching ||
+                  logoutMutation.isPending ||
+                  !sessionName
+                }
+              >
+                {logoutMutation.isPending ? (
+                  <span className={styles.buttonSpinner} aria-hidden="true" />
+                ) : (
+                  <LogOut size={16} aria-hidden="true" />
+                )}
+                Desconectar dispositivo
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleRefreshStatus}
+                disabled={sessionQuery.isLoading || sessionQuery.isFetching}
+              >
+                <RefreshCw
+                  size={16}
+                  aria-hidden="true"
+                  className={sessionQuery.isFetching ? styles.refreshIconSpinning : undefined}
+                />
+                Atualizar status
+              </Button>
+            </div>
+          </div>
 
-            {sessionQuery.isLoading ? (
+          {companyQuery.isError && (
+            <p className={styles.sessionWarning}>
+              Não foi possível carregar as informações da empresa. Utilizando a sessão padrão
+              <strong> {sessionName}</strong>.
+            </p>
+          )}
+
+          {sessionQuery.isLoading ? (
+            <div className={styles.sessionFeedback}>
+              <span className={styles.statusSpinner} aria-hidden="true" />
+              Carregando status da sessão...
+            </div>
+          ) : sessionQuery.isError ? (
+            <div className={styles.sessionError} role="alert">
+              Não foi possível carregar o status da sessão. Tente atualizar novamente ou verifique as
+              credenciais do WAHA.
+            </div>
+          ) : (
+            <p className={styles.statusDescription}>{statusInfo.description}</p>
+          )}
+
+          <div className={styles.sessionMetaRow}>
+            <span>
+              Empresa:{" "}
+              <span className={styles.sessionMetaHighlight}>{companyName ?? "Não informada"}</span>
+            </span>
+            {sessionUpdatedAt && (
+              <span>
+                Atualizado às <span className={styles.sessionMetaHighlight}>{sessionUpdatedAt}</span>
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className={styles.qrSection}>
+          <div className={styles.qrHeader}>
+            <h3>QR Code de autenticação</h3>
+            <div className={styles.qrActions}>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => void refetchQr()}
+                disabled={isFetchingQr || sessionQuery.isLoading || sessionQuery.isFetching}
+              >
+                <QrCode size={16} aria-hidden="true" />
+                Atualizar QR Code
+              </Button>
+            </div>
+          </div>
+          <div className={styles.qrContent}>
+            {isFetchingQr ? (
               <div className={styles.sessionFeedback}>
                 <span className={styles.statusSpinner} aria-hidden="true" />
-                Carregando status da sessão...
+                Gerando QR Code...
               </div>
-            ) : sessionQuery.isError ? (
+            ) : qrCode ? (
+              <img
+                src={qrCode}
+                alt="QR Code do WhatsApp"
+                className={styles.qrImage}
+                loading="lazy"
+              />
+            ) : isQrError ? (
               <div className={styles.sessionError} role="alert">
-                Não foi possível carregar o status da sessão. Tente atualizar novamente ou verifique as
-                credenciais do WAHA.
+                {qrError instanceof Error
+                  ? qrError.message
+                  : "Não foi possível carregar o QR Code. Tente novamente."}
               </div>
             ) : (
-              <p className={styles.statusDescription}>{statusInfo.description}</p>
-            )}
-
-            <div className={styles.sessionMetaRow}>
-              <span>
-                Empresa:{" "}
-                <span className={styles.sessionMetaHighlight}>{companyName ?? "Não informada"}</span>
-              </span>
-              {sessionUpdatedAt && (
-                <span>
-                  Atualizado às <span className={styles.sessionMetaHighlight}>{sessionUpdatedAt}</span>
-                </span>
-              )}
-            </div>
-          </div>
-
-          <div className={styles.qrSection}>
-            <div className={styles.qrHeader}>
-              <h3>QR Code de autenticação</h3>
-              <div className={styles.qrActions}>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => void refetchQr()}
-                  disabled={isFetchingQr || sessionQuery.isLoading || sessionQuery.isFetching}
-                >
-                  <QrCode size={16} aria-hidden="true" />
-                  Atualizar QR Code
-                </Button>
-              </div>
-            </div>
-            <div className={styles.qrContent}>
-              {isFetchingQr ? (
-                <div className={styles.sessionFeedback}>
-                  <span className={styles.statusSpinner} aria-hidden="true" />
-                  Gerando QR Code...
-                </div>
-              ) : qrCode ? (
-                <img
-                  src={qrCode}
-                  alt="QR Code do WhatsApp"
-                  className={styles.qrImage}
-                  loading="lazy"
-                />
-              ) : isQrError ? (
-                <div className={styles.sessionError} role="alert">
-                  {qrError instanceof Error
-                    ? qrError.message
-                    : "Não foi possível carregar o QR Code. Tente novamente."}
-                </div>
-              ) : (
-                <p className={styles.qrPlaceholder}>{qrPlaceholderMessage}</p>
-              )}
-            </div>
-            {qrUpdatedAtLabel && (
-              <p className={styles.sessionMetaRow}>
-                Última geração às
-                <span className={styles.sessionMetaHighlight}> {qrUpdatedAtLabel}</span>
-              </p>
+              <p className={styles.qrPlaceholder}>{qrPlaceholderMessage}</p>
             )}
           </div>
-          <WhatsAppWebEmbed
-            className={styles.embedWrapper}
-            fallback={
-              <div className={styles.fallbackMessage}>
-                <h3>Configuração necessária</h3>
-                <p>
-                  Defina <code>VITE_WAHA_WHATSAPP_WEB_URL</code> ou combine{' '}
-                  <code>VITE_WAHA_BASE_URL</code> com <code>VITE_WAHA_WHATSAPP_WEB_PATH</code> para carregar
-                  o WhatsApp Web integrado.
-                </p>
-              </div>
-            }
-          />
-        </section>
-        <div className={styles.instructions}>
-          <h2>Como conectar</h2>
-          <p>
-            Após a leitura do QR Code, o WAHA mantém a sessão ativa e sincroniza automaticamente as
-            mensagens com o painel de conversas.
-          </p>
-          <ol className={styles.steps}>
-            {steps.map((step, index) => (
-              <li key={step.title} className={styles.stepItem}>
-                <span className={styles.stepBadge}>{index + 1}</span>
-                <div className={styles.stepContent}>
-                  <h3>
-                    <span className={styles.stepIcon}>{step.icon}</span>
-                    {step.title}
-                  </h3>
-                  <p>{step.description}</p>
-                </div>
-              </li>
-            ))}
-          </ol>
+          {qrUpdatedAtLabel && (
+            <p className={styles.sessionMetaRow}>
+              Última geração às
+              <span className={styles.sessionMetaHighlight}> {qrUpdatedAtLabel}</span>
+            </p>
+          )}
         </div>
+        <WhatsAppWebEmbed
+          className={styles.embedWrapper}
+          fallback={
+            <div className={styles.fallbackMessage}>
+              <h3>Configuração necessária</h3>
+              <p>
+                Defina <code>VITE_WAHA_WHATSAPP_WEB_URL</code> ou combine{" "}
+                <code>VITE_WAHA_BASE_URL</code> com <code>VITE_WAHA_WHATSAPP_WEB_PATH</code> para carregar
+                o WhatsApp Web integrado.
+              </p>
+            </div>
+          }
+        />
+      </section>
+      <div className={styles.instructions}>
+        <h2>Como conectar</h2>
+        <p>
+          Após a leitura do QR Code, o WAHA mantém a sessão ativa e sincroniza automaticamente as
+          mensagens com o painel de conversas.
+        </p>
+        <ol className={styles.steps}>
+          {steps.map((step, index) => (
+            <li key={step.title} className={styles.stepItem}>
+              <span className={styles.stepBadge}>{index + 1}</span>
+              <div className={styles.stepContent}>
+                <h3>
+                  <span className={styles.stepIcon}>{step.icon}</span>
+                  {step.title}
+                </h3>
+                <p>{step.description}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
       </div>
+    </div>
+  );
+};
+
+interface DeviceLinkModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const DeviceLinkModal = ({ open, onClose }: DeviceLinkModalProps) => {
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      ariaLabel="Conectar um novo dispositivo"
+      contentClassName={styles.modalContent}
+    >
+      <DeviceLinkContent isActive={open} layout="modal" />
     </Modal>
   );
 };

--- a/frontend/src/features/chat/components/Modal.module.css
+++ b/frontend/src/features/chat/components/Modal.module.css
@@ -18,6 +18,8 @@
   max-width: min(640px, 100%);
   width: 100%;
   outline: none;
+  max-height: min(92vh, 720px);
+  overflow-y: auto;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/features/chat/components/Modal.tsx
+++ b/frontend/src/features/chat/components/Modal.tsx
@@ -1,5 +1,6 @@
 import type { MouseEvent, PropsWithChildren } from "react";
 import { useEffect, useRef } from "react";
+import clsx from "clsx";
 import { createPortal } from "react-dom";
 import styles from "./Modal.module.css";
 
@@ -7,6 +8,7 @@ interface ModalProps {
   open: boolean;
   ariaLabel: string;
   onClose: () => void;
+  contentClassName?: string;
 }
 
 const focusableSelectors = [
@@ -18,7 +20,13 @@ const focusableSelectors = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(",");
 
-export const Modal = ({ open, ariaLabel, onClose, children }: PropsWithChildren<ModalProps>) => {
+export const Modal = ({
+  open,
+  ariaLabel,
+  onClose,
+  contentClassName,
+  children,
+}: PropsWithChildren<ModalProps>) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const lastFocusedElementRef = useRef<HTMLElement | null>(null);
 
@@ -79,7 +87,7 @@ export const Modal = ({ open, ariaLabel, onClose, children }: PropsWithChildren<
     <div className={styles.overlay} role="presentation" onMouseDown={handleBackdropClick}>
       <div
         ref={containerRef}
-        className={styles.content}
+        className={clsx(styles.content, contentClassName)}
         role="dialog"
         aria-modal="true"
         aria-label={ariaLabel}


### PR DESCRIPTION
## Summary
- factor the device linking view into a reusable component used by both the modal and inline layout
- surface the WhatsApp connection guidance inside the chat viewport when no conversation is selected and adjust styling for the inline presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc8edc2dfc8326914fca764795cc20