### PR TITLE
feat: reuse header actions in admin layout

### DIFF
--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -21,6 +21,7 @@ import {
   Loader2,
   Settings,
 } from "lucide-react";
+import { HeaderActions } from "@/components/layout/HeaderActions";
 import { Link } from "react-router-dom";
 import { isActiveRoute, routes } from "@/config/routes";
 
@@ -106,9 +107,8 @@ export default function DashboardLayout() {
             <div className="flex h-14 items-center gap-4 px-4">
               <SidebarTrigger />
               <div className="flex-1" />
-              <div className="flex items-center gap-4">
-                <span className="text-sm text-muted-foreground">Admin CRM SaaS</span>
-              </div>
+              <span className="text-sm text-muted-foreground">Admin CRM SaaS</span>
+              <HeaderActions />
             </div>
           </header>
 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,53 +1,9 @@
-import { Search, User, LogOut, ArrowLeftRight } from "lucide-react";
-import { useCallback } from "react";
-import { useNavigate } from "react-router-dom";
-import { Button } from "@/components/ui/button";
+import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
-import { ModeToggle } from "@/components/ui/mode-toggle";
+import { HeaderActions } from "@/components/layout/HeaderActions";
 import { SidebarTrigger } from "@/components/ui/sidebar";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { IntimacaoMenu } from "@/components/notifications/IntimacaoMenu";
-import { useAuth } from "@/features/auth/AuthProvider";
-import { routes } from "@/config/routes";
-
-const getInitials = (name: string | undefined) => {
-  if (!name) {
-    return "--";
-  }
-
-  const parts = name
-    .split(/\s+/u)
-    .filter(Boolean)
-    .slice(0, 2);
-
-  if (parts.length === 0) {
-    return name.slice(0, 2).toUpperCase();
-  }
-
-  return parts
-    .map((part) => part.charAt(0).toUpperCase())
-    .join("");
-};
 
 export function Header() {
-  const navigate = useNavigate();
-  const { user, logout } = useAuth();
-  const canAccessConfiguracoes =
-    user?.modulos?.some((moduleId) => moduleId === "configuracoes" || moduleId.startsWith("configuracoes-")) ?? false;
-
-  const handleLogout = useCallback(() => {
-    logout();
-    navigate(routes.login, { replace: true });
-  }, [logout, navigate]);
-
   return (
     <header className="h-16 bg-card border-b border-border px-6 flex items-center justify-between gap-4">
       {/* Search */}
@@ -65,76 +21,7 @@ export function Header() {
       </div>
 
       {/* Actions */}
-      <div className="flex items-center gap-3">
-        <ModeToggle />
-        {/* Notifications */}
-        <IntimacaoMenu />
-
-        {/* User Menu */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" className="flex items-center gap-2">
-              <Avatar className="h-8 w-8">
-                <AvatarFallback className="bg-primary text-primary-foreground">
-                  {getInitials(user?.nome_completo)}
-                </AvatarFallback>
-              </Avatar>
-              <div className="text-left">
-                <p className="text-sm font-medium truncate max-w-[160px]">
-                  {user?.nome_completo ?? "Usuário"}
-                </p>
-                <p className="text-xs text-muted-foreground truncate max-w-[160px]">
-                  {user?.email ?? "Conta"}
-                </p>
-              </div>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-48">
-            <DropdownMenuLabel>Minha Conta</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onSelect={(event) => {
-                event.preventDefault();
-                navigate("/meu-perfil");
-              }}
-            >
-              <User className="mr-2 h-4 w-4" />
-              Perfil
-            </DropdownMenuItem>
-            {user?.id === 3 && (
-              <DropdownMenuItem
-                onSelect={(event) => {
-                  event.preventDefault();
-                  navigate(routes.admin.dashboard);
-                }}
-              >
-                <ArrowLeftRight className="mr-2 h-4 w-4" />
-                Alternar perfil
-              </DropdownMenuItem>
-            )}
-            {/*{canAccessConfiguracoes && (*/}
-            {/*  <DropdownMenuItem*/}
-            {/*    onSelect={(event) => {*/}
-            {/*      event.preventDefault();*/}
-            {/*      navigate("/configuracoes");*/}
-            {/*    }}*/}
-            {/*  >*/}
-            {/*    Configurações*/}
-            {/*  </DropdownMenuItem>*/}
-            {/*)}*/}
-            {/*<DropdownMenuSeparator />*/}
-            <DropdownMenuItem
-              onSelect={(event) => {
-                event.preventDefault();
-                handleLogout();
-              }}
-            >
-              <LogOut className="mr-2 h-4 w-4" />
-              Sair
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+      <HeaderActions />
     </header>
   );
 }

--- a/frontend/src/components/layout/HeaderActions.tsx
+++ b/frontend/src/components/layout/HeaderActions.tsx
@@ -1,0 +1,118 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowLeftRight, LogOut, User } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { ModeToggle } from "@/components/ui/mode-toggle";
+import { IntimacaoMenu } from "@/components/notifications/IntimacaoMenu";
+import { useAuth } from "@/features/auth/AuthProvider";
+import { routes } from "@/config/routes";
+
+const getInitials = (name: string | undefined) => {
+  if (!name) {
+    return "--";
+  }
+
+  const parts = name
+    .split(/\s+/u)
+    .filter(Boolean)
+    .slice(0, 2);
+
+  if (parts.length === 0) {
+    return name.slice(0, 2).toUpperCase();
+  }
+
+  return parts
+    .map((part) => part.charAt(0).toUpperCase())
+    .join("");
+};
+
+export function HeaderActions() {
+  const navigate = useNavigate();
+  const { user, logout } = useAuth();
+  const canAccessConfiguracoes =
+    user?.modulos?.some((moduleId) => moduleId === "configuracoes" || moduleId.startsWith("configuracoes-")) ?? false;
+
+  const handleLogout = useCallback(() => {
+    logout();
+    navigate(routes.login, { replace: true });
+  }, [logout, navigate]);
+
+  return (
+    <div className="flex items-center gap-3">
+      <ModeToggle />
+      <IntimacaoMenu />
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" className="flex items-center gap-2">
+            <Avatar className="h-8 w-8">
+              <AvatarFallback className="bg-primary text-primary-foreground">
+                {getInitials(user?.nome_completo)}
+              </AvatarFallback>
+            </Avatar>
+            <div className="text-left">
+              <p className="text-sm font-medium truncate max-w-[160px]">
+                {user?.nome_completo ?? "Usuário"}
+              </p>
+              <p className="text-xs text-muted-foreground truncate max-w-[160px]">
+                {user?.email ?? "Conta"}
+              </p>
+            </div>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-48">
+          <DropdownMenuLabel>Minha Conta</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={(event) => {
+              event.preventDefault();
+              navigate("/meu-perfil");
+            }}
+          >
+            <User className="mr-2 h-4 w-4" />
+            Perfil
+          </DropdownMenuItem>
+          {user?.id === 3 && (
+            <DropdownMenuItem
+              onSelect={(event) => {
+                event.preventDefault();
+                navigate(routes.admin.dashboard);
+              }}
+            >
+              <ArrowLeftRight className="mr-2 h-4 w-4" />
+              Alternar perfil
+            </DropdownMenuItem>
+          )}
+          {/*{canAccessConfiguracoes && (*/}
+          {/*  <DropdownMenuItem*/}
+          {/*    onSelect={(event) => {*/}
+          {/*      event.preventDefault();*/}
+          {/*      navigate("/configuracoes");*/}
+          {/*    }}*/}
+          {/*  >*/}
+          {/*    Configurações*/}
+          {/*  </DropdownMenuItem>*/}
+          {/*)}*/}
+          <DropdownMenuItem
+            onSelect={(event) => {
+              event.preventDefault();
+              handleLogout();
+            }}
+          >
+            <LogOut className="mr-2 h-4 w-4" />
+            Sair
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extract the header action menu into a shared component
- reuse the shared header actions in the CRM and admin layouts so the profile switch shows the same menu

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccd22a478c832699cac7bfd11a82db