### PR TITLE
Ensure support schema initialization during startup

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -41,6 +41,7 @@ import swaggerJsdoc from 'swagger-jsdoc';
 import swaggerOptions from './swagger';
 import cronJobs from './services/cronJobs';
 import { ensureChatSchema } from './services/chatSchema';
+import { ensureSupportSchema } from './services/supportSchema';
 import { authenticateRequest } from './middlewares/authMiddleware';
 import { authorizeModules } from './middlewares/moduleAuthorization';
 
@@ -213,9 +214,9 @@ if (!hasFrontendBuild) {
 
 async function startServer() {
   try {
-    await ensureChatSchema();
+    await Promise.all([ensureChatSchema(), ensureSupportSchema()]);
   } catch (error) {
-    console.error('Failed to initialize chat storage schema', error);
+    console.error('Failed to initialize application storage schema', error);
     process.exit(1);
   }
 

--- a/backend/src/services/supportSchema.ts
+++ b/backend/src/services/supportSchema.ts
@@ -1,0 +1,74 @@
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import path from 'node:path';
+import pool from './db';
+
+type Queryable = {
+  query: (text: string, params?: unknown[]) => Promise<unknown>;
+};
+
+let cachedSql: string | null = null;
+let initializationPromise: Promise<void> | null = null;
+let cachedSchemaPath: string | null = null;
+
+async function resolveSchemaPath(): Promise<string> {
+  if (cachedSchemaPath) {
+    return cachedSchemaPath;
+  }
+
+  const candidatePaths = [
+    path.resolve(__dirname, '..', 'sql', 'support.sql'),
+    path.resolve(__dirname, '../..', 'sql', 'support.sql'),
+    path.resolve(process.cwd(), 'sql', 'support.sql'),
+    path.resolve(process.cwd(), 'backend', 'sql', 'support.sql'),
+  ];
+
+  for (const candidate of candidatePaths) {
+    try {
+      await access(candidate, constants.R_OK);
+      cachedSchemaPath = candidate;
+      return candidate;
+    } catch (error) {
+      const errno = (error as NodeJS.ErrnoException).code;
+      if (errno && ['ENOENT', 'ENOTDIR'].includes(errno)) {
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  throw new Error(
+    `Support schema file not found. Checked: ${candidatePaths
+      .map((candidate) => `"${candidate}"`)
+      .join(', ')}`,
+  );
+}
+
+async function loadSchemaSql(): Promise<string> {
+  if (cachedSql) {
+    return cachedSql;
+  }
+
+  const schemaPath = await resolveSchemaPath();
+  const sql = await readFile(schemaPath, 'utf-8');
+  cachedSql = sql;
+  return sql;
+}
+
+async function executeSchema(client: Queryable): Promise<void> {
+  const sql = await loadSchemaSql();
+  await client.query(sql);
+}
+
+export async function ensureSupportSchema(client: Queryable = pool): Promise<void> {
+  if (!initializationPromise) {
+    initializationPromise = executeSchema(client).catch((error) => {
+      initializationPromise = null;
+      throw error;
+    });
+  }
+
+  await initializationPromise;
+}
+


### PR DESCRIPTION
## Summary
- add a support schema initializer that loads the support.sql definition lazily
- initialize both chat and support schemas during server startup to avoid missing table errors
- reuse a single startup log message for storage initialization failures

## Testing
- `npm test -- tests/supportService.test.ts` *(fails: existing SupportService.create assertion unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ce1d92bfac8326be630a3f469aae22