### PR TITLE
Restrict usuario listing to authenticated company

### DIFF
--- a/backend/tests/chatService.test.ts
+++ b/backend/tests/chatService.test.ts
@@ -252,7 +252,10 @@ test('ChatService.updateConversation updates metadata fields', async () => {
   });
 
   assert.equal(pool.calls.length, 2);
-  assert.match(pool.calls[0]!.text ?? '', /FROM public\."vw\.usuarios"/);
+  assert.match(
+    pool.calls[0]!.text ?? '',
+    /FROM public\.(?:"vw\.usuarios"|vw_usuarios)/
+  );
   assert.match(pool.calls[1]!.text ?? '', /UPDATE chat_conversations/);
   assert.equal(updated?.responsible?.id, '7');
   assert.deepEqual(updated?.tags, ['Lead', 'VIP']);

--- a/backend/tests/usuarioController.test.ts
+++ b/backend/tests/usuarioController.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { Request, Response } from 'express';
+
+import { listUsuarios } from '../src/controllers/usuarioController';
+import pool from '../src/services/db';
+
+type QueryCall = { text: string; values?: unknown[] };
+type QueryResponse = { rows: any[]; rowCount: number };
+
+type MockResponse = {
+  statusCode: number;
+  payload: unknown;
+  status(code: number): MockResponse;
+  json(data: unknown): MockResponse;
+};
+
+const createMockResponse = (): MockResponse => ({
+  statusCode: 200,
+  payload: undefined,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(data) {
+    this.payload = data;
+    return this;
+  },
+});
+
+test('listUsuarios limita os resultados à empresa do usuário autenticado', async (t) => {
+  const responses: QueryResponse[] = [
+    { rows: [{ empresa: 7 }], rowCount: 1 },
+    { rows: [{ id: 1 }, { id: 2 }], rowCount: 2 },
+  ];
+  const queries: QueryCall[] = [];
+
+  t.mock.method(pool, 'query', async (text: string, values?: unknown[]) => {
+    queries.push({ text, values });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error('Unexpected query execution');
+    }
+    return response;
+  });
+
+  const req = { auth: { userId: 42 } } as unknown as Request;
+  const res = createMockResponse();
+
+  await listUsuarios(req, res as unknown as Response);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.payload, [{ id: 1 }, { id: 2 }]);
+  assert.equal(queries.length, 2);
+  assert.match(queries[1]?.text ?? '', /WHERE u\.empresa = \$1/);
+  assert.deepEqual(queries[1]?.values, [7]);
+});
+
+test('listUsuarios retorna lista vazia quando usuário autenticado não possui empresa', async (t) => {
+  const responses: QueryResponse[] = [{ rows: [{ empresa: null }], rowCount: 1 }];
+  const queries: QueryCall[] = [];
+
+  t.mock.method(pool, 'query', async (text: string, values?: unknown[]) => {
+    queries.push({ text, values });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error('Unexpected query execution');
+    }
+    return response;
+  });
+
+  const req = { auth: { userId: 84 } } as unknown as Request;
+  const res = createMockResponse();
+
+  await listUsuarios(req, res as unknown as Response);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.payload, []);
+  assert.equal(queries.length, 1, 'should not query usuarios view without empresa vinculada');
+});


### PR DESCRIPTION
## Summary
- scope the usuario listing to the authenticated user's company by reusing the company lookup logic
- ensure users without an associated company receive an empty list instead of cross-tenant data
- cover the new access rules with controller tests and update chat service expectations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cccdce5c888326b56bc6d18a65e312