### PR TITLE
Normalize Datajud query process number

### DIFF
--- a/backend/src/services/datajudService.ts
+++ b/backend/src/services/datajudService.ts
@@ -135,12 +135,9 @@ export const fetchDatajudMovimentacoes = async (
   const numeroNormalizado =
     numeroProcessoSomenteDigitos.length > 0
       ? numeroProcessoSomenteDigitos
-      : numeroProcesso;
+      : numeroProcesso.trim();
 
-  const numeroForQueryDigits = numeroProcesso.replace(/\D/g, '').trim();
-  const numeroForQuery = numeroForQueryDigits || numeroProcesso.trim();
-
-  if (!numeroForQuery) {
+  if (!numeroNormalizado) {
     throw new Error('Número do processo inválido para consulta');
   }
 
@@ -148,7 +145,6 @@ export const fetchDatajudMovimentacoes = async (
   const fetchImpl = resolveFetch();
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), DATAJUD_TIMEOUT_MS);
-  const numeroForQuery = numeroProcesso;
 
   try {
     const response = await fetchImpl(url, {


### PR DESCRIPTION
## Summary
- trim the process number fallback when building the Datajud query
- ensure the request always uses a non-empty normalized value comprised of digits when available

## Testing
- npm --prefix backend run build

------
https://chatgpt.com/codex/tasks/task_e_68ccad754c548326a339e5a0b833a1ac