### PR TITLE
Ajusta APIs de usuários para novo campo setor

### DIFF
--- a/backend/dist/controllers/authController.js
+++ b/backend/dist/controllers/authController.js
@@ -18,7 +18,21 @@ const login = async (req, res) => {
     }
     try {
         const normalizedEmail = normalizeEmail(email);
-        const userResult = await db_1.default.query('SELECT id, nome_completo, email, senha, status, perfil FROM public.usuarios WHERE LOWER(email) = $1 LIMIT 1', [normalizedEmail]);
+        const userResult = await db_1.default.query(`SELECT u.id,
+              u.nome_completo,
+              u.email,
+              u.senha,
+              u.status,
+              u.perfil,
+              u.empresa AS empresa_id,
+              emp.nome_empresa AS empresa_nome,
+              u.setor AS setor_id,
+              esc.nome AS setor_nome
+         FROM public.usuarios u
+         LEFT JOIN public.empresas emp ON emp.id = u.empresa
+         LEFT JOIN public.escritorios esc ON esc.id = u.setor
+        WHERE LOWER(u.email) = $1
+        LIMIT 1`, [normalizedEmail]);
         if (userResult.rowCount === 0) {
             res.status(401).json({ error: 'E-mail ou senha incorretos.' });
             return;
@@ -48,6 +62,10 @@ const login = async (req, res) => {
                 email: user.email,
                 perfil: user.perfil,
                 modulos,
+                empresa_id: user.empresa_id,
+                empresa_nome: user.empresa_nome,
+                setor_id: user.setor_id,
+                setor_nome: user.setor_nome,
             },
         });
     }
@@ -63,7 +81,20 @@ const getCurrentUser = async (req, res) => {
         return;
     }
     try {
-        const result = await db_1.default.query('SELECT id, nome_completo, email, perfil, status FROM public."vw.usuarios" WHERE id = $1', [req.auth.userId]);
+        const result = await db_1.default.query(`SELECT u.id,
+              u.nome_completo,
+              u.email,
+              u.perfil,
+              u.status,
+              u.empresa AS empresa_id,
+              emp.nome_empresa AS empresa_nome,
+              u.setor AS setor_id,
+              esc.nome AS setor_nome
+         FROM public.usuarios u
+         LEFT JOIN public.empresas emp ON emp.id = u.empresa
+         LEFT JOIN public.escritorios esc ON esc.id = u.setor
+        WHERE u.id = $1
+        LIMIT 1`, [req.auth.userId]);
         if (result.rowCount === 0) {
             res.status(404).json({ error: 'Usuário não encontrado.' });
             return;
@@ -76,6 +107,10 @@ const getCurrentUser = async (req, res) => {
             email: user.email,
             perfil: user.perfil,
             status: user.status,
+            empresa_id: user.empresa_id,
+            empresa_nome: user.empresa_nome,
+            setor_id: user.setor_id,
+            setor_nome: user.setor_nome,
             modulos,
         });
     }

