### PR TITLE
Fix support request creation insert logic

### DIFF
--- a/backend/src/services/supportService.ts
+++ b/backend/src/services/supportService.ts
@@ -258,11 +258,30 @@ export class SupportService {
     const requesterName = normalizeText(input.requesterName);
     const requesterEmail = normalizeEmail(input.requesterEmail);
 
+    const columns = ['subject', 'description', 'status'];
+    const values: unknown[] = [subject, description, status];
+
+    if (requesterId != null) {
+      columns.push('requester_id');
+      values.push(requesterId);
+    }
+
+    if (requesterName !== null) {
+      columns.push('requester_name');
+      values.push(requesterName);
+    }
+
+    if (requesterEmail !== null) {
+      columns.push('requester_email');
+      values.push(requesterEmail);
+    }
+
+    const placeholders = columns.map((_, index) => `$${index + 1}`).join(', ');
     const result = await this.db.query(
-      `INSERT INTO support_requests (subject, description, status, requester_id, requester_name, requester_email)
-       VALUES ($1, $2, $3, $4, $5, $6)
+      `INSERT INTO support_requests (${columns.join(', ')})
+       VALUES (${placeholders})
        RETURNING id, subject, description, status, requester_id, requester_name, requester_email, support_agent_id, support_agent_name, created_at, updated_at`,
-      [subject, description, status, requesterId, requesterName, requesterEmail]
+      values
     );
 
     return mapRow(result.rows[0] as SupportRequestRow);

--- a/backend/tests/supportService.test.ts
+++ b/backend/tests/supportService.test.ts
@@ -30,8 +30,11 @@ test('SupportService.create normalizes payload and returns persisted request', a
     subject: 'Test subject',
     description: 'Detailed description',
     status: 'open' as SupportStatus,
+    requester_id: null,
     requester_name: 'Maria',
     requester_email: 'maria@example.com',
+    support_agent_id: null,
+    support_agent_name: null,
     created_at: '2024-01-01T00:00:00.000Z',
     updated_at: '2024-01-01T00:00:00.000Z',
   };
@@ -67,8 +70,11 @@ test('SupportService.create normalizes payload and returns persisted request', a
     subject: 'Test subject',
     description: 'Detailed description',
     status: 'open',
+    requesterId: null,
     requesterName: 'Maria',
     requesterEmail: 'maria@example.com',
+    supportAgentId: null,
+    supportAgentName: null,
     createdAt: '2024-01-01T00:00:00.000Z',
     updatedAt: '2024-01-01T00:00:00.000Z',
   };


### PR DESCRIPTION
## Summary
- ensure SupportService.create builds insert statements dynamically so requester metadata is only sent when provided and returned consistently
- update the compiled support service and unit tests to reflect the corrected behaviour

## Testing
- npm test -- tests/supportService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ce20397dd8832690313819e0325a43