### PR TITLE
Add admin navigation toggle and routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { Loader2 } from "lucide-react";
-import { routes } from "@/config/routes";
+import { adminRelativePath, routes } from "@/config/routes";
 import Landing from "./pages/Landing";
 import Clientes from "./pages/Clientes";
 import NovoCliente from "./pages/NovoCliente";
@@ -62,6 +62,22 @@ import NotFound from "./pages/NotFound";
 import { AuthProvider } from "@/features/auth/AuthProvider";
 import { ProtectedRoute } from "@/features/auth/ProtectedRoute";
 import { RequireModule } from "@/features/auth/RequireModule";
+import { RequireAdminUser } from "@/features/auth/RequireAdminUser";
+import DashboardLayout from "@/components/layout/DashboardLayout";
+import AdminDashboard from "./pages/administrator/Dashboard";
+import AdminCompanies from "./pages/administrator/Companies";
+import AdminNewCompany from "./pages/administrator/NewCompany";
+import AdminPlans from "./pages/administrator/Plans";
+import AdminNewPlan from "./pages/administrator/NewPlan";
+import AdminSubscriptions from "./pages/administrator/Subscriptions";
+import AdminNewSubscription from "./pages/administrator/NewSubscription";
+import AdminUsers from "./pages/administrator/Users";
+import AdminNewUser from "./pages/administrator/NewUser";
+import AdminAnalytics from "./pages/administrator/Analytics";
+import AdminSupport from "./pages/administrator/Support";
+import AdminLogs from "./pages/administrator/Logs";
+import AdminSettings from "./pages/administrator/Settings";
+import AdminNotFound from "./pages/administrator/NotFound";
 
 const CRMLayout = lazy(() =>
   import("@/components/layout/CRMLayout").then((module) => ({ default: module.CRMLayout })),
@@ -247,9 +263,34 @@ const App = () => (
                 )}
               />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-                <Route path="*" element={<NotFound />} />
-              </Route>
-            </Routes>
+              <Route path="*" element={<NotFound />} />
+            </Route>
+            <Route
+              path={`${routes.admin.root}/*`}
+              element={(
+                <ProtectedRoute>
+                  <RequireAdminUser>
+                    <DashboardLayout />
+                  </RequireAdminUser>
+                </ProtectedRoute>
+              )}
+            >
+              <Route index element={<AdminDashboard />} />
+              <Route path={adminRelativePath.companies} element={<AdminCompanies />} />
+              <Route path={adminRelativePath.newCompany} element={<AdminNewCompany />} />
+              <Route path={adminRelativePath.plans} element={<AdminPlans />} />
+              <Route path={adminRelativePath.newPlan} element={<AdminNewPlan />} />
+              <Route path={adminRelativePath.subscriptions} element={<AdminSubscriptions />} />
+              <Route path={adminRelativePath.newSubscription} element={<AdminNewSubscription />} />
+              <Route path={adminRelativePath.users} element={<AdminUsers />} />
+              <Route path={adminRelativePath.newUser} element={<AdminNewUser />} />
+              <Route path={adminRelativePath.analytics} element={<AdminAnalytics />} />
+              <Route path={adminRelativePath.support} element={<AdminSupport />} />
+              <Route path={adminRelativePath.logs} element={<AdminLogs />} />
+              <Route path={adminRelativePath.settings} element={<AdminSettings />} />
+              <Route path="*" element={<AdminNotFound />} />
+            </Route>
+          </Routes>
           </Suspense>
         </BrowserRouter>
       </AuthProvider>

--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -20,46 +20,47 @@ import {
   Settings,
 } from "lucide-react";
 import { Link } from "react-router-dom";
+import { isActiveRoute, routes } from "@/config/routes";
 
 const navigation = [
   {
     name: "Dashboard",
-    href: "/",
+    href: routes.admin.dashboard,
     icon: LayoutDashboard,
   },
   {
     name: "Empresas",
-    href: "/companies",
+    href: routes.admin.companies,
     icon: Building2,
   },
   {
     name: "Planos",
-    href: "/plans",
+    href: routes.admin.plans,
     icon: Package,
   },
   {
     name: "Assinaturas",
-    href: "/subscriptions",
+    href: routes.admin.subscriptions,
     icon: CreditCard,
   },
   {
     name: "Usuários",
-    href: "/users",
+    href: routes.admin.users,
     icon: Users,
   },
   {
     name: "Relatórios",
-    href: "/analytics",
+    href: routes.admin.analytics,
     icon: BarChart3,
   },
   {
     name: "Suporte",
-    href: "/support",
+    href: routes.admin.support,
     icon: HeadphonesIcon,
   },
   {
     name: "Configurações",
-    href: "/settings",
+    href: routes.admin.settings,
     icon: Settings,
   },
 ];
@@ -85,7 +86,7 @@ export default function DashboardLayout() {
                 <SidebarMenuItem key={item.name}>
                   <SidebarMenuButton
                     asChild
-                    isActive={location.pathname === item.href}
+                    isActive={isActiveRoute(location.pathname, item.href)}
                   >
                     <Link to={item.href} className="flex items-center gap-3">
                       <item.icon className="h-4 w-4" />

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { Search, User, LogOut } from "lucide-react";
+import { Search, User, LogOut, ArrowLeftRight } from "lucide-react";
 import { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
@@ -101,6 +101,18 @@ export function Header() {
               <User className="mr-2 h-4 w-4" />
               Perfil
             </DropdownMenuItem>
+            {user?.id === 3 && (
+              <DropdownMenuItem
+                onSelect={(event) => {
+                  event.preventDefault();
+                  navigate(routes.admin.dashboard);
+                }}
+              >
+                <ArrowLeftRight className="mr-2 h-4 w-4" />
+                Alternar perfil
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuSeparator />
             {/*{canAccessConfiguracoes && (*/}
             {/*  <DropdownMenuItem*/}
             {/*    onSelect={(event) => {*/}

--- a/frontend/src/features/auth/RequireAdminUser.tsx
+++ b/frontend/src/features/auth/RequireAdminUser.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from "react";
+import { ShieldAlert } from "lucide-react";
+import { useAuth } from "./AuthProvider";
+
+interface RequireAdminUserProps {
+  children: ReactNode;
+}
+
+export const RequireAdminUser = ({ children }: RequireAdminUserProps) => {
+  const { user, isLoading } = useAuth();
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (user?.id === 3) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="flex min-h-full flex-col items-center justify-center gap-4 p-6 text-center">
+      <ShieldAlert className="h-12 w-12 text-muted-foreground" aria-hidden="true" />
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Acesso restrito</h1>
+        <p className="text-sm text-muted-foreground">
+          Você não possui permissão para acessar o ambiente administrativo. Solicite a um administrador que habilite seu acesso.
+        </p>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add "Alternar perfil" option for the user dropdown that routes admins to the administrator dashboard
- introduce an admin-only route guard and wire the administrator layout and pages into the router
- align the administrator sidebar navigation with the configured admin routes for consistent linking

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccc36f010c83268cd3b0c23cfcf84d