### PR TITLE
Ajusta origem de dados de usuários no painel de configurações

### DIFF
--- a/frontend/src/pages/configuracoes/usuarios/Usuarios.tsx
+++ b/frontend/src/pages/configuracoes/usuarios/Usuarios.tsx
@@ -107,7 +107,7 @@ export default function Usuarios() {
   useEffect(() => {
     const fetchUsers = async () => {
       try {
-        const url = joinUrl(apiUrl, "/api/usuarios");
+        const url = joinUrl(apiUrl, "/api/usuarios/empresa");
         const response = await fetch(url, { headers: { Accept: "application/json" } });
         if (!response.ok) {
           throw new Error("Failed to fetch users");


### PR DESCRIPTION
## Summary
- ajusta a listagem de usuários em Configurações para consumir o endpoint /api/usuarios/empresa

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce097287888326b8db56e40e66109c