--- a/backend/dist/controllers/usuarioController.js
+++ b/backend/dist/controllers/usuarioController.js
@@ -77,7 +77,7 @@ const parseStatus = (value) => {
 };
 const listUsuarios = async (_req, res) => {
     try {
-        const result = await db_1.default.query('SELECT id, nome_completo, cpf, email, perfil, empresa, escritorio, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao 	FROM public."vw.usuarios"');
+        const result = await db_1.default.query('SELECT id, nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao 	FROM public."vw.usuarios"');
         res.json(result.rows);
     }
     catch (error) {
@@ -89,7 +89,7 @@ exports.listUsuarios = listUsuarios;
 const getUsuarioById = async (req, res) => {
     const { id } = req.params;
     try {
-        const result = await db_1.default.query('SELECT id, nome_completo, cpf, email, perfil, empresa, escritorio, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao  FROM public."vw.usuarios" WHERE id = $1', [id]);
+        const result = await db_1.default.query('SELECT id, nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao  FROM public."vw.usuarios" WHERE id = $1', [id]);
         if (result.rowCount === 0) {
             return res.status(404).json({ error: 'Usuário não encontrado' });
         }
@@ -102,7 +102,7 @@ const getUsuarioById = async (req, res) => {
 };
 exports.getUsuarioById = getUsuarioById;
 const createUsuario = async (req, res) => {
-    const { nome_completo, cpf, email, perfil, empresa, escritorio, oab, status, senha, telefone, ultimo_login, observacoes, } = req.body;
+    const { nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, } = req.body;
     try {
         if (!req.auth) {
             return res.status(401).json({ error: 'Token inválido.' });
@@ -142,26 +142,26 @@ const createUsuario = async (req, res) => {
                 return res.status(400).json({ error: 'Empresa informada não existe' });
             }
         }
-        const escritorioIdResult = parseOptionalId(escritorio);
-        if (escritorioIdResult === 'invalid') {
-            return res.status(400).json({ error: 'ID de escritório inválido' });
+        const setorIdResult = parseOptionalId(setor);
+        if (setorIdResult === 'invalid') {
+            return res.status(400).json({ error: 'ID de setor inválido' });
         }
-        const escritorioId = escritorioIdResult;
-        if (escritorioId !== null) {
-            const escritorioExists = await db_1.default.query('SELECT 1 FROM public.escritorios WHERE id = $1', [escritorioId]);
-            if (escritorioExists.rowCount === 0) {
+        const setorId = setorIdResult;
+        if (setorId !== null) {
+            const setorExists = await db_1.default.query('SELECT 1 FROM public.escritorios WHERE id = $1', [setorId]);
+            if (setorExists.rowCount === 0) {
                 return res
                     .status(400)
-                    .json({ error: 'Escritório informado não existe' });
+                    .json({ error: 'Setor informado não existe' });
             }
         }
-        const result = await db_1.default.query('INSERT INTO public.usuarios (nome_completo, cpf, email, perfil, empresa, escritorio, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, NOW()) RETURNING id, nome_completo, cpf, email, perfil, empresa, escritorio, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao', [
+        const result = await db_1.default.query('INSERT INTO public.usuarios (nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, NOW()) RETURNING id, nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao', [
             nome_completo,
             cpf,
             email,
             perfil,
             empresaId,
-            escritorioId,
+            setorId,
             oab,
             parsedStatus,
             senha,
@@ -179,7 +179,7 @@ const createUsuario = async (req, res) => {
 exports.createUsuario = createUsuario;
 const updateUsuario = async (req, res) => {
     const { id } = req.params;
-    const { nome_completo, cpf, email, perfil, empresa, escritorio, oab, status, senha, telefone, ultimo_login, observacoes, } = req.body;
+    const { nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, } = req.body;
     try {
         const parsedStatus = parseStatus(status);
         if (parsedStatus === 'invalid') {
@@ -196,26 +196,26 @@ const updateUsuario = async (req, res) => {
                 return res.status(400).json({ error: 'Empresa informada não existe' });
             }
         }
-        const escritorioIdResult = parseOptionalId(escritorio);
-        if (escritorioIdResult === 'invalid') {
-            return res.status(400).json({ error: 'ID de escritório inválido' });
+        const setorIdResult = parseOptionalId(setor);
+        if (setorIdResult === 'invalid') {
+            return res.status(400).json({ error: 'ID de setor inválido' });
         }
-        const escritorioId = escritorioIdResult;
-        if (escritorioId !== null) {
-            const escritorioExists = await db_1.default.query('SELECT 1 FROM public.escritorios WHERE id = $1', [escritorioId]);
-            if (escritorioExists.rowCount === 0) {
+        const setorId = setorIdResult;
+        if (setorId !== null) {
+            const setorExists = await db_1.default.query('SELECT 1 FROM public.escritorios WHERE id = $1', [setorId]);
+            if (setorExists.rowCount === 0) {
                 return res
                     .status(400)
-                    .json({ error: 'Escritório informado não existe' });
+                    .json({ error: 'Setor informado não existe' });
             }
         }
-        const result = await db_1.default.query('UPDATE public.usuarios SET nome_completo = $1, cpf = $2, email = $3, perfil = $4, empresa = $5, escritorio = $6, oab = $7, status = $8, senha = $9, telefone = $10, ultimo_login = $11, observacoes = $12 WHERE id = $13 RETURNING id, nome_completo, cpf, email, perfil, empresa, escritorio, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao', [
+        const result = await db_1.default.query('UPDATE public.usuarios SET nome_completo = $1, cpf = $2, email = $3, perfil = $4, empresa = $5, setor = $6, oab = $7, status = $8, senha = $9, telefone = $10, ultimo_login = $11, observacoes = $12 WHERE id = $13 RETURNING id, nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao', [
             nome_completo,
             cpf,
             email,
             perfil,
             empresaId,
-            escritorioId,
+            setorId,
             oab,
             parsedStatus,
             senha,

--- a/backend/dist/routes/usuarioRoutes.js
+++ b/backend/dist/routes/usuarioRoutes.js
@@ -25,7 +25,7 @@ const router = (0, express_1.Router)();
  *           type: string
  *         empresa:
  *           type: string
- *         escritorio:
+ *         setor:
  *           type: string
  *         oab:
  *           type: string
@@ -107,7 +107,7 @@ router.get(['/usuarios/:id', '/users/:id'], usuarioController_1.getUsuarioById);
  *                 type: integer
  *               empresa:
  *                 type: integer
- *               escritorio:
+ *               setor:
  *                 type: integer
  *               oab:
  *                 type: string
@@ -160,7 +160,7 @@ router.post(['/usuarios', '/users'], usuarioController_1.createUsuario);
  *                 type: integer
  *               empresa:
  *                 type: integer
- *               escritorio:
+ *               setor:
  *                 type: integer
  *               oab:
  *                 type: string

--- a/backend/dist/services/datajudService.js
+++ b/backend/dist/services/datajudService.js
@@ -74,7 +74,11 @@ const fetchDatajudMovimentacoes = async (alias, numeroProcesso) => {
         throw new Error('Alias do Datajud inválido para consulta');
     }
     const url = `${DATAJUD_BASE_URL}/${normalizedAlias}/_search`;
-
+    const numeroForQueryDigits = numeroProcesso.replace(/\D/g, '').trim();
+    const numeroForQuery = numeroForQueryDigits || numeroProcesso.trim();
+    if (!numeroForQuery) {
+        throw new Error('Número do processo inválido para consulta');
+    }
     const fetchImpl = resolveFetch();
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), DATAJUD_TIMEOUT_MS);
@@ -87,7 +91,7 @@ const fetchDatajudMovimentacoes = async (alias, numeroProcesso) => {
                 Authorization: `APIKey ${apiKey}`,
             },
             body: JSON.stringify({
-                query: { match: { numeroProcesso } },
+                query: { match: { numeroProcesso: numeroForQuery } },
                 size: 1,
             }),
             signal: controller.signal,

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -31,7 +31,7 @@ export const login = async (req: Request, res: Response) => {
               esc.nome AS setor_nome
          FROM public.usuarios u
          LEFT JOIN public.empresas emp ON emp.id = u.empresa
-         LEFT JOIN public.escritorios esc ON esc.id = u.escritorio
+         LEFT JOIN public.escritorios esc ON esc.id = u.setor
         WHERE LOWER(u.email) = $1
         LIMIT 1`,
       [normalizedEmail]

--- a/backend/src/controllers/usuarioController.ts
+++ b/backend/src/controllers/usuarioController.ts
@@ -95,7 +95,7 @@ const parseStatus = (value: unknown): boolean | 'invalid' => {
 export const listUsuarios = async (_req: Request, res: Response) => {
   try {
     const result = await pool.query(
-      'SELECT id, nome_completo, cpf, email, perfil, empresa, escritorio, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao 	FROM public."vw.usuarios"'    );
+      'SELECT id, nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao 	FROM public."vw.usuarios"'    );
     res.json(result.rows);
   } catch (error) {
     console.error(error);
@@ -107,7 +107,7 @@ export const getUsuarioById = async (req: Request, res: Response) => {
   const { id } = req.params;
   try {
     const result = await pool.query(
-      'SELECT id, nome_completo, cpf, email, perfil, empresa, escritorio, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao  FROM public."vw.usuarios" WHERE id = $1',
+      'SELECT id, nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao  FROM public."vw.usuarios" WHERE id = $1',
       [id]
     );
     if (result.rowCount === 0) {
@@ -127,7 +127,7 @@ export const createUsuario = async (req: Request, res: Response) => {
     email,
     perfil,
     empresa,
-    escritorio,
+    setor,
     oab,
     status,
     senha,
@@ -194,33 +194,33 @@ export const createUsuario = async (req: Request, res: Response) => {
       }
     }
 
-    const escritorioIdResult = parseOptionalId(escritorio);
-    if (escritorioIdResult === 'invalid') {
-      return res.status(400).json({ error: 'ID de escritório inválido' });
+    const setorIdResult = parseOptionalId(setor);
+    if (setorIdResult === 'invalid') {
+      return res.status(400).json({ error: 'ID de setor inválido' });
     }
-    const escritorioId = escritorioIdResult;
+    const setorId = setorIdResult;
 
-    if (escritorioId !== null) {
-      const escritorioExists = await pool.query(
+    if (setorId !== null) {
+      const setorExists = await pool.query(
         'SELECT 1 FROM public.escritorios WHERE id = $1',
-        [escritorioId]
+        [setorId]
       );
-      if (escritorioExists.rowCount === 0) {
+      if (setorExists.rowCount === 0) {
         return res
           .status(400)
-          .json({ error: 'Escritório informado não existe' });
+          .json({ error: 'Setor informado não existe' });
       }
     }
 
     const result = await pool.query(
-      'INSERT INTO public.usuarios (nome_completo, cpf, email, perfil, empresa, escritorio, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, NOW()) RETURNING id, nome_completo, cpf, email, perfil, empresa, escritorio, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao',
+      'INSERT INTO public.usuarios (nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, NOW()) RETURNING id, nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao',
       [
         nome_completo,
         cpf,
         email,
         perfil,
         empresaId,
-        escritorioId,
+        setorId,
         oab,
         parsedStatus,
         senha,
@@ -244,7 +244,7 @@ export const updateUsuario = async (req: Request, res: Response) => {
     email,
     perfil,
     empresa,
-    escritorio,
+    setor,
     oab,
     status,
     senha,
@@ -275,33 +275,33 @@ export const updateUsuario = async (req: Request, res: Response) => {
       }
     }
 
-    const escritorioIdResult = parseOptionalId(escritorio);
-    if (escritorioIdResult === 'invalid') {
-      return res.status(400).json({ error: 'ID de escritório inválido' });
+    const setorIdResult = parseOptionalId(setor);
+    if (setorIdResult === 'invalid') {
+      return res.status(400).json({ error: 'ID de setor inválido' });
     }
-    const escritorioId = escritorioIdResult;
+    const setorId = setorIdResult;
 
-    if (escritorioId !== null) {
-      const escritorioExists = await pool.query(
+    if (setorId !== null) {
+      const setorExists = await pool.query(
         'SELECT 1 FROM public.escritorios WHERE id = $1',
-        [escritorioId]
+        [setorId]
       );
-      if (escritorioExists.rowCount === 0) {
+      if (setorExists.rowCount === 0) {
         return res
           .status(400)
-          .json({ error: 'Escritório informado não existe' });
+          .json({ error: 'Setor informado não existe' });
       }
     }
 
     const result = await pool.query(
-      'UPDATE public.usuarios SET nome_completo = $1, cpf = $2, email = $3, perfil = $4, empresa = $5, escritorio = $6, oab = $7, status = $8, senha = $9, telefone = $10, ultimo_login = $11, observacoes = $12 WHERE id = $13 RETURNING id, nome_completo, cpf, email, perfil, empresa, escritorio, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao',
+      'UPDATE public.usuarios SET nome_completo = $1, cpf = $2, email = $3, perfil = $4, empresa = $5, setor = $6, oab = $7, status = $8, senha = $9, telefone = $10, ultimo_login = $11, observacoes = $12 WHERE id = $13 RETURNING id, nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao',
       [
         nome_completo,
         cpf,
         email,
         perfil,
         empresaId,
-        escritorioId,
+        setorId,
         oab,
         parsedStatus,
         senha,

--- a/backend/src/routes/usuarioRoutes.ts
+++ b/backend/src/routes/usuarioRoutes.ts
@@ -31,7 +31,7 @@ const router = Router();
  *           type: string
  *         empresa:
  *           type: string
- *         escritorio:
+ *         setor:
  *           type: string
  *         oab:
  *           type: string
@@ -116,7 +116,7 @@ router.get(['/usuarios/:id', '/users/:id'], getUsuarioById);
  *                 type: integer
  *               empresa:
  *                 type: integer
- *               escritorio:
+ *               setor:
  *                 type: integer
  *               oab:
  *                 type: string
@@ -170,7 +170,7 @@ router.post(['/usuarios', '/users'], createUsuario);
  *                 type: integer
  *               empresa:
  *                 type: integer
- *               escritorio:
+ *               setor:
  *                 type: integer
  *               oab:
  *                 type: string

--- a/backend/src/services/datajudService.ts
+++ b/backend/src/services/datajudService.ts
@@ -132,6 +132,14 @@ export const fetchDatajudMovimentacoes = async (
   const url = `${DATAJUD_BASE_URL}/${normalizedAlias}/_search`;
 
 
+  const numeroForQueryDigits = numeroProcesso.replace(/\D/g, '').trim();
+  const numeroForQuery = numeroForQueryDigits || numeroProcesso.trim();
+
+  if (!numeroForQuery) {
+    throw new Error('Número do processo inválido para consulta');
+  }
+
+
   const fetchImpl = resolveFetch();
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), DATAJUD_TIMEOUT_MS);


### PR DESCRIPTION
## Summary
- atualiza as consultas de autenticação para carregar empresa e setor usando o novo campo `setor`
- ajusta listagem, criação e edição de usuários para validar o setor e persistir o novo campo, além da documentação Swagger correspondente
- sanitiza o número de processo usado na busca do Datajud antes de montar a query

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cca7db27b88326a26eca5663363caa