### PR TITLE
Restrict user listing to authenticated company

### DIFF
--- a/backend/src/controllers/usuarioController.ts
+++ b/backend/src/controllers/usuarioController.ts
@@ -93,7 +93,7 @@ const parseStatus = (value: unknown): boolean | 'invalid' => {
 };
 
 const baseUsuarioSelect =
-  'SELECT id, nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao FROM public.vw_usuarios vu';
+  'SELECT u.id, u.nome_completo, u.cpf, u.email, u.perfil, u.empresa, u.setor, u.oab, u.status, u.senha, u.telefone, u.ultimo_login, u.observacoes, u.datacriacao FROM public.usuarios u';
 
 type EmpresaLookupResult =
   | { success: true; empresaId: number | null }
@@ -138,31 +138,20 @@ export const listUsuarios = async (req: Request, res: Response) => {
       return res.status(401).json({ error: 'Token inválido.' });
     }
 
-    const empresaUsuarioResult = await pool.query(
-      'SELECT empresa FROM public.usuarios WHERE id = $1 LIMIT 1',
-      [req.auth.userId]
-    );
+    const empresaLookup = await fetchAuthenticatedUserEmpresa(req.auth.userId);
 
-    if (empresaUsuarioResult.rowCount === 0) {
-      return res.status(404).json({ error: 'Usuário autenticado não encontrado' });
+    if (!empresaLookup.success) {
+      return res.status(empresaLookup.status).json({ error: empresaLookup.message });
     }
 
-    const empresaAtualResult = parseOptionalId(
-      (empresaUsuarioResult.rows[0] as { empresa: unknown }).empresa
-    );
+    const { empresaId } = empresaLookup;
 
-    if (empresaAtualResult === 'invalid') {
-      return res
-        .status(500)
-        .json({ error: 'Não foi possível identificar a empresa do usuário autenticado.' });
-    }
-
-    if (empresaAtualResult === null) {
+    if (empresaId === null) {
       return res.json([]);
     }
 
     const result = await pool.query(`${baseUsuarioSelect} WHERE u.empresa = $1`, [
-      empresaAtualResult,
+      empresaId,
     ]);
     res.json(result.rows);
   } catch (error) {
@@ -187,7 +176,7 @@ export const getUsuarioById = async (req: Request, res: Response) => {
     const { empresaId } = empresaLookup;
 
     const result = await pool.query(
-      `${baseUsuarioSelect} INNER JOIN public.usuarios u ON u.id = vu.id WHERE vu.id = $1 AND u.empresa IS NOT DISTINCT FROM $2::INT`,
+      `${baseUsuarioSelect} WHERE u.id = $1 AND u.empresa IS NOT DISTINCT FROM $2::INT`,
       [id, empresaId]
     );
 

--- a/backend/tests/usuarioController.test.ts
+++ b/backend/tests/usuarioController.test.ts
@@ -104,7 +104,7 @@ test('getUsuarioById returns user when it belongs to the same company', async ()
   assert.deepEqual(res.body, userRow);
   assert.equal(calls.length, 2);
   assert.match(calls[0]?.text ?? '', /SELECT empresa FROM public\.usuarios/);
-  assert.match(calls[1]?.text ?? '', /JOIN public\.usuarios/);
+  assert.match(calls[1]?.text ?? '', /FROM public\.usuarios u/);
   assert.match(calls[1]?.text ?? '', /u\.empresa IS NOT DISTINCT FROM \$2::INT/);
   assert.deepEqual(calls[1]?.values, ['123', 42]);
 });


### PR DESCRIPTION
## Summary
- fetch usuarios for listings directly from public.usuarios and reuse the authenticated user's company lookup
- ensure the list and single-user queries filter by the logged-in user's company id
- update the usuario controller tests to match the new query structure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce0369d0648326b7b99c39f7d1b080