### PR TITLE
Integrate admin plans page with API data

### DIFF
--- a/backend/src/controllers/planoController.ts
+++ b/backend/src/controllers/planoController.ts
@@ -10,13 +10,220 @@ const isRecorrenciaValida = (value: unknown): value is Recorrencia =>
 type PlanoRow = {
   id: number;
   nome: string;
-  valor: number;
-  ativo: boolean;
-  datacadastro: Date;
-  descricao: string;
+  valor: number | string | null;
+  ativo: boolean | null;
+  datacadastro: Date | string | null;
+  descricao: string | null;
   recorrencia: Recorrencia | null;
-  qtde_usuarios: number | null;
-  recursos: string | null;
+  qtde_usuarios: number | string | null;
+  recursos: unknown;
+  max_casos?: number | string | null;
+  maxCases?: number | string | null;
+};
+
+type PlanoResponseRow = Omit<PlanoRow, 'recursos' | 'max_casos' | 'maxCases'> & {
+  recursos: string[];
+  max_casos: number | null;
+  maxCases: number | null;
+};
+
+type RecursosDetails = {
+  recursos: string[];
+  maxCasos: number | null;
+};
+
+const FEATURE_KEYS = [
+  'features',
+  'recursos',
+  'items',
+  'itens',
+  'lista',
+  'listaRecursos',
+  'lista_recursos',
+  'values',
+  'value',
+  'feature',
+  'recurso',
+] as const;
+
+const MAX_CASES_KEYS = [
+  'maxCases',
+  'max_casos',
+  'maxProcessos',
+  'max_processos',
+  'limiteCasos',
+  'limite_casos',
+  'limiteProcessos',
+  'limite_processos',
+  'maximoCasos',
+  'maximo_casos',
+  'maximoProcessos',
+  'maximo_processos',
+] as const;
+
+const toInteger = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const normalized = Number(trimmed.replace(/[^\d-]/g, ''));
+    if (Number.isFinite(normalized)) {
+      return Math.trunc(normalized);
+    }
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 1 : 0;
+  }
+
+  return null;
+};
+
+const pushFeature = (features: string[], entry: unknown) => {
+  if (entry === null || entry === undefined) {
+    return;
+  }
+
+  const text =
+    typeof entry === 'string'
+      ? entry.trim()
+      : typeof entry === 'number' || typeof entry === 'boolean'
+        ? String(entry)
+        : '';
+
+  if (text) {
+    features.push(text);
+  }
+};
+
+const parseRecursosDetails = (value: unknown): RecursosDetails => {
+  const features: string[] = [];
+  let maxCasos: number | null = null;
+
+  const visit = (input: unknown): void => {
+    if (input === null || input === undefined) {
+      return;
+    }
+
+    if (typeof input === 'string') {
+      const trimmed = input.trim();
+      if (!trimmed) {
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(trimmed);
+        visit(parsed);
+        return;
+      } catch {
+        // Ignored – fallback to splitting by common separators
+      }
+
+      trimmed
+        .split(/[\n;,]+/)
+        .map((item) => item.trim())
+        .filter(Boolean)
+        .forEach((item) => pushFeature(features, item));
+
+      return;
+    }
+
+    if (typeof input === 'number' || typeof input === 'boolean') {
+      pushFeature(features, input);
+      return;
+    }
+
+    if (Array.isArray(input)) {
+      input.forEach((item) => visit(item));
+      return;
+    }
+
+    if (typeof input === 'object') {
+      const obj = input as Record<string, unknown>;
+
+      FEATURE_KEYS.forEach((key) => {
+        if (key in obj) {
+          visit(obj[key]);
+        }
+      });
+
+      for (const key of MAX_CASES_KEYS) {
+        if (key in obj) {
+          const parsed = toInteger(obj[key]);
+          if (parsed !== null) {
+            maxCasos = parsed;
+            break;
+          }
+        }
+      }
+
+      return;
+    }
+  };
+
+  visit(value);
+
+  const uniqueFeatures = Array.from(new Set(features));
+
+  return {
+    recursos: uniqueFeatures,
+    maxCasos,
+  };
+};
+
+const prepareRecursosForStorage = (
+  recursosInput: unknown,
+  maxCasosInput: unknown,
+  fallback: RecursosDetails | null = null
+): string | null => {
+  const fallbackDetails = fallback ?? { recursos: [], maxCasos: null };
+
+  const sourceFeatures = recursosInput === undefined ? fallbackDetails.recursos : recursosInput;
+  const sourceMaxCasos = maxCasosInput === undefined ? fallbackDetails.maxCasos : maxCasosInput;
+
+  const normalized = parseRecursosDetails({
+    features: sourceFeatures,
+    maxCases: sourceMaxCasos,
+  });
+
+  if (!normalized.recursos.length && normalized.maxCasos === null) {
+    return null;
+  }
+
+  const payload: Record<string, unknown> = {};
+
+  if (normalized.recursos.length) {
+    payload.features = normalized.recursos;
+  }
+
+  if (normalized.maxCasos !== null) {
+    payload.maxCases = normalized.maxCasos;
+  }
+
+  return JSON.stringify(payload);
+};
+
+const formatPlanoRow = (row: PlanoRow): PlanoResponseRow => {
+  const recursosDetalhes = parseRecursosDetails(row.recursos);
+  const explicitMaxCasos =
+    toInteger((row as { max_casos?: unknown }).max_casos) ??
+    toInteger((row as { maxCases?: unknown }).maxCases);
+
+  const maxCasos = explicitMaxCasos ?? recursosDetalhes.maxCasos ?? null;
+
+  return {
+    ...row,
+    ativo: row.ativo ?? true,
+    recursos: recursosDetalhes.recursos,
+    max_casos: maxCasos,
+    maxCases: maxCasos,
+  };
 };
 
 export const listPlanos = async (_req: Request, res: Response) => {
@@ -24,7 +231,8 @@ export const listPlanos = async (_req: Request, res: Response) => {
     const result = await pool.query(
       'SELECT id, nome, valor, ativo, datacadastro, descricao, recorrencia, qtde_usuarios, recursos FROM public.planos'
     );
-    res.json(result.rows);
+    const formatted = result.rows.map((row) => formatPlanoRow(row as PlanoRow));
+    res.json(formatted);
   } catch (error) {
     console.error(error);
     res.status(500).json({ error: 'Internal server error' });
@@ -40,12 +248,14 @@ export const createPlano = async (req: Request, res: Response) => {
     recorrencia = 'nenhuma',
     qtde_usuarios,
     recursos,
+    max_casos,
+    maxCases,
   } = req.body;
 
   const descricaoValue: string = descricao ?? '';
   const ativoValue: boolean = ativo ?? true;
   const qtdeUsuariosValue = qtde_usuarios ?? null;
-  const recursosValue = recursos ?? null;
+  const recursosValue = prepareRecursosForStorage(recursos, max_casos ?? maxCases);
 
   if (recorrencia !== null && !isRecorrenciaValida(recorrencia)) {
     return res.status(400).json({ error: 'Recorrência inválida' });
@@ -56,7 +266,8 @@ export const createPlano = async (req: Request, res: Response) => {
       'INSERT INTO public.planos (nome, valor, ativo, datacadastro, descricao, recorrencia, qtde_usuarios, recursos) VALUES ($1, $2, $3, NOW(), $4, $5, $6, $7) RETURNING id, nome, valor, ativo, datacadastro, descricao, recorrencia, qtde_usuarios, recursos',
       [nome, valor, ativoValue, descricaoValue, recorrencia, qtdeUsuariosValue, recursosValue]
     );
-    res.status(201).json(result.rows[0]);
+    const payload = formatPlanoRow(result.rows[0] as PlanoRow);
+    res.status(201).json(payload);
   } catch (error) {
     console.error(error);
     res.status(500).json({ error: 'Internal server error' });
@@ -73,6 +284,8 @@ export const updatePlano = async (req: Request, res: Response) => {
     recorrencia,
     qtde_usuarios,
     recursos,
+    max_casos,
+    maxCases,
   } = req.body;
 
   try {
@@ -85,10 +298,15 @@ export const updatePlano = async (req: Request, res: Response) => {
       return res.status(404).json({ error: 'Plano não encontrado' });
     }
 
-    const currentPlano = existingResult.rows[0] as PlanoRow;
+    const currentPlanoRow = existingResult.rows[0] as PlanoRow;
+    const currentPlano = formatPlanoRow(currentPlanoRow);
+    const currentRecursos = parseRecursosDetails(currentPlanoRow.recursos);
 
     const hasQtdeUsuarios = Object.prototype.hasOwnProperty.call(req.body, 'qtde_usuarios');
     const hasRecursos = Object.prototype.hasOwnProperty.call(req.body, 'recursos');
+    const hasMaxCasos =
+      Object.prototype.hasOwnProperty.call(req.body, 'max_casos') ||
+      Object.prototype.hasOwnProperty.call(req.body, 'maxCases');
     const hasRecorrencia = Object.prototype.hasOwnProperty.call(req.body, 'recorrencia');
 
     let updatedRecorrencia: Recorrencia | null;
@@ -112,7 +330,13 @@ export const updatePlano = async (req: Request, res: Response) => {
       ? qtde_usuarios ?? null
       : currentPlano.qtde_usuarios;
 
-    const updatedRecursos = hasRecursos ? recursos ?? null : currentPlano.recursos;
+    const recursosValue = hasRecursos || hasMaxCasos
+      ? prepareRecursosForStorage(
+          hasRecursos ? recursos : currentPlano.recursos,
+          hasMaxCasos ? max_casos ?? maxCases : currentPlano.max_casos,
+          currentRecursos
+        )
+      : ((currentPlanoRow.recursos ?? null) as string | null);
 
     const result = await pool.query(
       'UPDATE public.planos SET nome = $1, valor = $2, ativo = $3, descricao = $4, recorrencia = $5, qtde_usuarios = $6, recursos = $7 WHERE id = $8 RETURNING id, nome, valor, ativo, datacadastro, descricao, recorrencia, qtde_usuarios, recursos',
@@ -123,12 +347,13 @@ export const updatePlano = async (req: Request, res: Response) => {
         (descricao ?? currentPlano.descricao) ?? '',
         updatedRecorrencia,
         updatedQtdeUsuarios,
-        updatedRecursos,
+        recursosValue,
         id,
       ]
     );
 
-    res.json(result.rows[0]);
+    const payload = formatPlanoRow(result.rows[0] as PlanoRow);
+    res.json(payload);
   } catch (error) {
     console.error(error);
     res.status(500).json({ error: 'Internal server error' });

--- a/frontend/src/pages/administrator/Plans.tsx
+++ b/frontend/src/pages/administrator/Plans.tsx
@@ -1,13 +1,508 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { mockPlans } from "@/data/mockData";
+import { getApiUrl } from "@/lib/api";
 import { routes } from "@/config/routes";
 import { Plus, Check, Package, Users, FileText } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
+type BillingCadence = "monthly" | "annual" | "none" | "custom";
+
+type Plan = {
+  id: number;
+  name: string;
+  description: string;
+  price: number | null;
+  priceLabel: string;
+  billingCycle: BillingCadence;
+  maxUsers: number | null;
+  maxCases: number | null;
+  features: string[];
+  isActive: boolean;
+  createdAt: Date | null;
+};
+
+const currencyFormatter = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+  minimumFractionDigits: 2,
+});
+
+const billingCycleDescriptions: Record<BillingCadence, { short: string; description: string }> = {
+  monthly: { short: "mês", description: "Cobrança mensal" },
+  annual: { short: "ano", description: "Cobrança anual" },
+  none: { short: "período", description: "Cobrança única" },
+  custom: { short: "ciclo", description: "Ciclo personalizado" },
+};
+
+function normalizeApiRows(data: unknown): unknown[] {
+  if (Array.isArray(data)) {
+    return data;
+  }
+
+  if (Array.isArray((data as { rows?: unknown[] })?.rows)) {
+    return (data as { rows: unknown[] }).rows;
+  }
+
+  const nestedData = (data as { data?: unknown })?.data;
+  if (Array.isArray(nestedData)) {
+    return nestedData;
+  }
+
+  if (Array.isArray((nestedData as { rows?: unknown[] })?.rows)) {
+    return (nestedData as { rows: unknown[] }).rows;
+  }
+
+  return [];
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const sanitized = trimmed.replace(/[^\d,.-]/g, "").replace(/\.(?=.*\.)/g, "");
+    const normalized = sanitized.replace(",", ".");
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  if (typeof value === "boolean") {
+    return value ? 1 : 0;
+  }
+
+  return null;
+}
+
+function parseLimit(value: unknown): number | null {
+  const numeric = toNumber(value);
+  if (numeric === null || !Number.isFinite(numeric)) {
+    return null;
+  }
+
+  return Math.trunc(numeric);
+}
+
+function parseBillingCadence(value: unknown): BillingCadence {
+  if (typeof value !== "string") {
+    return "custom";
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return "custom";
+  }
+
+  if (["mensal", "monthly", "mes", "mês"].includes(normalized)) {
+    return "monthly";
+  }
+
+  if (["anual", "annual", "ano", "yearly"].includes(normalized)) {
+    return "annual";
+  }
+
+  if (
+    [
+      "nenhuma",
+      "none",
+      "sem recorrencia",
+      "sem recorrência",
+      "unico",
+      "único",
+      "once",
+    ].includes(normalized)
+  ) {
+    return "none";
+  }
+
+  return "custom";
+}
+
+function parseRecursosValue(value: unknown): { features: string[]; maxCases: number | null } {
+  const features: string[] = [];
+  let maxCases: number | null = null;
+
+  const addFeature = (entry: unknown) => {
+    if (entry === null || entry === undefined) {
+      return;
+    }
+
+    let text: string | null = null;
+
+    if (typeof entry === "string") {
+      text = entry.replace(/^[•\-*\u2022]+\s*/, "").trim();
+    } else if (typeof entry === "number" || typeof entry === "boolean") {
+      text = String(entry);
+    }
+
+    if (text) {
+      features.push(text);
+    }
+  };
+
+  const visit = (input: unknown): void => {
+    if (input === null || input === undefined) {
+      return;
+    }
+
+    if (typeof input === "string") {
+      const trimmed = input.trim();
+      if (!trimmed) {
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(trimmed);
+        visit(parsed);
+        return;
+      } catch {
+        // fallback to split string into individual features
+      }
+
+      trimmed
+        .split(/[\n;,]+/)
+        .map((item) => item.trim())
+        .filter(Boolean)
+        .forEach((item) => addFeature(item));
+
+      return;
+    }
+
+    if (typeof input === "number" || typeof input === "boolean") {
+      addFeature(input);
+      return;
+    }
+
+    if (Array.isArray(input)) {
+      input.forEach((item) => visit(item));
+      return;
+    }
+
+    if (typeof input === "object") {
+      const obj = input as Record<string, unknown>;
+
+      const featureCandidates: unknown[] = [];
+      for (const key of [
+        "features",
+        "recursos",
+        "items",
+        "itens",
+        "lista",
+        "listaRecursos",
+        "lista_recursos",
+        "values",
+        "value",
+        "feature",
+        "recurso",
+      ]) {
+        if (key in obj) {
+          featureCandidates.push(obj[key]);
+        }
+      }
+
+      featureCandidates.forEach((candidate) => visit(candidate));
+
+      for (const key of [
+        "maxCases",
+        "max_casos",
+        "maxProcessos",
+        "max_processos",
+        "limiteCasos",
+        "limite_casos",
+        "limiteProcessos",
+        "limite_processos",
+        "maximoCasos",
+        "maximo_casos",
+      ]) {
+        if (key in obj) {
+          const parsed = parseLimit(obj[key]);
+          if (parsed !== null) {
+            maxCases = parsed;
+            break;
+          }
+        }
+      }
+    }
+  };
+
+  visit(value);
+
+  return {
+    features: Array.from(new Set(features)),
+    maxCases,
+  };
+}
+
+function formatLimit(value: number | null, singular: string, plural: string): string {
+  if (value === null) {
+    return "Sob consulta";
+  }
+
+  if (value === -1) {
+    return `${plural} ilimitados`;
+  }
+
+  if (value < 0) {
+    return "Sob consulta";
+  }
+
+  if (value === 0) {
+    return `Sem ${plural}`;
+  }
+
+  if (value === 1) {
+    return `Até 1 ${singular}`;
+  }
+
+  return `Até ${value} ${plural}`;
+}
+
+function hasPrioritarySupport(features: string[]): boolean {
+  return features.some((feature) => {
+    const normalized = feature.toLowerCase();
+    return normalized.includes("prioritário") || normalized.includes("prioritario") || normalized.includes("24/7");
+  });
+}
+
+function hasApiAccess(features: string[]): boolean {
+  return features.some((feature) => feature.toLowerCase().includes("api"));
+}
+
+function parsePlan(row: unknown): Plan | null {
+  if (!row || typeof row !== "object") {
+    return null;
+  }
+
+  const raw = row as Record<string, unknown>;
+
+  const id = toNumber(raw.id ?? raw.ID ?? raw.plano_id ?? raw.plan_id);
+  if (id === null) {
+    return null;
+  }
+
+  let name = `Plano ${id}`;
+  if (typeof raw.nome === "string" && raw.nome.trim()) {
+    name = raw.nome.trim();
+  } else if (typeof raw.name === "string" && raw.name.trim()) {
+    name = raw.name.trim();
+  }
+
+  let description = "";
+  if (typeof raw.descricao === "string" && raw.descricao.trim()) {
+    description = raw.descricao.trim();
+  } else if (typeof raw.description === "string" && raw.description.trim()) {
+    description = raw.description.trim();
+  }
+
+  const billingCycle = parseBillingCadence(
+    raw.recorrencia ?? raw.billingCycle ?? raw.ciclo ?? raw.ciclo_cobranca
+  );
+
+  const priceValue = toNumber(
+    raw.valor ?? raw.price ?? raw.valor_mensal ?? raw.preco ?? raw.preco_mensal
+  );
+
+  let priceLabel: string;
+  if (priceValue !== null) {
+    priceLabel = currencyFormatter.format(priceValue);
+  } else if (typeof raw.valor === "string" && raw.valor.trim()) {
+    priceLabel = raw.valor.trim();
+  } else if (typeof raw.price === "string" && raw.price.trim()) {
+    priceLabel = raw.price.trim();
+  } else {
+    priceLabel = "Sob consulta";
+  }
+
+  const maxUsers = parseLimit(
+    raw.qtde_usuarios ??
+      raw.maxUsers ??
+      raw.qtdeUsuarios ??
+      raw.limiteUsuarios ??
+      raw.limite_usuarios ??
+      raw.max_usuarios
+  );
+
+  const recursosCandidates =
+    raw.recursos ?? raw.features ?? raw.recursos_detalhes ?? raw.detalhes_recursos ?? raw.resources;
+  const parsedRecursos = parseRecursosValue(recursosCandidates);
+
+  const explicitMaxCases = parseLimit(
+    raw.max_casos ??
+      raw.maxCases ??
+      raw.max_processos ??
+      raw.maxProcessos ??
+      raw.limiteCasos ??
+      raw.limite_casos ??
+      raw.limiteProcessos ??
+      raw.limite_processos ??
+      raw.maximoCasos ??
+      raw.maximo_casos
+  );
+
+  const maxCases = explicitMaxCases ?? parsedRecursos.maxCases ?? null;
+
+  const ativoRaw = raw.ativo ?? raw.isActive ?? raw.status;
+  let isActive = true;
+  if (typeof ativoRaw === "boolean") {
+    isActive = ativoRaw;
+  } else if (typeof ativoRaw === "number") {
+    isActive = ativoRaw !== 0;
+  } else if (typeof ativoRaw === "string") {
+    const normalized = ativoRaw.trim().toLowerCase();
+    if (["false", "0", "inativo", "inactive", "desativado"].includes(normalized)) {
+      isActive = false;
+    } else if (["true", "1", "ativo", "active"].includes(normalized)) {
+      isActive = true;
+    }
+  }
+
+  let createdAt: Date | null = null;
+  if (typeof raw.datacadastro === "string" && raw.datacadastro.trim()) {
+    const parsedDate = new Date(raw.datacadastro);
+    if (!Number.isNaN(parsedDate.getTime())) {
+      createdAt = parsedDate;
+    }
+  } else if (raw.datacadastro instanceof Date && !Number.isNaN(raw.datacadastro.getTime())) {
+    createdAt = raw.datacadastro;
+  }
+
+  return {
+    id,
+    name,
+    description,
+    price: priceValue,
+    priceLabel,
+    billingCycle,
+    maxUsers,
+    maxCases,
+    features: parsedRecursos.features,
+    isActive,
+    createdAt,
+  };
+}
+
 export default function Plans() {
   const navigate = useNavigate();
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let disposed = false;
+    const controller = new AbortController();
+
+    const fetchPlans = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch(getApiUrl("planos"), {
+          headers: { Accept: "application/json" },
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          const message = await response.text();
+          throw new Error(
+            `Falha ao carregar planos (HTTP ${response.status})${message ? `: ${message}` : ""}`
+          );
+        }
+
+        const data = await response.json();
+        const rows = normalizeApiRows(data);
+        const parsed = rows
+          .map((row) => parsePlan(row))
+          .filter((plan): plan is Plan => plan !== null);
+
+        if (!disposed) {
+          setPlans(parsed);
+        }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          return;
+        }
+
+        console.error(err);
+        if (!disposed) {
+          setError(err instanceof Error ? err.message : "Não foi possível carregar os planos.");
+          setPlans([]);
+        }
+      } finally {
+        if (!disposed) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchPlans();
+
+    return () => {
+      disposed = true;
+      controller.abort();
+    };
+  }, []);
+
+  const stats = useMemo(() => {
+    if (plans.length === 0) {
+      return {
+        totalPlans: 0,
+        activeCount: 0,
+        hasPrice: false,
+        totalRevenue: 0,
+        totalRevenueLabel: "—",
+        mostPopularPlan: null as Plan | null,
+        popularPlanId: null as number | null,
+      };
+    }
+
+    const totalPlans = plans.length;
+    const activeCount = plans.filter((plan) => plan.isActive).length;
+    const totalRevenue = plans.reduce((sum, plan) => sum + (plan.price ?? 0), 0);
+    const hasPrice = plans.some((plan) => plan.price !== null);
+    const totalRevenueLabel = hasPrice ? currencyFormatter.format(totalRevenue) : "—";
+
+    const rankedSource = (() => {
+      const withPrice = plans.filter((plan) => plan.isActive && plan.price !== null);
+      if (withPrice.length > 0) {
+        return withPrice;
+      }
+
+      const active = plans.filter((plan) => plan.isActive);
+      return active.length > 0 ? active : plans;
+    })();
+
+    const [mostPopularPlan] = rankedSource
+      .slice()
+      .sort(
+        (a, b) => (b.price ?? Number.NEGATIVE_INFINITY) - (a.price ?? Number.NEGATIVE_INFINITY)
+      );
+
+    return {
+      totalPlans,
+      activeCount,
+      hasPrice,
+      totalRevenue,
+      totalRevenueLabel,
+      mostPopularPlan: mostPopularPlan ?? null,
+      popularPlanId: mostPopularPlan?.id ?? null,
+    };
+  }, [plans]);
+
+  const showEmptyState = !loading && plans.length === 0;
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -16,12 +511,11 @@ export default function Plans() {
           <p className="text-muted-foreground">Gerencie os planos de assinatura do seu CRM</p>
         </div>
         <Button onClick={() => navigate(routes.admin.newPlan)}>
-          <Plus className="h-4 w-4 mr-2" />
+          <Plus className="mr-2 h-4 w-4" />
           Novo Plano
         </Button>
       </div>
 
-      {/* Plans Overview */}
       <div className="grid gap-4 md:grid-cols-3">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -29,8 +523,10 @@ export default function Plans() {
             <Package className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{mockPlans.filter(p => p.isActive).length}</div>
-            <p className="text-xs text-muted-foreground">De {mockPlans.length} planos criados</p>
+            <div className="text-2xl font-bold">{stats.activeCount}</div>
+            <p className="text-xs text-muted-foreground">
+              De {stats.totalPlans} planos cadastrados
+            </p>
           </CardContent>
         </Card>
 
@@ -41,164 +537,237 @@ export default function Plans() {
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">
-              R$ {mockPlans.reduce((acc, plan) => acc + plan.price, 0).toLocaleString()}
+              {stats.hasPrice ? stats.totalRevenueLabel : "—"}
             </div>
-            <p className="text-xs text-muted-foreground">Potencial mensal</p>
+            <p className="text-xs text-muted-foreground">
+              {stats.hasPrice
+                ? "Potencial mensal cadastrado"
+                : "Defina valores para estimar a receita"}
+            </p>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Plano Mais Popular</CardTitle>
+            <CardTitle className="text-sm font-medium">Plano em Destaque</CardTitle>
             <Users className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">Profissional</div>
-            <p className="text-xs text-muted-foreground">Baseado em assinaturas ativas</p>
+            <div className="text-2xl font-bold">
+              {stats.mostPopularPlan?.name ?? "—"}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {stats.mostPopularPlan
+                ? "Selecionado entre os planos ativos"
+                : "Cadastre um plano para iniciar"}
+            </p>
           </CardContent>
         </Card>
       </div>
 
-      {/* Plans Grid */}
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {mockPlans.map((plan) => (
-          <Card key={plan.id} className="relative">
-            {plan.name === 'Profissional' && (
-              <div className="absolute -top-2 left-1/2 transform -translate-x-1/2">
-                <Badge className="bg-primary text-primary-foreground">Mais Popular</Badge>
-              </div>
-            )}
-            
-            <CardHeader>
-              <div className="flex items-center justify-between">
-                <CardTitle className="text-xl">{plan.name}</CardTitle>
-                {plan.isActive ? (
-                  <Badge variant="default">Ativo</Badge>
-                ) : (
-                  <Badge variant="secondary">Inativo</Badge>
+      {error && (
+        <div
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+          role="alert"
+        >
+          Não foi possível carregar os planos: {error}
+        </div>
+      )}
+
+      {loading ? (
+        <Card>
+          <CardContent className="py-12 text-center text-muted-foreground">
+            Carregando planos...
+          </CardContent>
+        </Card>
+      ) : showEmptyState ? (
+        <Card>
+          <CardContent className="py-12 text-center text-muted-foreground">
+            Nenhum plano cadastrado até o momento.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {plans.map((plan) => {
+            const billingInfo = billingCycleDescriptions[plan.billingCycle];
+            const userLimit = formatLimit(plan.maxUsers, "usuário", "usuários");
+            const caseLimit = formatLimit(plan.maxCases, "caso", "casos");
+
+            return (
+              <Card key={plan.id} className="relative">
+                {stats.popularPlanId === plan.id && (
+                  <div className="absolute -top-2 left-1/2 -translate-x-1/2 transform">
+                    <Badge className="bg-primary text-primary-foreground">Mais Popular</Badge>
+                  </div>
                 )}
-              </div>
-              <CardDescription>{plan.description}</CardDescription>
-            </CardHeader>
-            
-            <CardContent className="space-y-4">
-              <div className="text-center">
-                <div className="text-3xl font-bold">R$ {plan.price}</div>
-                <div className="text-sm text-muted-foreground">
-                  por {plan.billingCycle === 'monthly' ? 'mês' : 'ano'}
-                </div>
-              </div>
 
-              <div className="space-y-2">
-                <div className="text-sm font-medium">Limites:</div>
-                <div className="text-sm text-muted-foreground">
-                  • {plan.maxUsers === -1 ? 'Usuários ilimitados' : `Até ${plan.maxUsers} usuários`}
-                </div>
-                <div className="text-sm text-muted-foreground">
-                  • {plan.maxCases === -1 ? 'Casos ilimitados' : `Até ${plan.maxCases} casos`}
-                </div>
-              </div>
+                <CardHeader>
+                  <div className="flex items-center justify-between">
+                    <CardTitle className="text-xl">{plan.name}</CardTitle>
+                    {plan.isActive ? (
+                      <Badge variant="default">Ativo</Badge>
+                    ) : (
+                      <Badge variant="secondary">Inativo</Badge>
+                    )}
+                  </div>
+                  <CardDescription>{plan.description}</CardDescription>
+                </CardHeader>
 
-              <div className="space-y-2">
-                <div className="text-sm font-medium">Recursos inclusos:</div>
-                <div className="space-y-1">
-                  {plan.features.map((feature, index) => (
-                    <div key={index} className="flex items-center gap-2 text-sm text-muted-foreground">
-                      <Check className="h-3 w-3 text-green-500" />
-                      {feature}
+                <CardContent className="space-y-4">
+                  <div className="text-center">
+                    <div className="text-3xl font-bold">{plan.priceLabel}</div>
+                    <div className="text-sm text-muted-foreground">
+                      {plan.billingCycle === "none"
+                        ? "valor único"
+                        : `por ${billingInfo.short}`}
                     </div>
-                  ))}
-                </div>
-              </div>
+                  </div>
 
-              <div className="flex gap-2 pt-4">
-                <Button variant="outline" size="sm" className="flex-1">
-                  Editar
-                </Button>
-                <Button 
-                  variant={plan.isActive ? "destructive" : "default"} 
-                  size="sm" 
-                  className="flex-1"
-                >
-                  {plan.isActive ? 'Desativar' : 'Ativar'}
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+                  <div className="space-y-2">
+                    <div className="text-sm font-medium">Limites:</div>
+                    <div className="text-sm text-muted-foreground">• {userLimit}</div>
+                    <div className="text-sm text-muted-foreground">• {caseLimit}</div>
+                  </div>
 
-      {/* Plan Comparison */}
+                  <div className="space-y-2">
+                    <div className="text-sm font-medium">Recursos inclusos:</div>
+                    {plan.features.length > 0 ? (
+                      <div className="space-y-1">
+                        {plan.features.map((feature, index) => (
+                          <div
+                            key={`${plan.id}-feature-${index}`}
+                            className="flex items-center gap-2 text-sm text-muted-foreground"
+                          >
+                            <Check className="h-3 w-3 text-green-500" />
+                            {feature}
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">
+                        Nenhum recurso cadastrado.
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="flex gap-2 pt-4">
+                    <Button variant="outline" size="sm" className="flex-1">
+                      Editar
+                    </Button>
+                    <Button
+                      variant={plan.isActive ? "destructive" : "default"}
+                      size="sm"
+                      className="flex-1"
+                    >
+                      {plan.isActive ? "Desativar" : "Ativar"}
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
       <Card>
         <CardHeader>
           <CardTitle>Comparação de Planos</CardTitle>
           <CardDescription>Visualize as diferenças entre os planos disponíveis</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead>
-                <tr className="border-b">
-                  <th className="text-left py-2">Recurso</th>
-                  {mockPlans.map((plan) => (
-                    <th key={plan.id} className="text-center py-2 min-w-[120px]">
-                      {plan.name}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody className="text-sm">
-                <tr className="border-b">
-                  <td className="py-2 font-medium">Preço mensal</td>
-                  {mockPlans.map((plan) => (
-                    <td key={plan.id} className="text-center py-2">
-                      R$ {plan.price}
-                    </td>
-                  ))}
-                </tr>
-                <tr className="border-b">
-                  <td className="py-2 font-medium">Usuários</td>
-                  {mockPlans.map((plan) => (
-                    <td key={plan.id} className="text-center py-2">
-                      {plan.maxUsers === -1 ? 'Ilimitado' : plan.maxUsers}
-                    </td>
-                  ))}
-                </tr>
-                <tr className="border-b">
-                  <td className="py-2 font-medium">Casos</td>
-                  {mockPlans.map((plan) => (
-                    <td key={plan.id} className="text-center py-2">
-                      {plan.maxCases === -1 ? 'Ilimitado' : plan.maxCases}
-                    </td>
-                  ))}
-                </tr>
-                <tr className="border-b">
-                  <td className="py-2 font-medium">Suporte prioritário</td>
-                  {mockPlans.map((plan) => (
-                    <td key={plan.id} className="text-center py-2">
-                      {plan.features.some(f => f.includes('prioritário') || f.includes('24/7')) ? (
-                        <Check className="h-4 w-4 text-green-500 mx-auto" />
-                      ) : (
-                        <span className="text-muted-foreground">-</span>
-                      )}
-                    </td>
-                  ))}
-                </tr>
-                <tr className="border-b">
-                  <td className="py-2 font-medium">API Access</td>
-                  {mockPlans.map((plan) => (
-                    <td key={plan.id} className="text-center py-2">
-                      {plan.features.some(f => f.includes('API')) ? (
-                        <Check className="h-4 w-4 text-green-500 mx-auto" />
-                      ) : (
-                        <span className="text-muted-foreground">-</span>
-                      )}
-                    </td>
-                  ))}
-                </tr>
-              </tbody>
-            </table>
-          </div>
+          {loading ? (
+            <p className="text-sm text-muted-foreground">
+              Carregando dados de comparação...
+            </p>
+          ) : plans.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Cadastre um plano para visualizar a comparação.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b">
+                    <th className="py-2 text-left">Recurso</th>
+                    {plans.map((plan) => (
+                      <th key={`comparison-${plan.id}`} className="min-w-[140px] py-2 text-center">
+                        {plan.name}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-b">
+                    <td className="py-2 font-medium">Preço</td>
+                    {plans.map((plan) => (
+                      <td key={`price-${plan.id}`} className="py-2 text-center">
+                        {plan.priceLabel}
+                      </td>
+                    ))}
+                  </tr>
+                  <tr className="border-b">
+                    <td className="py-2 font-medium">Ciclo de cobrança</td>
+                    {plans.map((plan) => {
+                      const billingInfo = billingCycleDescriptions[plan.billingCycle];
+                      return (
+                        <td key={`cycle-${plan.id}`} className="py-2 text-center">
+                          {billingInfo.description}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                  <tr className="border-b">
+                    <td className="py-2 font-medium">Usuários</td>
+                    {plans.map((plan) => (
+                      <td key={`users-${plan.id}`} className="py-2 text-center">
+                        {plan.maxUsers === null
+                          ? "—"
+                          : plan.maxUsers === -1
+                            ? "Ilimitado"
+                            : plan.maxUsers}
+                      </td>
+                    ))}
+                  </tr>
+                  <tr className="border-b">
+                    <td className="py-2 font-medium">Casos</td>
+                    {plans.map((plan) => (
+                      <td key={`cases-${plan.id}`} className="py-2 text-center">
+                        {plan.maxCases === null
+                          ? "—"
+                          : plan.maxCases === -1
+                            ? "Ilimitado"
+                            : plan.maxCases}
+                      </td>
+                    ))}
+                  </tr>
+                  <tr className="border-b">
+                    <td className="py-2 font-medium">Suporte prioritário</td>
+                    {plans.map((plan) => (
+                      <td key={`support-${plan.id}`} className="py-2 text-center">
+                        {hasPrioritarySupport(plan.features) ? (
+                          <Check className="mx-auto h-4 w-4 text-green-500" />
+                        ) : (
+                          <span className="text-muted-foreground">-</span>
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                  <tr>
+                    <td className="py-2 font-medium">Acesso à API</td>
+                    {plans.map((plan) => (
+                      <td key={`api-${plan.id}`} className="py-2 text-center">
+                        {hasApiAccess(plan.features) ? (
+                          <Check className="mx-auto h-4 w-4 text-green-500" />
+                        ) : (
+                          <span className="text-muted-foreground">-</span>
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- normalize plan records in the API controller so the planos endpoints expose parsed feature lists and optional limits while accepting the new metadata on create/update
- replace the administrator plans page mock data with an API-driven implementation that parses plan metadata, shows loading/error states, and renders updated stats and comparisons

## Testing
- npm --prefix frontend run lint
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68cd52f38e1c83268156c3cc308cdae3