### PR TITLE
Adjust client endpoints to link records to user company

### DIFF
--- a/backend/src/routes/clienteRoutes.ts
+++ b/backend/src/routes/clienteRoutes.ts
@@ -48,8 +48,8 @@ const router = Router();
  *           type: string
  *         ativo:
  *           type: boolean
- *         foto:
- *           type: string
+ *         idempresa:
+ *           type: integer
  *         datacadastro:
  *           type: string
  *           format: date-time
@@ -155,8 +155,6 @@ router.get('/clientes/:id', getClienteById);
  *                 type: string
  *               ativo:
  *                 type: boolean
- *               foto:
- *                 type: string
  *     responses:
  *       201:
  *         description: Cliente criado
@@ -212,8 +210,6 @@ router.post('/clientes', createCliente);
  *                 type: string
  *               ativo:
  *                 type: boolean
- *               foto:
- *                 type: string
  *     responses:
  *       200:
  *         description: Cliente atualizado


### PR DESCRIPTION
## Summary
- associate customer CRUD operations with the authenticated user's company, validating module access
- persist the company identifier when creating or updating customers and restrict toggles to same company
- update client API documentation to describe the new idempresa field

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce051d05d483268e5f71aab32e8695