### PR TITLE
Restrict usuario lookup to tenant

### DIFF
--- a/backend/src/controllers/usuarioController.ts
+++ b/backend/src/controllers/usuarioController.ts
@@ -93,7 +93,43 @@ const parseStatus = (value: unknown): boolean | 'invalid' => {
 };
 
 const baseUsuarioSelect =
-  'SELECT id, nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao FROM public.vw_usuarios';
+  'SELECT id, nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao FROM public.vw_usuarios vu';
+
+type EmpresaLookupResult =
+  | { success: true; empresaId: number | null }
+  | { success: false; status: number; message: string };
+
+const fetchAuthenticatedUserEmpresa = async (userId: number): Promise<EmpresaLookupResult> => {
+  const empresaUsuarioResult = await pool.query(
+    'SELECT empresa FROM public.usuarios WHERE id = $1 LIMIT 1',
+    [userId]
+  );
+
+  if (empresaUsuarioResult.rowCount === 0) {
+    return {
+      success: false,
+      status: 404,
+      message: 'Usuário autenticado não encontrado',
+    };
+  }
+
+  const empresaAtualResult = parseOptionalId(
+    (empresaUsuarioResult.rows[0] as { empresa: unknown }).empresa
+  );
+
+  if (empresaAtualResult === 'invalid') {
+    return {
+      success: false,
+      status: 500,
+      message: 'Não foi possível identificar a empresa do usuário autenticado.',
+    };
+  }
+
+  return {
+    success: true,
+    empresaId: empresaAtualResult,
+  };
+};
 
 export const listUsuarios = async (_req: Request, res: Response) => {
   try {
@@ -108,7 +144,22 @@ export const listUsuarios = async (_req: Request, res: Response) => {
 export const getUsuarioById = async (req: Request, res: Response) => {
   const { id } = req.params;
   try {
-    const result = await pool.query(`${baseUsuarioSelect} WHERE id = $1`, [id]);
+    if (!req.auth) {
+      return res.status(401).json({ error: 'Token inválido.' });
+    }
+
+    const empresaLookup = await fetchAuthenticatedUserEmpresa(req.auth.userId);
+
+    if (!empresaLookup.success) {
+      return res.status(empresaLookup.status).json({ error: empresaLookup.message });
+    }
+
+    const { empresaId } = empresaLookup;
+
+    const result = await pool.query(
+      `${baseUsuarioSelect} INNER JOIN public.usuarios u ON u.id = vu.id WHERE vu.id = $1 AND u.empresa IS NOT DISTINCT FROM $2::INT`,
+      [id, empresaId]
+    );
     if (result.rowCount === 0) {
       return res.status(404).json({ error: 'Usuário não encontrado' });
     }
@@ -150,24 +201,13 @@ export const createUsuario = async (req: Request, res: Response) => {
       return res.status(400).json({ error: 'ID de empresa inválido' });
     }
 
-    const empresaUsuarioResult = await pool.query(
-      'SELECT empresa FROM public.usuarios WHERE id = $1 LIMIT 1',
-      [req.auth.userId]
-    );
+    const empresaLookup = await fetchAuthenticatedUserEmpresa(req.auth.userId);
 
-    if (empresaUsuarioResult.rowCount === 0) {
-      return res.status(404).json({ error: 'Usuário autenticado não encontrado' });
+    if (!empresaLookup.success) {
+      return res.status(empresaLookup.status).json({ error: empresaLookup.message });
     }
 
-    const empresaAtualResult = parseOptionalId(
-      (empresaUsuarioResult.rows[0] as { empresa: unknown }).empresa
-    );
-
-    if (empresaAtualResult === 'invalid') {
-      return res
-        .status(500)
-        .json({ error: 'Não foi possível identificar a empresa do usuário autenticado.' });
-    }
+    const empresaAtualResult = empresaLookup.empresaId;
 
     if (empresaIdResult !== null && empresaAtualResult !== null && empresaIdResult !== empresaAtualResult) {
       return res

--- a/backend/tests/chatService.test.ts
+++ b/backend/tests/chatService.test.ts
@@ -252,7 +252,7 @@ test('ChatService.updateConversation updates metadata fields', async () => {
   });
 
   assert.equal(pool.calls.length, 2);
-  assert.match(pool.calls[0]!.text ?? '', /FROM public\."vw\.usuarios"/);
+  assert.match(pool.calls[0]!.text ?? '', /FROM public\.vw_usuarios/);
   assert.match(pool.calls[1]!.text ?? '', /UPDATE chat_conversations/);
   assert.equal(updated?.responsible?.id, '7');
   assert.deepEqual(updated?.tags, ['Lead', 'VIP']);

--- a/backend/tests/usuarioController.test.ts
+++ b/backend/tests/usuarioController.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { Request, Response } from 'express';
+import { Pool } from 'pg';
+
+process.env.DATABASE_URL ??= 'postgresql://user:pass@localhost:5432/testdb';
+
+type QueryCall = { text: string; values?: unknown[] };
+type QueryResponse = { rows: any[]; rowCount: number };
+
+let getUsuarioById: typeof import('../src/controllers/usuarioController')['getUsuarioById'];
+
+test.before(async () => {
+  ({ getUsuarioById } = await import('../src/controllers/usuarioController'));
+});
+
+const createMockResponse = () => {
+  const response: Partial<Response> & { statusCode: number; body: unknown } = {
+    statusCode: 200,
+    body: undefined,
+    status(code: number) {
+      this.statusCode = code;
+      return this as Response;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this as Response;
+    },
+  };
+
+  return response as Response & { statusCode: number; body: unknown };
+};
+
+const setupQueryMock = (responses: QueryResponse[]) => {
+  const calls: QueryCall[] = [];
+  const mock = test.mock.method(
+    Pool.prototype,
+    'query',
+    async function (this: Pool, text: string, values?: unknown[]) {
+      calls.push({ text, values });
+
+      if (responses.length === 0) {
+        throw new Error('Unexpected query invocation');
+      }
+
+      return responses.shift()!;
+    }
+  );
+
+  const restore = () => {
+    mock.mock.restore();
+  };
+
+  return { calls, restore };
+};
+
+const createAuth = (userId: number) => ({
+  userId,
+  payload: {
+    sub: userId,
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  },
+});
+
+test('getUsuarioById returns user when it belongs to the same company', async () => {
+  const userRow = {
+    id: 123,
+    nome_completo: 'Maria Silva',
+    cpf: '12345678901',
+    email: 'maria@example.com',
+    perfil: 'admin',
+    empresa: 42,
+    setor: 7,
+    oab: '12345',
+    status: true,
+    senha: '$hashed',
+    telefone: '(11) 99999-0000',
+    ultimo_login: '2024-01-01T12:00:00.000Z',
+    observacoes: null,
+    datacriacao: '2023-01-01T12:00:00.000Z',
+  };
+
+  const { calls, restore } = setupQueryMock([
+    { rows: [{ empresa: 42 }], rowCount: 1 },
+    { rows: [userRow], rowCount: 1 },
+  ]);
+
+  const req = {
+    params: { id: '123' },
+    auth: createAuth(10),
+  } as unknown as Request;
+
+  const res = createMockResponse();
+
+  try {
+    await getUsuarioById(req, res);
+  } finally {
+    restore();
+  }
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, userRow);
+  assert.equal(calls.length, 2);
+  assert.match(calls[0]?.text ?? '', /SELECT empresa FROM public\.usuarios/);
+  assert.match(calls[1]?.text ?? '', /JOIN public\.usuarios/);
+  assert.match(calls[1]?.text ?? '', /u\.empresa IS NOT DISTINCT FROM \$2::INT/);
+  assert.deepEqual(calls[1]?.values, ['123', 42]);
+});
+
+test('getUsuarioById returns 404 when user belongs to another company', async () => {
+  const { calls, restore } = setupQueryMock([
+    { rows: [{ empresa: 42 }], rowCount: 1 },
+    { rows: [], rowCount: 0 },
+  ]);
+
+  const req = {
+    params: { id: '999' },
+    auth: createAuth(10),
+  } as unknown as Request;
+
+  const res = createMockResponse();
+
+  try {
+    await getUsuarioById(req, res);
+  } finally {
+    restore();
+  }
+
+  assert.equal(res.statusCode, 404);
+  assert.deepEqual(res.body, { error: 'Usuário não encontrado' });
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls[1]?.values, ['999', 42]);
+});
+


### PR DESCRIPTION
## Summary
- reuse the authenticated user's company lookup helper in the usuario controller
- constrain `getUsuarioById` to rows that match the authenticated company and return 401/404 when scoped access fails
- cover the multi-tenant behaviour with new controller tests and adjust existing expectations for the shared query string

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cccdce77548326a7bcb4757014c744