### PR TITLE
Fix backend default port fallback

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -45,7 +45,7 @@ import { authenticateRequest } from './middlewares/authMiddleware';
 import { authorizeModules } from './middlewares/moduleAuthorization';
 
 const app = express();
-const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 0;
+const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3001;
 
 app.use(express.json({ limit: '50mb' }));
 app.use(express.urlencoded({ extended: true, limit: '50mb' }));


### PR DESCRIPTION
## Summary
- default the Express server to listen on port 3001 when PORT is not defined so the API remains reachable at its documented URL

## Testing
- npm test *(fails: ChatService.updateConversation updates metadata fields – pre-existing assertion mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbf5106b88326abed562cf715c833