### PR TITLE
Fix production API base URL fallback

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -38,7 +38,7 @@ npm run dev
 
 ## Documentos Padrão
 
-O módulo de templates de documentos consome a API disponível em `http://localhost:3001/api`. Caso o backend esteja em outra URL, defina a variável de ambiente `VITE_API_URL` antes de iniciar o projeto. Caso contrário, o frontend utilizará automaticamente o mesmo domínio em que estiver publicado.
+O módulo de templates de documentos consome a API disponível em `http://localhost:3001/api`. Caso o backend esteja em outra URL, defina a variável de ambiente `VITE_API_URL` antes de iniciar o projeto. Caso contrário, o frontend utilizará automaticamente o mesmo domínio em que estiver publicado ou, se essa informação não estiver disponível (por exemplo, durante o build em ambientes de homologação/produção), recorrerá ao endpoint público `https://jusconnec.quantumtecnologia.com.br`.
 
 Para facilitar o desenvolvimento utilizando a API de produção, o projeto inclui um arquivo `.env.development` com `VITE_API_URL=https://jusconnec.quantumtecnologia.com.br`. Assim, ao executar `npm run dev`, o frontend apontará automaticamente para os endpoints em produção.
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,6 +3,8 @@ const envApiUrlCandidates = [
   import.meta.env.VITE_API_BASE_URL as string | undefined,
 ];
 
+const PRODUCTION_DEFAULT_API_URL = 'https://jusconnec.quantumtecnologia.com.br';
+
 const rawEnvApiUrl = envApiUrlCandidates
   .map((value) => value?.trim())
   .find((value): value is string => Boolean(value?.length));
@@ -35,7 +37,7 @@ function resolveFallbackBaseUrl(): string {
     return normalizeBaseUrl(window.location.origin);
   }
 
-  return 'http://localhost:3001';
+  return PRODUCTION_DEFAULT_API_URL;
 }
 
 let cachedApiBaseUrl: string | undefined;


### PR DESCRIPTION
## Summary
- default the production API base URL fallback to https://jusconnec.quantumtecnologia.com.br when the environment does not provide one
- document the new fallback behaviour in the frontend README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccb031f2fc8326a5faf90d75a0d896