### PR TITLE
Add process editing dialog and sanitize Datajud query

### DIFF
--- a/backend/src/services/datajudService.ts
+++ b/backend/src/services/datajudService.ts
@@ -134,6 +134,14 @@ export const fetchDatajudMovimentacoes = async (
     ? normalizedAlias
     : `api_publica_${normalizedAlias.replace(/^api_publica_/, '')}`;
 
+  const trimmedNumero = typeof numeroProcesso === 'string' ? numeroProcesso.trim() : '';
+  const digitsOnly = trimmedNumero.replace(/\D/g, '');
+  const numeroForQuery = digitsOnly || trimmedNumero;
+
+  if (!numeroForQuery) {
+    throw new Error('Número do processo inválido para consulta');
+  }
+
   const url = `${DATAJUD_BASE_URL}/${aliasWithPrefix}/_search`;
 
   const fetchImpl = resolveFetch();
@@ -149,7 +157,7 @@ export const fetchDatajudMovimentacoes = async (
         Authorization: `APIKey ${apiKey}`,
       },
       body: JSON.stringify({
-        query: { match: { numeroProcesso } },
+        query: { match: { numeroProcesso: numeroForQuery } },
         size: 1,
       }),
       signal: controller.signal,


### PR DESCRIPTION
## Summary
- strip non-digit characters from process numbers before querying the DataJud API
- store the raw processo payload in the detail page and expose a dialog to edit tribunal metadata
- let users configure DataJud tribunal/type from the process view and trigger updates without leaving the page

## Testing
- npm run lint
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68cc96fcb1308326b79b0597f8978951