### PR TITLE
Add loading screen while login state initializes

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -51,6 +51,17 @@ const Login = () => {
     }
   };
 
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-background via-primary/5 to-accent/10 flex items-center justify-center p-4">
+        <div className="flex flex-col items-center gap-3 text-muted-foreground">
+          <Loader2 className="h-10 w-10 animate-spin text-primary" />
+          <span className="text-sm">Carregando acesso...</span>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-primary/5 to-accent/10 flex items-center justify-center p-4">
       <div className="w-full max-w-md">


### PR DESCRIPTION
## Summary
- exibir indicador de carregamento em tela cheia enquanto o estado de autenticação está inicializando na tela de login

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccaf4f6b6083269a9d6f388da3509c