### PR TITLE
Use authenticated company name for WAHA sessions

### DIFF
--- a/frontend/src/features/chat/services/deviceLinkingApi.ts
+++ b/frontend/src/features/chat/services/deviceLinkingApi.ts
@@ -123,6 +123,11 @@ const buildWahaUrl = (baseUrl: string, path: string): string => {
 };
 
 export const deriveSessionName = (companyName?: string | null): string => {
+  const normalizedOriginal = normalizeString(companyName);
+  if (normalizedOriginal) {
+    return normalizedOriginal;
+  }
+
   if (!companyName) {
     return fallbackSessionName;
   }

--- a/frontend/src/hooks/useWAHA.ts
+++ b/frontend/src/hooks/useWAHA.ts
@@ -264,7 +264,7 @@ const readStringProperty = (
   return pickFirstString(record[key]);
 };
 
-export const useWAHA = () => {
+export const useWAHA = (sessionNameOverride?: string | null) => {
   const [chats, setChats] = useState<ChatOverview[]>([]);
   const [messages, setMessages] = useState<Record<string, Message[]>>({});
   const [activeChatId, setActiveChatId] = useState<string | null>(null);
@@ -285,6 +285,16 @@ export const useWAHA = () => {
   const isFetchingChatsRef = useRef(false);
   const messagePaginationRef = useRef<Record<string, MessagePaginationState>>({});
   const enrichingChatsRef = useRef(new Set<string>());
+
+  useEffect(() => {
+    wahaService.setSessionOverride(sessionNameOverride ?? null);
+
+    return () => {
+      if (sessionNameOverride) {
+        wahaService.setSessionOverride(null);
+      }
+    };
+  }, [sessionNameOverride]);
 
   const ensureMessagePaginationState = useCallback(
     (chatId: string): MessagePaginationState => {


### PR DESCRIPTION
## Summary
- derive WAHA session names from the authenticated user's company
- update the device linking modal to avoid extra company lookups when auth data is available
- allow WAHA service and hook consumers to override the session used for API calls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc94e8c1f483269130228f16336ca8