### PR TITLE
fix: restore admin navigation and profile toggle

### DIFF
--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -1,5 +1,5 @@
-import { Suspense } from "react";
-import { Outlet, useLocation } from "react-router-dom";
+import { Suspense, useCallback } from "react";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import {
   Sidebar,
   SidebarContent,
@@ -21,7 +21,7 @@ import {
   Loader2,
   Settings,
 } from "lucide-react";
-import { Link } from "react-router-dom";
+import { HeaderActions } from "@/components/layout/HeaderActions";
 import { isActiveRoute, routes } from "@/config/routes";
 
 const navigation = [
@@ -69,6 +69,14 @@ const navigation = [
 
 export default function DashboardLayout() {
   const location = useLocation();
+  const navigate = useNavigate();
+
+  const handleNavigate = useCallback(
+    (target: string) => {
+      navigate(target);
+    },
+    [navigate],
+  );
 
   return (
     <SidebarProvider>
@@ -87,13 +95,12 @@ export default function DashboardLayout() {
               {navigation.map((item) => (
                 <SidebarMenuItem key={item.name}>
                   <SidebarMenuButton
-                    asChild
                     isActive={isActiveRoute(location.pathname, item.href)}
+                    onClick={() => handleNavigate(item.href)}
+                    className="flex items-center gap-3"
                   >
-                    <Link to={item.href} className="flex items-center gap-3">
-                      <item.icon className="h-4 w-4" />
-                      <span>{item.name}</span>
-                    </Link>
+                    <item.icon className="h-4 w-4" />
+                    <span>{item.name}</span>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               ))}
@@ -106,9 +113,8 @@ export default function DashboardLayout() {
             <div className="flex h-14 items-center gap-4 px-4">
               <SidebarTrigger />
               <div className="flex-1" />
-              <div className="flex items-center gap-4">
-                <span className="text-sm text-muted-foreground">Admin CRM SaaS</span>
-              </div>
+              <span className="text-sm text-muted-foreground">Admin CRM SaaS</span>
+              <HeaderActions />
             </div>
           </header>
 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,53 +1,9 @@
-import { Search, User, LogOut, ArrowLeftRight } from "lucide-react";
-import { useCallback } from "react";
-import { useNavigate } from "react-router-dom";
-import { Button } from "@/components/ui/button";
+import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
-import { ModeToggle } from "@/components/ui/mode-toggle";
+import { HeaderActions } from "@/components/layout/HeaderActions";
 import { SidebarTrigger } from "@/components/ui/sidebar";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { IntimacaoMenu } from "@/components/notifications/IntimacaoMenu";
-import { useAuth } from "@/features/auth/AuthProvider";
-import { routes } from "@/config/routes";
-
-const getInitials = (name: string | undefined) => {
-  if (!name) {
-    return "--";
-  }
-
-  const parts = name
-    .split(/\s+/u)
-    .filter(Boolean)
-    .slice(0, 2);
-
-  if (parts.length === 0) {
-    return name.slice(0, 2).toUpperCase();
-  }
-
-  return parts
-    .map((part) => part.charAt(0).toUpperCase())
-    .join("");
-};
 
 export function Header() {
-  const navigate = useNavigate();
-  const { user, logout } = useAuth();
-  const canAccessConfiguracoes =
-    user?.modulos?.some((moduleId) => moduleId === "configuracoes" || moduleId.startsWith("configuracoes-")) ?? false;
-
-  const handleLogout = useCallback(() => {
-    logout();
-    navigate(routes.login, { replace: true });
-  }, [logout, navigate]);
-
   return (
     <header className="h-16 bg-card border-b border-border px-6 flex items-center justify-between gap-4">
       {/* Search */}
@@ -65,76 +21,7 @@ export function Header() {
       </div>
 
       {/* Actions */}
-      <div className="flex items-center gap-3">
-        <ModeToggle />
-        {/* Notifications */}
-        <IntimacaoMenu />
-
-        {/* User Menu */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" className="flex items-center gap-2">
-              <Avatar className="h-8 w-8">
-                <AvatarFallback className="bg-primary text-primary-foreground">
-                  {getInitials(user?.nome_completo)}
-                </AvatarFallback>
-              </Avatar>
-              <div className="text-left">
-                <p className="text-sm font-medium truncate max-w-[160px]">
-                  {user?.nome_completo ?? "Usuário"}
-                </p>
-                <p className="text-xs text-muted-foreground truncate max-w-[160px]">
-                  {user?.email ?? "Conta"}
-                </p>
-              </div>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-48">
-            <DropdownMenuLabel>Minha Conta</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onSelect={(event) => {
-                event.preventDefault();
-                navigate("/meu-perfil");
-              }}
-            >
-              <User className="mr-2 h-4 w-4" />
-              Perfil
-            </DropdownMenuItem>
-            {user?.id === 3 && (
-              <DropdownMenuItem
-                onSelect={(event) => {
-                  event.preventDefault();
-                  navigate(routes.admin.dashboard);
-                }}
-              >
-                <ArrowLeftRight className="mr-2 h-4 w-4" />
-                Alternar perfil
-              </DropdownMenuItem>
-            )}
-            {/*{canAccessConfiguracoes && (*/}
-            {/*  <DropdownMenuItem*/}
-            {/*    onSelect={(event) => {*/}
-            {/*      event.preventDefault();*/}
-            {/*      navigate("/configuracoes");*/}
-            {/*    }}*/}
-            {/*  >*/}
-            {/*    Configurações*/}
-            {/*  </DropdownMenuItem>*/}
-            {/*)}*/}
-            {/*<DropdownMenuSeparator />*/}
-            <DropdownMenuItem
-              onSelect={(event) => {
-                event.preventDefault();
-                handleLogout();
-              }}
-            >
-              <LogOut className="mr-2 h-4 w-4" />
-              Sair
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+      <HeaderActions />
     </header>
   );
 }

--- a/frontend/src/components/layout/HeaderActions.tsx
+++ b/frontend/src/components/layout/HeaderActions.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useMemo } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { ArrowLeftRight, LogOut, User } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { ModeToggle } from "@/components/ui/mode-toggle";
+import { IntimacaoMenu } from "@/components/notifications/IntimacaoMenu";
+import { useAuth } from "@/features/auth/AuthProvider";
+import { routes } from "@/config/routes";
+
+const getInitials = (name: string | undefined) => {
+  if (!name) {
+    return "--";
+  }
+
+  const parts = name
+    .split(/\s+/u)
+    .filter(Boolean)
+    .slice(0, 2);
+
+  if (parts.length === 0) {
+    return name.slice(0, 2).toUpperCase();
+  }
+
+  return parts
+    .map((part) => part.charAt(0).toUpperCase())
+    .join("");
+};
+
+export function HeaderActions() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { user, logout } = useAuth();
+  const canAccessConfiguracoes =
+    user?.modulos?.some((moduleId) => moduleId === "configuracoes" || moduleId.startsWith("configuracoes-")) ?? false;
+
+  const isOnAdminArea = useMemo(() => {
+    const adminRoot = routes.admin.root;
+    return location.pathname === adminRoot || location.pathname.startsWith(`${adminRoot}/`);
+  }, [location.pathname]);
+
+  const profileToggleLabel = isOnAdminArea ? "Alternar para CRM" : "Alternar para admin";
+
+  const handleProfileToggle = useCallback(() => {
+    if (isOnAdminArea) {
+      navigate(routes.home, { replace: true });
+      return;
+    }
+
+    navigate(routes.admin.dashboard, { replace: true });
+  }, [isOnAdminArea, navigate]);
+
+  const handleLogout = useCallback(() => {
+    logout();
+    navigate(routes.login, { replace: true });
+  }, [logout, navigate]);
+
+  return (
+    <div className="flex items-center gap-3">
+      <ModeToggle />
+      <IntimacaoMenu />
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" className="flex items-center gap-2">
+            <Avatar className="h-8 w-8">
+              <AvatarFallback className="bg-primary text-primary-foreground">
+                {getInitials(user?.nome_completo)}
+              </AvatarFallback>
+            </Avatar>
+            <div className="text-left">
+              <p className="text-sm font-medium truncate max-w-[160px]">
+                {user?.nome_completo ?? "Usuário"}
+              </p>
+              <p className="text-xs text-muted-foreground truncate max-w-[160px]">
+                {user?.email ?? "Conta"}
+              </p>
+            </div>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-48">
+          <DropdownMenuLabel>Minha Conta</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={(event) => {
+              event.preventDefault();
+              navigate("/meu-perfil");
+            }}
+          >
+            <User className="mr-2 h-4 w-4" />
+            Perfil
+          </DropdownMenuItem>
+          {user?.id === 3 && (
+            <DropdownMenuItem
+              onSelect={(event) => {
+                event.preventDefault();
+                handleProfileToggle();
+              }}
+            >
+              <ArrowLeftRight className="mr-2 h-4 w-4" />
+              {profileToggleLabel}
+            </DropdownMenuItem>
+          )}
+          {/*{canAccessConfiguracoes && (*/}
+          {/*  <DropdownMenuItem*/}
+          {/*    onSelect={(event) => {*/}
+          {/*      event.preventDefault();*/}
+          {/*      navigate("/configuracoes");*/}
+          {/*    }}*/}
+          {/*  >*/}
+          {/*    Configurações*/}
+          {/*  </DropdownMenuItem>*/}
+          {/*)}*/}
+          <DropdownMenuItem
+            onSelect={(event) => {
+              event.preventDefault();
+              handleLogout();
+            }}
+          >
+            <LogOut className="mr-2 h-4 w-4" />
+            Sair
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- make the shared header actions detect when the admin area is active and send users back to CRM when toggling profiles
- update the admin sidebar buttons to programmatically navigate so each menu entry opens its screen again

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccd22a478c832699cac7bfd11a82db