### PR TITLE
Canonicalize Datajud aliases from URLs

### DIFF
--- a/backend/dist/controllers/processoController.js
+++ b/backend/dist/controllers/processoController.js
@@ -6,6 +6,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.deleteProcesso = exports.getProcessoMovimentacoes = exports.updateProcesso = exports.createProcesso = exports.getProcessoById = exports.listProcessosByCliente = exports.listProcessos = void 0;
 const db_1 = __importDefault(require("../services/db"));
 const datajudService_1 = require("../services/datajudService");
+const datajud_1 = require("../utils/datajud");
 const normalizeString = (value) => {
     if (typeof value !== 'string') {
         return null;
@@ -118,7 +119,7 @@ const mapProcessoRow = (row) => ({
     advogado_responsavel: row.advogado_responsavel,
     data_distribuicao: row.data_distribuicao,
     datajud_tipo_justica: row.datajud_tipo_justica ?? null,
-    datajud_alias: row.datajud_alias ?? null,
+    datajud_alias: (0, datajud_1.canonicalizeDatajudAlias)(row.datajud_alias),
     criado_em: row.criado_em,
     atualizado_em: row.atualizado_em,
     cliente: row.cliente_id
@@ -278,7 +279,7 @@ const createProcesso = async (req, res) => {
         ? normalizeLowercase(datajud_tipo_justica)
         : null;
     const datajudAliasValue = columnInfo.hasDatajudAlias
-        ? normalizeLowercase(datajud_alias)
+        ? (0, datajud_1.canonicalizeDatajudAlias)(datajud_alias)
         : null;
     const missingDatajudFields = [];
     if (columnInfo.hasDatajudTipoJustica && !datajudTipoJusticaValue) {
@@ -390,7 +391,7 @@ const updateProcesso = async (req, res) => {
         ? normalizeLowercase(datajud_tipo_justica)
         : null;
     const datajudAliasValue = columnInfo.hasDatajudAlias
-        ? normalizeLowercase(datajud_alias)
+        ? (0, datajud_1.canonicalizeDatajudAlias)(datajud_alias)
         : null;
     const missingDatajudFields = [];
     if (columnInfo.hasDatajudTipoJustica && !datajudTipoJusticaValue) {
@@ -496,7 +497,7 @@ const getProcessoMovimentacoes = async (req, res) => {
         }
         const row = result.rows[0];
         const numeroProcesso = normalizeString(row.numero);
-        const datajudAlias = normalizeString(row.datajud_alias);
+        const datajudAlias = (0, datajud_1.canonicalizeDatajudAlias)(row.datajud_alias);
         if (!numeroProcesso || !datajudAlias) {
             return res.json([]);
         }

--- a/backend/dist/services/datajudService.js
+++ b/backend/dist/services/datajudService.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.fetchDatajudMovimentacoes = void 0;
+const datajud_1 = require("../utils/datajud");
 const DATAJUD_BASE_URL = 'https://api-publica.datajud.cnj.jus.br';
 const DATAJUD_TIMEOUT_MS = 15000;
 const isNonEmptyString = (value) => typeof value === 'string' && value.trim() !== '';
@@ -68,7 +69,10 @@ const fetchDatajudMovimentacoes = async (alias, numeroProcesso) => {
     if (!apiKey) {
         throw new Error('DATAJUD_API_KEY não configurada');
     }
-    const normalizedAlias = alias.replace(/^\/+|\/+$/g, '');
+    const normalizedAlias = (0, datajud_1.canonicalizeDatajudAlias)(alias);
+    if (!normalizedAlias) {
+        throw new Error('Alias do Datajud inválido para consulta');
+    }
     const url = `${DATAJUD_BASE_URL}/${normalizedAlias}/_search`;
     const fetchImpl = resolveFetch();
     const controller = new AbortController();

--- a/backend/dist/utils/datajud.js
+++ b/backend/dist/utils/datajud.js
@@ -1,0 +1,51 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.canonicalizeDatajudAlias = void 0;
+const DATAJUD_ALIAS_PATTERN = /api_publica_[a-z0-9_-]+/;
+const sanitizeAliasSegment = (segment) => {
+    const cleaned = segment.replace(/[^a-z0-9_-]/g, '');
+    return cleaned;
+};
+const canonicalizeDatajudAlias = (value) => {
+    if (typeof value !== 'string') {
+        return null;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return null;
+    }
+    const lower = trimmed.toLowerCase();
+    const directMatch = lower.match(DATAJUD_ALIAS_PATTERN);
+    if (directMatch && directMatch[0]) {
+        return directMatch[0];
+    }
+    let candidate = lower;
+    if (candidate.includes('://')) {
+        try {
+            const url = new URL(candidate);
+            candidate = url.pathname;
+        }
+        catch (error) {
+            // ignore invalid URL and fallback to manual normalization
+        }
+    }
+    candidate = candidate
+        .replace(/^https?:\/\//, '')
+        .replace(/^(?:www\.)?(?:api[-_]?publica\.)?datajud\.cnj\.jus\.br/, '')
+        .replace(/^\/+/, '');
+    const withoutQueryOrFragment = candidate.split(/[?#]/)[0] ?? '';
+    if (!withoutQueryOrFragment) {
+        return null;
+    }
+    const firstSegment = withoutQueryOrFragment.split('/')[0] ?? '';
+    const sanitizedSegment = sanitizeAliasSegment(firstSegment);
+    if (!sanitizedSegment) {
+        return null;
+    }
+    const withoutPrefix = sanitizedSegment.replace(/^api_publica_/, '');
+    if (!withoutPrefix) {
+        return null;
+    }
+    return `api_publica_${withoutPrefix}`;
+};
+exports.canonicalizeDatajudAlias = canonicalizeDatajudAlias;

--- a/backend/src/controllers/processoController.ts
+++ b/backend/src/controllers/processoController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import pool from '../services/db';
 import { Processo } from '../models/processo';
 import { fetchDatajudMovimentacoes } from '../services/datajudService';
+import { canonicalizeDatajudAlias } from '../utils/datajud';
 
 const normalizeString = (value: unknown): string | null => {
   if (typeof value !== 'string') {
@@ -146,7 +147,7 @@ const mapProcessoRow = (row: any): Processo => ({
   advogado_responsavel: row.advogado_responsavel,
   data_distribuicao: row.data_distribuicao,
   datajud_tipo_justica: row.datajud_tipo_justica ?? null,
-  datajud_alias: row.datajud_alias ?? null,
+  datajud_alias: canonicalizeDatajudAlias(row.datajud_alias),
   criado_em: row.criado_em,
   atualizado_em: row.atualizado_em,
   cliente: row.cliente_id
@@ -345,7 +346,7 @@ export const createProcesso = async (req: Request, res: Response) => {
     ? normalizeLowercase(datajud_tipo_justica)
     : null;
   const datajudAliasValue = columnInfo.hasDatajudAlias
-    ? normalizeLowercase(datajud_alias)
+    ? canonicalizeDatajudAlias(datajud_alias)
     : null;
 
   const missingDatajudFields: string[] = [];
@@ -498,7 +499,7 @@ export const updateProcesso = async (req: Request, res: Response) => {
     ? normalizeLowercase(datajud_tipo_justica)
     : null;
   const datajudAliasValue = columnInfo.hasDatajudAlias
-    ? normalizeLowercase(datajud_alias)
+    ? canonicalizeDatajudAlias(datajud_alias)
     : null;
 
   const missingDatajudFields: string[] = [];
@@ -638,7 +639,7 @@ export const getProcessoMovimentacoes = async (req: Request, res: Response) => {
     const row = result.rows[0] as { numero: string | null; datajud_alias: string | null };
 
     const numeroProcesso = normalizeString(row.numero);
-    const datajudAlias = normalizeString(row.datajud_alias);
+    const datajudAlias = canonicalizeDatajudAlias(row.datajud_alias);
 
     if (!numeroProcesso || !datajudAlias) {
       return res.json([]);

--- a/backend/src/services/datajudService.ts
+++ b/backend/src/services/datajudService.ts
@@ -1,3 +1,5 @@
+import { canonicalizeDatajudAlias } from '../utils/datajud';
+
 const DATAJUD_BASE_URL = 'https://api-publica.datajud.cnj.jus.br';
 const DATAJUD_TIMEOUT_MS = 15000;
 
@@ -120,7 +122,12 @@ export const fetchDatajudMovimentacoes = async (
     throw new Error('DATAJUD_API_KEY não configurada');
   }
 
-  const normalizedAlias = alias.replace(/^\/+|\/+$/g, '');
+  const normalizedAlias = canonicalizeDatajudAlias(alias);
+
+  if (!normalizedAlias) {
+    throw new Error('Alias do Datajud inválido para consulta');
+  }
+
   const url = `${DATAJUD_BASE_URL}/${normalizedAlias}/_search`;
 
   const fetchImpl = resolveFetch();

--- a/backend/src/utils/datajud.ts
+++ b/backend/src/utils/datajud.ts
@@ -1,0 +1,61 @@
+const DATAJUD_ALIAS_PATTERN = /api_publica_[a-z0-9_-]+/;
+
+const sanitizeAliasSegment = (segment: string): string => {
+  const cleaned = segment.replace(/[^a-z0-9_-]/g, '');
+  return cleaned;
+};
+
+export const canonicalizeDatajudAlias = (
+  value: unknown,
+): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const lower = trimmed.toLowerCase();
+
+  const directMatch = lower.match(DATAJUD_ALIAS_PATTERN);
+  if (directMatch && directMatch[0]) {
+    return directMatch[0];
+  }
+
+  let candidate = lower;
+
+  if (candidate.includes('://')) {
+    try {
+      const url = new URL(candidate);
+      candidate = url.pathname;
+    } catch (error) {
+      // ignore invalid URL and fallback to manual normalization
+    }
+  }
+
+  candidate = candidate
+    .replace(/^https?:\/\//, '')
+    .replace(/^(?:www\.)?(?:api[-_]?publica\.)?datajud\.cnj\.jus\.br/, '')
+    .replace(/^\/+/, '');
+
+  const withoutQueryOrFragment = candidate.split(/[?#]/)[0] ?? '';
+  if (!withoutQueryOrFragment) {
+    return null;
+  }
+
+  const firstSegment = withoutQueryOrFragment.split('/')[0] ?? '';
+  const sanitizedSegment = sanitizeAliasSegment(firstSegment);
+
+  if (!sanitizedSegment) {
+    return null;
+  }
+
+  const withoutPrefix = sanitizedSegment.replace(/^api_publica_/, '');
+  if (!withoutPrefix) {
+    return null;
+  }
+
+  return `api_publica_${withoutPrefix}`;
+};

--- a/frontend/src/pages/Processos.tsx
+++ b/frontend/src/pages/Processos.tsx
@@ -52,6 +52,7 @@ import {
   DATAJUD_TRIBUNAIS_BY_CATEGORIA,
   getDatajudCategoriaLabel,
   getDatajudTribunalLabel,
+  normalizeDatajudAlias,
 } from "@/data/datajud";
 
 interface ProcessoCliente {
@@ -257,7 +258,7 @@ const mapApiProcessoToProcesso = (processo: ApiProcesso): Processo => {
     "Não informado";
   const rawCategoria = processo.datajud_tipo_justica?.trim() || null;
   const categoriaLabel = getDatajudCategoriaLabel(rawCategoria);
-  const datajudAlias = processo.datajud_alias?.trim() || null;
+  const datajudAlias = normalizeDatajudAlias(processo.datajud_alias);
   const datajudTribunal = getDatajudTribunalLabel(datajudAlias);
 
   return {

--- a/frontend/src/pages/VisualizarProcesso.tsx
+++ b/frontend/src/pages/VisualizarProcesso.tsx
@@ -30,6 +30,7 @@ import { getApiUrl } from "@/lib/api";
 import {
   getDatajudCategoriaLabel,
   getDatajudTribunalLabel,
+  normalizeDatajudAlias,
 } from "@/data/datajud";
 
 interface ApiProcessoCliente {
@@ -226,7 +227,7 @@ const mapApiProcessoToDetalhes = (processo: ApiProcessoResponse): ProcessoDetalh
     "Não informado";
   const dataDistribuicao = normalizeString(processo.data_distribuicao) || null;
   const datajudTipoJustica = normalizeString(processo.datajud_tipo_justica) || null;
-  const datajudAlias = normalizeString(processo.datajud_alias) || null;
+  const datajudAlias = normalizeDatajudAlias(processo.datajud_alias);
   const datajudCategoriaLabel = getDatajudCategoriaLabel(datajudTipoJustica);
   const datajudTribunal = getDatajudTribunalLabel(datajudAlias);
   const clienteResumo = processo.cliente ?? null;


### PR DESCRIPTION
## Summary
- add a shared Datajud alias canonicalizer on the backend and reuse it when reading, validating or syncing processos
- update the Datajud service to always call the CNJ API with the canonical alias that works even if the stored value was a full URL
- mirror the alias normalization logic on the frontend so tribunais and movimentações render when legacy URLs are present

## Testing
- npm run build (backend)
- npm run build (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68cc89eb95948326976cf0af9dc1b04d