### PR TITLE
Ensure new user inherits authenticated company

### DIFF
--- a/frontend/src/pages/configuracoes/usuarios/NovoUsuario.tsx
+++ b/frontend/src/pages/configuracoes/usuarios/NovoUsuario.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/select";
 import { toast } from "@/components/ui/use-toast";
 import { getApiBaseUrl } from "@/lib/api";
+import { useAuth } from "@/features/auth/AuthProvider";
 
 const apiUrl = getApiBaseUrl();
 
@@ -65,6 +66,7 @@ export default function NovoUsuario() {
   const navigate = useNavigate();
   const [perfis, setPerfis] = useState<ApiPerfil[]>([]);
   const [setores, setSetores] = useState<ApiSetor[]>([]);
+  const { user } = useAuth();
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
@@ -124,6 +126,11 @@ export default function NovoUsuario() {
   }, []);
 
   const onSubmit = async (data: FormValues) => {
+    if (!user) {
+      toast({ title: "Sessão expirada", description: "Faça login novamente.", variant: "destructive" });
+      return;
+    }
+
     let password = data.password;
     if (!password) {
       password = Math.random().toString(36).slice(-8);
@@ -131,14 +138,15 @@ export default function NovoUsuario() {
 
     const perfilId = Number(data.perfilId);
     const setorId = Number(data.setorId);
+    const empresaId = user.empresa_id ?? null;
 
     const payload = {
       nome_completo: data.name,
       cpf: "",
       email: data.email,
       perfil: Number.isNaN(perfilId) ? null : perfilId,
-      empresa: 1,
-      escritorio: Number.isNaN(setorId) ? null : setorId,
+      empresa: empresaId,
+      setor: Number.isNaN(setorId) ? null : setorId,
       oab: null,
       status: true,
       senha: password,


### PR DESCRIPTION
## Summary
- use the authenticated user's company from the auth context when preparing the new user payload
- prevent submissions when the session is missing and send setor instead of escritorio in the request body

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccc6db67208326b66d6215aecb76af