### PR TITLE
Fix Datajud query payload

### DIFF
--- a/backend/dist/services/datajudService.js
+++ b/backend/dist/services/datajudService.js
@@ -74,7 +74,8 @@ const fetchDatajudMovimentacoes = async (alias, numeroProcesso) => {
         throw new Error('Alias do Datajud inválido para consulta');
     }
     const url = `${DATAJUD_BASE_URL}/${normalizedAlias}/_search`;
-
+    const numeroForQuery = numeroProcesso.replace(/\D+/g, '');
+    const numeroNormalizado = numeroForQuery.length > 0 ? numeroForQuery : numeroProcesso;
     const fetchImpl = resolveFetch();
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), DATAJUD_TIMEOUT_MS);
@@ -87,7 +88,7 @@ const fetchDatajudMovimentacoes = async (alias, numeroProcesso) => {
                 Authorization: `APIKey ${apiKey}`,
             },
             body: JSON.stringify({
-                query: { match: { numeroProcesso } },
+                query: { match: { numeroProcesso: numeroNormalizado } },
                 size: 1,
             }),
             signal: controller.signal,

--- a/backend/src/services/datajudService.ts
+++ b/backend/src/services/datajudService.ts
@@ -131,6 +131,8 @@ export const fetchDatajudMovimentacoes = async (
 
   const url = `${DATAJUD_BASE_URL}/${normalizedAlias}/_search`;
 
+  const numeroForQuery = numeroProcesso.replace(/\D+/g, '');
+  const numeroNormalizado = numeroForQuery.length > 0 ? numeroForQuery : numeroProcesso;
 
   const fetchImpl = resolveFetch();
   const controller = new AbortController();
@@ -145,7 +147,7 @@ export const fetchDatajudMovimentacoes = async (
         Authorization: `APIKey ${apiKey}`,
       },
       body: JSON.stringify({
-        query: { match: { numeroProcesso: numeroForQuery } },
+        query: { match: { numeroProcesso: numeroNormalizado } },
         size: 1,
       }),
       signal: controller.signal,


### PR DESCRIPTION
## Summary
- normalize the process number before building the Datajud query payload
- ensure the JSON payload references the defined normalized number so requests are sent correctly

## Testing
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68cca596a8e08326a2a12a986678fb20