### PR TITLE
Fix Radix select empty value errors

### DIFF
--- a/frontend/src/pages/administrator/EditCompany.tsx
+++ b/frontend/src/pages/administrator/EditCompany.tsx
@@ -20,6 +20,8 @@ import {
   CompanyFormApiPlan as ApiPlan,
   CompanyFormApiUser as ApiUser,
   CompanyFormData,
+  NO_MANAGER_SELECTED_VALUE,
+  NO_PLAN_SELECTED_VALUE,
   PlanOption,
   UserOption,
   initialCompanyFormData,
@@ -386,8 +388,15 @@ export default function EditCompany() {
                 <div className="space-y-2">
                   <Label>Plano</Label>
                   <Select
-                    value={formData.planId}
-                    onValueChange={(value) => setFormData((previous) => ({ ...previous, planId: value }))}
+                    value={
+                      formData.planId === "" ? NO_PLAN_SELECTED_VALUE : formData.planId
+                    }
+                    onValueChange={(value) =>
+                      setFormData((previous) => ({
+                        ...previous,
+                        planId: value === NO_PLAN_SELECTED_VALUE ? "" : value,
+                      }))
+                    }
                     disabled={isLoadingAuxiliaryData}
                   >
                     <SelectTrigger>
@@ -396,7 +405,7 @@ export default function EditCompany() {
                       </SelectValue>
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="">Sem plano</SelectItem>
+                      <SelectItem value={NO_PLAN_SELECTED_VALUE}>Sem plano</SelectItem>
                       {planOptions.map((option) => (
                         <SelectItem key={option.id} value={option.id}>
                           {option.isActive ? option.label : `${option.label} (inativo)`}
@@ -408,8 +417,15 @@ export default function EditCompany() {
                 <div className="space-y-2">
                   <Label>Responsável</Label>
                   <Select
-                    value={formData.managerId}
-                    onValueChange={(value) => setFormData((previous) => ({ ...previous, managerId: value }))}
+                    value={
+                      formData.managerId === "" ? NO_MANAGER_SELECTED_VALUE : formData.managerId
+                    }
+                    onValueChange={(value) =>
+                      setFormData((previous) => ({
+                        ...previous,
+                        managerId: value === NO_MANAGER_SELECTED_VALUE ? "" : value,
+                      }))
+                    }
                     disabled={isLoadingAuxiliaryData}
                   >
                     <SelectTrigger>
@@ -420,7 +436,7 @@ export default function EditCompany() {
                       </SelectValue>
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="">Sem responsável</SelectItem>
+                      <SelectItem value={NO_MANAGER_SELECTED_VALUE}>Sem responsável</SelectItem>
                       {userOptions.map((option) => (
                         <SelectItem key={option.id} value={option.id}>
                           {option.label}

--- a/frontend/src/pages/administrator/NewCompany.tsx
+++ b/frontend/src/pages/administrator/NewCompany.tsx
@@ -16,6 +16,8 @@ import {
   CompanyFormApiPlan as ApiPlan,
   CompanyFormApiUser as ApiUser,
   CompanyFormData,
+  NO_MANAGER_SELECTED_VALUE,
+  NO_PLAN_SELECTED_VALUE,
   PlanOption,
   UserOption,
   initialCompanyFormData,
@@ -292,9 +294,14 @@ export default function NewCompany() {
               <div className="space-y-2">
                 <Label htmlFor="planId">Plano</Label>
                 <Select
-                  value={formData.planId}
+                  value={
+                    formData.planId === "" ? NO_PLAN_SELECTED_VALUE : formData.planId
+                  }
                   onValueChange={(value) =>
-                    setFormData((previous) => ({ ...previous, planId: value }))
+                    setFormData((previous) => ({
+                      ...previous,
+                      planId: value === NO_PLAN_SELECTED_VALUE ? "" : value,
+                    }))
                   }
                   disabled={isLoadingPlans}
                 >
@@ -306,11 +313,11 @@ export default function NewCompany() {
                           : "Selecione um plano (opcional)"
                       }
                     >
-                      {selectedPlanLabel}
+                      {selectedPlanLabel ?? undefined}
                     </SelectValue>
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="">Sem plano</SelectItem>
+                    <SelectItem value={NO_PLAN_SELECTED_VALUE}>Sem plano</SelectItem>
                     {planOptions.map((plan) => (
                       <SelectItem key={plan.id} value={plan.id}>
                         {plan.isActive ? plan.label : `${plan.label} (inativo)`}
@@ -322,9 +329,16 @@ export default function NewCompany() {
               <div className="space-y-2">
                 <Label htmlFor="managerId">Responsável</Label>
                 <Select
-                  value={formData.managerId}
+                  value={
+                    formData.managerId === ""
+                      ? NO_MANAGER_SELECTED_VALUE
+                      : formData.managerId
+                  }
                   onValueChange={(value) =>
-                    setFormData((previous) => ({ ...previous, managerId: value }))
+                    setFormData((previous) => ({
+                      ...previous,
+                      managerId: value === NO_MANAGER_SELECTED_VALUE ? "" : value,
+                    }))
                   }
                   disabled={isLoadingUsers}
                 >
@@ -338,7 +352,7 @@ export default function NewCompany() {
                     />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="">Sem responsável</SelectItem>
+                    <SelectItem value={NO_MANAGER_SELECTED_VALUE}>Sem responsável</SelectItem>
                     {userOptions.map((user) => (
                       <SelectItem key={user.id} value={user.id}>
                         {user.label}

--- a/frontend/src/pages/administrator/company-form-utils.ts
+++ b/frontend/src/pages/administrator/company-form-utils.ts
@@ -43,6 +43,9 @@ export const initialCompanyFormData: CompanyFormData = {
   isActive: true,
 };
 
+export const NO_PLAN_SELECTED_VALUE = "__no_plan_selected__";
+export const NO_MANAGER_SELECTED_VALUE = "__no_manager_selected__";
+
 export const parseDataArray = <T,>(payload: unknown): T[] => parseCompaniesDataArray<T>(payload);
 
 export const resolveBooleanFlag = (value: unknown): boolean | null => {

--- a/frontend/src/pages/configuracoes/parametros/Setores.tsx
+++ b/frontend/src/pages/configuracoes/parametros/Setores.tsx
@@ -84,6 +84,8 @@ const emptyForm: SetorFormState = {
   ativo: true,
 };
 
+const NO_COMPANY_SELECTED_VALUE = "__no_company_selected__";
+
 function joinUrl(base: string, path = "") {
   const b = base.replace(/\/+$/, "");
   const p = path ? (path.startsWith("/") ? path : `/${path}`) : "";
@@ -374,14 +376,23 @@ export default function Setores() {
             <div className="space-y-2">
               <Label>Empresa</Label>
               <Select
-                value={formState.empresaId}
-                onValueChange={(value) => setFormState((prev) => ({ ...prev, empresaId: value }))}
+                value={
+                  formState.empresaId === ""
+                    ? NO_COMPANY_SELECTED_VALUE
+                    : formState.empresaId
+                }
+                onValueChange={(value) =>
+                  setFormState((prev) => ({
+                    ...prev,
+                    empresaId: value === NO_COMPANY_SELECTED_VALUE ? "" : value,
+                  }))
+                }
               >
                 <SelectTrigger>
                   <SelectValue placeholder="Selecione uma empresa" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="">Sem empresa</SelectItem>
+                  <SelectItem value={NO_COMPANY_SELECTED_VALUE}>Sem empresa</SelectItem>
                   {empresas.map((empresa) => (
                     <SelectItem key={empresa.id} value={empresa.id.toString()}>
                       {empresa.nome || `Empresa #${empresa.id}`}


### PR DESCRIPTION
## Summary
- introduce shared constants for representing cleared Radix Select values
- update company and sector forms to use sentinel values instead of empty strings
- ensure optional selects still map back to empty values for submission

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce13ef80548326991be08cc323281a