### PR TITLE
Fix admin companies page crash when formatting MRR

### DIFF
--- a/frontend/src/pages/administrator/Companies.tsx
+++ b/frontend/src/pages/administrator/Companies.tsx
@@ -42,6 +42,14 @@ export default function Companies() {
     return plan?.name || "Sem plano";
   };
 
+  const formatCurrency = (value?: number) => {
+    if (value === undefined || value === null) {
+      return "0";
+    }
+
+    return value.toLocaleString("pt-BR");
+  };
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -161,9 +169,7 @@ export default function Companies() {
                       {new Date(company.lastActivity).toLocaleDateString('pt-BR')}
                     </TableCell>
                     <TableCell>
-                      <div className="font-medium">
-                        R$ {company.subscription?.mrr.toLocaleString() || '0'}
-                      </div>
+                      <div className="font-medium">R$ {formatCurrency(company.subscription?.mrr)}</div>
                     </TableCell>
                     <TableCell className="text-right">
                       <Button variant="ghost" size="sm">


### PR DESCRIPTION
## Summary
- guard MRR formatting on the admin companies table so the page renders for companies without subscriptions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd4a72147c832693a13bcb1cc2819c