### PR TITLE
Add lazy loading for admin area

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { Loader2 } from "lucide-react";
-import { routes } from "@/config/routes";
+import { adminRelativePath, routes } from "@/config/routes";
 import Landing from "./pages/Landing";
 import Clientes from "./pages/Clientes";
 import NovoCliente from "./pages/NovoCliente";
@@ -62,11 +62,27 @@ import NotFound from "./pages/NotFound";
 import { AuthProvider } from "@/features/auth/AuthProvider";
 import { ProtectedRoute } from "@/features/auth/ProtectedRoute";
 import { RequireModule } from "@/features/auth/RequireModule";
+import { RequireAdminUser } from "@/features/auth/RequireAdminUser";
 
 const CRMLayout = lazy(() =>
   import("@/components/layout/CRMLayout").then((module) => ({ default: module.CRMLayout })),
 );
 const Dashboard = lazy(() => import("./pages/Dashboard"));
+const AdminLayout = lazy(() => import("@/components/layout/DashboardLayout"));
+const AdminDashboard = lazy(() => import("./pages/administrator/Dashboard"));
+const AdminCompanies = lazy(() => import("./pages/administrator/Companies"));
+const AdminNewCompany = lazy(() => import("./pages/administrator/NewCompany"));
+const AdminPlans = lazy(() => import("./pages/administrator/Plans"));
+const AdminNewPlan = lazy(() => import("./pages/administrator/NewPlan"));
+const AdminSubscriptions = lazy(() => import("./pages/administrator/Subscriptions"));
+const AdminNewSubscription = lazy(() => import("./pages/administrator/NewSubscription"));
+const AdminUsers = lazy(() => import("./pages/administrator/Users"));
+const AdminNewUser = lazy(() => import("./pages/administrator/NewUser"));
+const AdminAnalytics = lazy(() => import("./pages/administrator/Analytics"));
+const AdminSupport = lazy(() => import("./pages/administrator/Support"));
+const AdminLogs = lazy(() => import("./pages/administrator/Logs"));
+const AdminSettings = lazy(() => import("./pages/administrator/Settings"));
+const AdminNotFound = lazy(() => import("./pages/administrator/NotFound"));
 
 const queryClient = new QueryClient();
 
@@ -247,7 +263,34 @@ const App = () => (
                 )}
               />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-                <Route path="*" element={<NotFound />} />
+              <Route path="*" element={<NotFound />} />
+              </Route>
+              <Route
+                path={`${routes.admin.root}/*`}
+                element={(
+                  <Suspense fallback={<LandingFallback />}>
+                    <ProtectedRoute>
+                      <RequireAdminUser>
+                        <AdminLayout />
+                      </RequireAdminUser>
+                    </ProtectedRoute>
+                  </Suspense>
+                )}
+              >
+                <Route index element={<AdminDashboard />} />
+                <Route path={adminRelativePath.companies} element={<AdminCompanies />} />
+                <Route path={adminRelativePath.newCompany} element={<AdminNewCompany />} />
+                <Route path={adminRelativePath.plans} element={<AdminPlans />} />
+                <Route path={adminRelativePath.newPlan} element={<AdminNewPlan />} />
+                <Route path={adminRelativePath.subscriptions} element={<AdminSubscriptions />} />
+                <Route path={adminRelativePath.newSubscription} element={<AdminNewSubscription />} />
+                <Route path={adminRelativePath.users} element={<AdminUsers />} />
+                <Route path={adminRelativePath.newUser} element={<AdminNewUser />} />
+                <Route path={adminRelativePath.analytics} element={<AdminAnalytics />} />
+                <Route path={adminRelativePath.support} element={<AdminSupport />} />
+                <Route path={adminRelativePath.logs} element={<AdminLogs />} />
+                <Route path={adminRelativePath.settings} element={<AdminSettings />} />
+                <Route path="*" element={<AdminNotFound />} />
               </Route>
             </Routes>
           </Suspense>

--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -20,46 +20,47 @@ import {
   Settings,
 } from "lucide-react";
 import { Link } from "react-router-dom";
+import { isActiveRoute, routes } from "@/config/routes";
 
 const navigation = [
   {
     name: "Dashboard",
-    href: "/",
+    href: routes.admin.dashboard,
     icon: LayoutDashboard,
   },
   {
     name: "Empresas",
-    href: "/companies",
+    href: routes.admin.companies,
     icon: Building2,
   },
   {
     name: "Planos",
-    href: "/plans",
+    href: routes.admin.plans,
     icon: Package,
   },
   {
     name: "Assinaturas",
-    href: "/subscriptions",
+    href: routes.admin.subscriptions,
     icon: CreditCard,
   },
   {
     name: "Usuários",
-    href: "/users",
+    href: routes.admin.users,
     icon: Users,
   },
   {
     name: "Relatórios",
-    href: "/analytics",
+    href: routes.admin.analytics,
     icon: BarChart3,
   },
   {
     name: "Suporte",
-    href: "/support",
+    href: routes.admin.support,
     icon: HeadphonesIcon,
   },
   {
     name: "Configurações",
-    href: "/settings",
+    href: routes.admin.settings,
     icon: Settings,
   },
 ];
@@ -85,7 +86,7 @@ export default function DashboardLayout() {
                 <SidebarMenuItem key={item.name}>
                   <SidebarMenuButton
                     asChild
-                    isActive={location.pathname === item.href}
+                    isActive={isActiveRoute(location.pathname, item.href)}
                   >
                     <Link to={item.href} className="flex items-center gap-3">
                       <item.icon className="h-4 w-4" />

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { Search, User, LogOut } from "lucide-react";
+import { Search, User, LogOut, ArrowLeftRight } from "lucide-react";
 import { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
@@ -101,6 +101,17 @@ export function Header() {
               <User className="mr-2 h-4 w-4" />
               Perfil
             </DropdownMenuItem>
+            {user?.id === 3 && (
+              <DropdownMenuItem
+                onSelect={(event) => {
+                  event.preventDefault();
+                  navigate(routes.admin.dashboard);
+                }}
+              >
+                <ArrowLeftRight className="mr-2 h-4 w-4" />
+                Alternar perfil
+              </DropdownMenuItem>
+            )}
             {/*{canAccessConfiguracoes && (*/}
             {/*  <DropdownMenuItem*/}
             {/*    onSelect={(event) => {*/}

--- a/frontend/src/features/auth/RequireAdminUser.tsx
+++ b/frontend/src/features/auth/RequireAdminUser.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from "react";
+import { ShieldAlert } from "lucide-react";
+import { useAuth } from "./AuthProvider";
+
+interface RequireAdminUserProps {
+  children: ReactNode;
+}
+
+export const RequireAdminUser = ({ children }: RequireAdminUserProps) => {
+  const { user, isLoading } = useAuth();
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (user?.id === 3) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="flex min-h-full flex-col items-center justify-center gap-4 p-6 text-center">
+      <ShieldAlert className="h-12 w-12 text-muted-foreground" aria-hidden="true" />
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Acesso restrito</h1>
+        <p className="text-sm text-muted-foreground">
+          Você não possui permissão para acessar o ambiente administrativo. Solicite a um administrador que habilite seu acesso.
+        </p>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- lazy-load the administrator layout and pages and guard them behind RequireAdminUser
- restore the administrator routing tree with updated navigation helpers and Suspense fallback
- reintroduce the "Alternar perfil" header action for admin users

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccc74570b483268098a691bbb6ddb4