### PR TITLE
Handle empresas queries when vw.empresas view is missing

### DIFF
--- a/backend/src/controllers/empresaController.ts
+++ b/backend/src/controllers/empresaController.ts
@@ -1,11 +1,10 @@
 import { Request, Response } from 'express';
 import pool from '../services/db';
+import { queryEmpresas } from '../services/empresaQueries';
 
 export const listEmpresas = async (_req: Request, res: Response) => {
   try {
-    const result = await pool.query(
-      'SELECT id, nome_empresa, cnpj, telefone, email, plano, responsavel, ativo, datacadastro, atualizacao FROM public."vw.empresas";'
-    );
+    const result = await queryEmpresas();
     res.json(result.rows);
   } catch (error) {
     console.error(error);
@@ -17,10 +16,7 @@ export const getEmpresaById = async (req: Request, res: Response) => {
   const { id } = req.params;
 
   try {
-    const result = await pool.query(
-      'SELECT id, nome_empresa, cnpj, telefone, email, plano, responsavel, ativo, datacadastro, atualizacao FROM public."vw.empresas" WHERE id = $1',
-      [id]
-    );
+    const result = await queryEmpresas('WHERE id = $1', [id]);
 
     if (result.rowCount === 0) {
       return res.status(404).json({ error: 'Empresa não encontrada' });

--- a/backend/src/controllers/oportunidadeDocumentoController.ts
+++ b/backend/src/controllers/oportunidadeDocumentoController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import pool from '../services/db';
+import { queryEmpresas } from '../services/empresaQueries';
 import { replaceVariables } from '../services/templateService';
 
 type Primitive = string | number | boolean | null | undefined;
@@ -79,6 +80,9 @@ type EmpresaRow = {
   email: string | null;
   plano?: string | null;
   responsavel?: string | null;
+  ativo?: boolean | null;
+  datacadastro?: string | null;
+  atualizacao?: string | null;
 };
 
 type EnvolvidoRow = {
@@ -439,9 +443,7 @@ async function fetchOpportunityData(id: number) {
     responsavel = (responsavelResult.rowCount ?? 0) > 0 ? responsavelResult.rows[0] : null;
   }
 
-  const empresaResult = await pool.query<EmpresaRow>(
-    'SELECT id, nome_empresa, cnpj, telefone, email, plano, responsavel FROM public."vw.empresas" ORDER BY id LIMIT 1',
-  );
+  const empresaResult = await queryEmpresas<EmpresaRow>('ORDER BY id LIMIT 1');
   const empresa = (empresaResult.rowCount ?? 0) > 0 ? empresaResult.rows[0] : null;
 
   return { opportunity, solicitante, envolvidos: envolvidosResult.rows, responsavel, empresa };

--- a/backend/src/services/empresaQueries.ts
+++ b/backend/src/services/empresaQueries.ts
@@ -1,0 +1,53 @@
+import type { QueryResult } from 'pg';
+import pool from './db';
+
+type PostgresError = Error & { code?: string };
+
+const EMPRESA_SELECT_FIELDS =
+  'id, nome_empresa, cnpj, telefone, email, plano, responsavel, ativo, datacadastro, atualizacao';
+
+const EMPRESA_QUERY_SOURCES = [
+  {
+    label: 'view',
+    text: `SELECT ${EMPRESA_SELECT_FIELDS} FROM public."vw.empresas"`,
+  },
+  {
+    label: 'table',
+    text: `SELECT ${EMPRESA_SELECT_FIELDS} FROM public.empresas`,
+  },
+] as const;
+
+const isRecoverableEmpresasError = (error: unknown): error is PostgresError => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const { code } = error as PostgresError;
+  return code === '42P01' || code === '42703';
+};
+
+export const queryEmpresas = async <T = Record<string, unknown>>(
+  whereClause = '',
+  params: ReadonlyArray<unknown> = []
+): Promise<QueryResult<T>> => {
+  let lastError: unknown;
+
+  for (const { label, text } of EMPRESA_QUERY_SOURCES) {
+    try {
+      const sql = whereClause ? `${text} ${whereClause}` : text;
+      return await pool.query<T>(sql, params);
+    } catch (error) {
+      if (!isRecoverableEmpresasError(error)) {
+        throw error;
+      }
+
+      lastError = error;
+      console.warn(
+        `Empresas query via ${label} failed, attempting fallback to alternative source.`,
+        error
+      );
+    }
+  }
+
+  throw lastError ?? new Error('Falha ao consultar dados de empresas');
+};


### PR DESCRIPTION
## Summary
- add a reusable empresas query helper that falls back to the base table when the vw.empresas view is unavailable
- update the empresas controller and oportunidade documento controller to use the resilient query helper and keep typings aligned

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ce0162f93883268762cf218cc13aeb