### PR TITLE
Fix empresa listing query for updated schema

### DIFF
--- a/backend/src/services/empresaQueries.ts
+++ b/backend/src/services/empresaQueries.ts
@@ -3,17 +3,16 @@ import pool from './db';
 
 type PostgresError = Error & { code?: string };
 
-const EMPRESA_SELECT_FIELDS =
-  'id, nome_empresa, cnpj, telefone, email, plano, responsavel, ativo, datacadastro, atualizacao';
-
 const EMPRESA_QUERY_SOURCES = [
   {
     label: 'view',
-    text: `SELECT ${EMPRESA_SELECT_FIELDS} FROM public."vw.empresas"`,
+    text:
+      'SELECT id, nome_empresa, cnpj, telefone, email, plano, responsavel, ativo, datacadastro, atualizacao FROM public."vw.empresas"',
   },
   {
     label: 'table',
-    text: `SELECT ${EMPRESA_SELECT_FIELDS} FROM public.empresas`,
+    text:
+      'SELECT id, nome_empresa, cnpj, telefone, email, plano, responsavel, ativo, datacadastro, NULL::timestamp AS atualizacao FROM public.empresas',
   },
 ] as const;
 


### PR DESCRIPTION
## Summary
- update empresa list query fallback to project a null atualizacao column when querying the base table
- keep compatibility with views that still expose the atualizacao field while supporting the new schema

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce09bb19808326bfe2cb3983810dbe