### PR TITLE
Handle missing atualizacao column in empresa queries

### DIFF
--- a/backend/dist/services/empresaQueries.js
+++ b/backend/dist/services/empresaQueries.js
@@ -1,0 +1,43 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.queryEmpresas = void 0;
+const db_1 = __importDefault(require("./db"));
+const EMPRESA_QUERY_SOURCES = [
+    {
+        label: 'view',
+        text: 'SELECT id, nome_empresa, cnpj, telefone, email, plano, responsavel, ativo, datacadastro, NULL::timestamp AS atualizacao FROM public."vw.empresas"',
+    },
+    {
+        label: 'table',
+        text: 'SELECT id, nome_empresa, cnpj, telefone, email, plano, responsavel, ativo, datacadastro, NULL::timestamp AS atualizacao FROM public.empresas',
+    },
+];
+const isRecoverableEmpresasError = (error) => {
+    if (!error || typeof error !== 'object') {
+        return false;
+    }
+    const { code } = error;
+    return code === '42P01' || code === '42703';
+};
+const queryEmpresas = async (whereClause = '', params = []) => {
+    let lastError;
+    for (const { label, text } of EMPRESA_QUERY_SOURCES) {
+        try {
+            const sql = whereClause ? `${text} ${whereClause}` : text;
+            const queryParams = Array.from(params);
+            return await db_1.default.query(sql, queryParams);
+        }
+        catch (error) {
+            if (!isRecoverableEmpresasError(error)) {
+                throw error;
+            }
+            lastError = error;
+            console.warn(`Empresas query via ${label} failed, attempting fallback to alternative source.`, error);
+        }
+    }
+    throw lastError ?? new Error('Falha ao consultar dados de empresas');
+};
+exports.queryEmpresas = queryEmpresas;

--- a/backend/src/services/empresaQueries.ts
+++ b/backend/src/services/empresaQueries.ts
@@ -7,7 +7,7 @@ const EMPRESA_QUERY_SOURCES = [
   {
     label: 'view',
     text:
-      'SELECT id, nome_empresa, cnpj, telefone, email, plano, responsavel, ativo, datacadastro, atualizacao FROM public."vw.empresas"',
+      'SELECT id, nome_empresa, cnpj, telefone, email, plano, responsavel, ativo, datacadastro, NULL::timestamp AS atualizacao FROM public."vw.empresas"',
   },
   {
     label: 'table',


### PR DESCRIPTION
## Summary
- update empresa queries to always select a placeholder atualizacao column so the view/table without it no longer error
- include the compiled empresaQueries service so runtime code matches the updated query

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce1a25509083269e4936c76cd95fe2