### PR TITLE
feat(chat): add realtime conversation updates

### DIFF
--- a/backend/src/realtime/chatEvents.ts
+++ b/backend/src/realtime/chatEvents.ts
@@ -1,0 +1,293 @@
+import type { Request, Response } from 'express';
+import type {
+  ChatMessage,
+  ChatMessageStatus,
+  ConversationDetails,
+  ConversationSummary,
+} from '../services/chatService';
+
+interface ClientConnection {
+  id: number;
+  userId: number;
+  userName?: string;
+  response: Response;
+  keepAliveTimer: NodeJS.Timeout;
+}
+
+interface TypingEntry {
+  timeout: NodeJS.Timeout;
+  userName?: string;
+}
+
+const clients = new Set<ClientConnection>();
+const typingState = new Map<string, Map<number, TypingEntry>>();
+
+let nextClientId = 1;
+
+const KEEP_ALIVE_INTERVAL = 25_000;
+const TYPING_IDLE_TIMEOUT = 6_000;
+
+type ServerEventName =
+  | 'connection'
+  | 'conversation:update'
+  | 'conversation:read'
+  | 'message:new'
+  | 'message:status'
+  | 'typing'
+  | 'ping';
+
+interface ServerEvent<T = unknown> {
+  event: ServerEventName;
+  data?: T;
+}
+
+const safeJson = (payload: unknown): string => {
+  try {
+    return JSON.stringify(payload ?? {});
+  } catch (error) {
+    console.warn('Failed to serialize SSE payload', error);
+    return '{}';
+  }
+};
+
+const writeEvent = (client: ClientConnection, event: ServerEvent) => {
+  const chunks = [`event: ${event.event}`];
+  if (event.data !== undefined) {
+    const serialized = safeJson(event.data).split(/\n/);
+    for (const line of serialized) {
+      chunks.push(`data: ${line}`);
+    }
+  }
+  chunks.push('\n');
+
+  try {
+    client.response.write(chunks.join('\n'));
+  } catch (error) {
+    console.warn('Failed to write SSE event, dropping connection', error);
+    removeClient(client);
+  }
+};
+
+const removeClient = (client: ClientConnection) => {
+  if (!clients.has(client)) {
+    return;
+  }
+
+  clients.delete(client);
+
+  try {
+    clearInterval(client.keepAliveTimer);
+  } catch (error) {
+    console.warn('Failed to clear SSE keep-alive timer', error);
+  }
+
+  try {
+    client.response.end();
+  } catch (error) {
+    console.warn('Failed to gracefully terminate SSE response', error);
+  }
+};
+
+const registerClient = (
+  req: Request,
+  res: Response,
+  userId: number,
+  userName?: string
+) => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+
+  res.flushHeaders?.();
+
+  const connection: ClientConnection = {
+    id: nextClientId++,
+    userId,
+    userName,
+    response: res,
+    keepAliveTimer: setInterval(() => {
+      writeEvent(connection, { event: 'ping', data: { ts: Date.now() } });
+    }, KEEP_ALIVE_INTERVAL),
+  };
+
+  clients.add(connection);
+
+  writeEvent(connection, {
+    event: 'connection',
+    data: { userId: String(userId), userName },
+  });
+
+  req.on('close', () => {
+    removeClient(connection);
+  });
+};
+
+const broadcastEvent = (event: ServerEvent, options?: { excludeUserId?: number }) => {
+  if (clients.size === 0) {
+    return;
+  }
+
+  for (const client of clients) {
+    if (options?.excludeUserId && client.userId === options.excludeUserId) {
+      continue;
+    }
+    writeEvent(client, event);
+  }
+};
+
+const cleanupTypingEntry = (conversationId: string, userId: number) => {
+  const conversationTimers = typingState.get(conversationId);
+  if (!conversationTimers) {
+    return;
+  }
+
+  const entry = conversationTimers.get(userId);
+  if (entry) {
+    clearTimeout(entry.timeout);
+  }
+
+  conversationTimers.delete(userId);
+
+  if (conversationTimers.size === 0) {
+    typingState.delete(conversationId);
+  }
+};
+
+const scheduleTypingTimeout = (
+  conversationId: string,
+  userId: number,
+  userName: string | undefined
+) => {
+  let conversationTimers = typingState.get(conversationId);
+  if (!conversationTimers) {
+    conversationTimers = new Map<number, TypingEntry>();
+    typingState.set(conversationId, conversationTimers);
+  }
+
+  const timeout = setTimeout(() => {
+    conversationTimers?.delete(userId);
+    if (conversationTimers && conversationTimers.size === 0) {
+      typingState.delete(conversationId);
+    }
+    broadcastEvent({
+      event: 'typing',
+      data: {
+        conversationId,
+        userId: String(userId),
+        userName,
+        isTyping: false,
+        timeout: true,
+      },
+    });
+  }, TYPING_IDLE_TIMEOUT);
+
+  conversationTimers.set(userId, { timeout, userName });
+};
+
+export const streamConversations = (req: Request, res: Response) => {
+  if (!req.auth) {
+    res.status(401).json({ error: 'Token inválido.' });
+    return;
+  }
+
+  const payload = (req.auth.payload ?? {}) as Record<string, unknown>;
+  const userName =
+    typeof payload.name === 'string' && payload.name.trim().length > 0
+      ? payload.name.trim()
+      : undefined;
+
+  registerClient(req, res, req.auth.userId, userName);
+};
+
+export const publishConversationUpdate = (
+  conversation: ConversationSummary | ConversationDetails
+) => {
+  const payload: ConversationSummary = {
+    id: conversation.id,
+    name: conversation.name,
+    avatar: conversation.avatar,
+    shortStatus: conversation.shortStatus,
+    description: conversation.description,
+    unreadCount: conversation.unreadCount,
+    pinned: conversation.pinned,
+    lastMessage: conversation.lastMessage,
+    phoneNumber: conversation.phoneNumber,
+    responsible: conversation.responsible,
+    tags: conversation.tags,
+    isLinkedToClient: conversation.isLinkedToClient,
+    clientName: conversation.clientName,
+    customAttributes: conversation.customAttributes,
+    isPrivate: conversation.isPrivate,
+    internalNotes: conversation.internalNotes,
+  };
+
+  broadcastEvent({ event: 'conversation:update', data: payload });
+};
+
+export const publishMessageCreated = (
+  message: ChatMessage,
+  options?: { excludeUserId?: number }
+) => {
+  broadcastEvent(
+    {
+      event: 'message:new',
+      data: { conversationId: message.conversationId, message },
+    },
+    options
+  );
+};
+
+export const publishConversationRead = (
+  conversationId: string,
+  userId?: number
+) => {
+  broadcastEvent({
+    event: 'conversation:read',
+    data: {
+      conversationId,
+      userId: userId ? String(userId) : undefined,
+    },
+  });
+};
+
+export interface MessageStatusUpdate {
+  conversationId: string;
+  messageId: string;
+  status: ChatMessageStatus;
+}
+
+export const publishMessageStatusUpdate = (update: MessageStatusUpdate) => {
+  broadcastEvent({
+    event: 'message:status',
+    data: update,
+  });
+};
+
+export const updateTypingState = (
+  conversationId: string,
+  userId: number,
+  userName: string | undefined,
+  isTyping: boolean
+) => {
+  const normalizedConversationId = conversationId.trim();
+  if (!normalizedConversationId) {
+    return;
+  }
+
+  cleanupTypingEntry(normalizedConversationId, userId);
+
+  if (isTyping) {
+    scheduleTypingTimeout(normalizedConversationId, userId, userName);
+  }
+
+  broadcastEvent({
+    event: 'typing',
+    data: {
+      conversationId: normalizedConversationId,
+      userId: String(userId),
+      userName,
+      isTyping,
+    },
+  }, { excludeUserId: userId });
+};

--- a/backend/src/realtime/index.ts
+++ b/backend/src/realtime/index.ts
@@ -1,0 +1,9 @@
+export {
+  streamConversations,
+  publishConversationUpdate,
+  publishMessageCreated,
+  publishConversationRead,
+  publishMessageStatusUpdate,
+  updateTypingState,
+  type MessageStatusUpdate,
+} from './chatEvents';

--- a/backend/src/routes/chatRoutes.ts
+++ b/backend/src/routes/chatRoutes.ts
@@ -4,7 +4,9 @@ import {
   getConversationMessagesHandler,
   listConversationsHandler,
   markConversationReadHandler,
+  streamConversationEventsHandler,
   sendConversationMessageHandler,
+  updateTypingStateHandler,
   updateConversationHandler,
 } from '../controllers/chatController';
 
@@ -192,6 +194,24 @@ const router = Router();
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  */
+
+/**
+ * @swagger
+ * /api/conversations/stream:
+ *   get:
+ *     summary: Abre uma conexão de eventos em tempo real das conversas
+ *     tags: [Conversas]
+ *     description: |
+ *       Retorna uma conexão usando Server-Sent Events (SSE) para enviar notificações de
+ *       mensagens, atualizações de conversa e indicadores de digitação. É necessário
+ *       incluir o token de autenticação via cabeçalho Authorization.
+ *     responses:
+ *       200:
+ *         description: Conexão estabelecida com sucesso.
+ *       401:
+ *         description: Token inválido ou ausente.
+ */
+router.get('/conversations/stream', streamConversationEventsHandler);
 
 router.get('/conversations', listConversationsHandler);
 
@@ -435,5 +455,39 @@ router.post('/conversations/:conversationId/messages', sendConversationMessageHa
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 router.post('/conversations/:conversationId/read', markConversationReadHandler);
+
+/**
+ * @swagger
+ * /api/conversations/{conversationId}/typing:
+ *   post:
+ *     summary: Atualiza o estado de digitação do operador para a conversa
+ *     tags: [Conversas]
+ *     parameters:
+ *       - in: path
+ *         name: conversationId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Identificador da conversa
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               isTyping:
+ *                 type: boolean
+ *                 description: Indica se o usuário está digitando (true) ou não (false)
+ *             required: [isTyping]
+ *     responses:
+ *       202:
+ *         description: Estado de digitação registrado com sucesso
+ *       400:
+ *         description: Dados inválidos
+ *       401:
+ *         description: Token inválido ou ausente
+ */
+router.post('/conversations/:conversationId/typing', updateTypingStateHandler);
 
 export default router;

--- a/frontend/src/features/chat/components/ChatWindow.module.css
+++ b/frontend/src/features/chat/components/ChatWindow.module.css
@@ -787,6 +787,56 @@
   box-shadow: 0 -6px 18px rgba(15, 23, 42, 0.08);
 }
 
+.typingIndicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: hsl(var(--muted-foreground));
+  background: hsl(var(--muted));
+  border-radius: 999px;
+  padding: 0.4rem 0.85rem;
+  margin-bottom: 0.65rem;
+}
+
+.typingIndicatorDots {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.typingIndicatorDots span {
+  display: inline-block;
+  width: 0.35rem;
+  height: 0.35rem;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.45;
+  animation: chatTypingDots 1.2s ease-in-out infinite;
+}
+
+.typingIndicatorDots span:nth-child(2) {
+  animation-delay: 0.18s;
+}
+
+.typingIndicatorDots span:nth-child(3) {
+  animation-delay: 0.36s;
+}
+
+@keyframes chatTypingDots {
+  0%,
+  80%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.35;
+  }
+  40% {
+    transform: translateY(-3px);
+    opacity: 0.9;
+  }
+}
+
 @media (max-width: 1100px) {
   .wrapper {
     --details-panel-width: min(420px, 100vw);

--- a/frontend/src/features/chat/hooks/useChatRealtime.ts
+++ b/frontend/src/features/chat/hooks/useChatRealtime.ts
@@ -1,0 +1,226 @@
+import { useEffect, useRef, useState } from "react";
+import { getApiUrl } from "@/lib/api";
+import { useAuth } from "@/features/auth/AuthProvider";
+import type {
+  ConversationSummary,
+  Message,
+  MessageStatus,
+} from "../types";
+
+interface ConversationUpdatedPayload extends ConversationSummary {}
+
+interface MessageCreatedPayload {
+  conversationId: string;
+  message: Message;
+}
+
+interface MessageStatusPayload {
+  conversationId: string;
+  messageId: string;
+  status: MessageStatus;
+}
+
+interface ConversationReadPayload {
+  conversationId: string;
+  userId?: string;
+}
+
+interface TypingPayload {
+  conversationId: string;
+  userId: string;
+  userName?: string;
+  isTyping: boolean;
+}
+
+export interface ChatRealtimeHandlers {
+  onConversationUpdated?: (conversation: ConversationUpdatedPayload) => void;
+  onConversationRead?: (payload: ConversationReadPayload) => void;
+  onMessageCreated?: (payload: MessageCreatedPayload) => void;
+  onMessageStatusUpdated?: (payload: MessageStatusPayload) => void;
+  onTyping?: (payload: TypingPayload) => void;
+  onConnectionChange?: (isConnected: boolean) => void;
+}
+
+export interface UseChatRealtimeResult {
+  isConnected: boolean;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const parseSseEvent = (rawEvent: string): { event?: string; data?: unknown } | null => {
+  if (!rawEvent) {
+    return null;
+  }
+
+  const lines = rawEvent.split("\n");
+  let eventName: string | undefined;
+  const dataLines: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith(":")) {
+      continue;
+    }
+    if (trimmed.startsWith("event:")) {
+      eventName = trimmed.slice(6).trim();
+      continue;
+    }
+    if (trimmed.startsWith("data:")) {
+      dataLines.push(trimmed.slice(5).trimStart());
+      continue;
+    }
+  }
+
+  const dataString = dataLines.join("\n");
+  let data: unknown;
+
+  if (dataString.length > 0) {
+    try {
+      data = JSON.parse(dataString);
+    } catch (error) {
+      console.warn("Failed to parse SSE payload", error, { dataString });
+    }
+  }
+
+  return { event: eventName, data };
+};
+
+export const useChatRealtime = (handlers: ChatRealtimeHandlers): UseChatRealtimeResult => {
+  const { token } = useAuth();
+  const [isConnected, setIsConnected] = useState(false);
+  const handlersRef = useRef<ChatRealtimeHandlers>(handlers);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    handlersRef.current = handlers;
+  }, [handlers]);
+
+  useEffect(() => {
+    if (!token) {
+      setIsConnected(false);
+      return undefined;
+    }
+
+    let isCancelled = false;
+    let retryDelay = 1000;
+
+    const connect = async () => {
+      while (!isCancelled) {
+        const controller = new AbortController();
+        abortControllerRef.current = controller;
+
+        try {
+          const response = await fetch(getApiUrl("conversations/stream"), {
+            method: "GET",
+            headers: { Authorization: `Bearer ${token}` },
+            signal: controller.signal,
+          });
+
+          if (response.status === 401) {
+            console.error("Realtime stream unauthorized. Verify authentication token.");
+            break;
+          }
+
+          if (!response.ok || !response.body) {
+            throw new Error(`Unexpected realtime response: ${response.status}`);
+          }
+
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder("utf-8");
+          let buffer = "";
+
+          setIsConnected(true);
+          handlersRef.current.onConnectionChange?.(true);
+          retryDelay = 1000;
+
+          while (!isCancelled) {
+            const { value, done } = await reader.read();
+            if (done) {
+              buffer += decoder.decode();
+              break;
+            }
+            buffer += decoder.decode(value, { stream: true });
+
+            let separatorIndex = buffer.indexOf("\n\n");
+            while (separatorIndex !== -1) {
+              const rawEvent = buffer.slice(0, separatorIndex);
+              buffer = buffer.slice(separatorIndex + 2);
+              const parsed = parseSseEvent(rawEvent);
+              if (parsed?.event) {
+                dispatchEvent(parsed.event, parsed.data);
+              }
+              separatorIndex = buffer.indexOf("\n\n");
+            }
+          }
+
+          if (buffer.trim().length > 0) {
+            const parsed = parseSseEvent(buffer.trim());
+            if (parsed?.event) {
+              dispatchEvent(parsed.event, parsed.data);
+            }
+          }
+        } catch (error) {
+          if (controller.signal.aborted || isCancelled) {
+            break;
+          }
+          console.warn("Realtime stream disconnected", error);
+        } finally {
+          if (!isCancelled) {
+            setIsConnected(false);
+            handlersRef.current.onConnectionChange?.(false);
+          }
+        }
+
+        if (isCancelled) {
+          break;
+        }
+
+        await sleep(retryDelay);
+        retryDelay = Math.min(retryDelay * 2, 15_000);
+      }
+    };
+
+    const dispatchEvent = (event: string, data: unknown) => {
+      switch (event) {
+        case "conversation:update":
+          if (data && typeof data === "object") {
+            handlersRef.current.onConversationUpdated?.(data as ConversationUpdatedPayload);
+          }
+          break;
+        case "conversation:read":
+          if (data && typeof data === "object") {
+            handlersRef.current.onConversationRead?.(data as ConversationReadPayload);
+          }
+          break;
+        case "message:new":
+          if (data && typeof data === "object") {
+            handlersRef.current.onMessageCreated?.(data as MessageCreatedPayload);
+          }
+          break;
+        case "message:status":
+          if (data && typeof data === "object") {
+            handlersRef.current.onMessageStatusUpdated?.(data as MessageStatusPayload);
+          }
+          break;
+        case "typing":
+          if (data && typeof data === "object") {
+            handlersRef.current.onTyping?.(data as TypingPayload);
+          }
+          break;
+        case "ping":
+        case "connection":
+        default:
+          break;
+      }
+    };
+
+    void connect();
+
+    return () => {
+      isCancelled = true;
+      abortControllerRef.current?.abort();
+    };
+  }, [token]);
+
+  return { isConnected };
+};

--- a/frontend/src/features/chat/services/chatApi.ts
+++ b/frontend/src/features/chat/services/chatApi.ts
@@ -99,6 +99,15 @@ export const markConversationRead = async (conversationId: string) => {
   await parseJson(response);
 };
 
+export const setTypingState = async (conversationId: string, isTyping: boolean) => {
+  const response = await fetch(`/api/conversations/${conversationId}/typing`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ isTyping }),
+  });
+  await parseJson(response);
+};
+
 export const createConversation = async (
   payload: NewConversationInput,
 ): Promise<ConversationSummary> => {


### PR DESCRIPTION
## Summary
- add server-sent events hub for chat conversations and integrate controllers to publish message, read, and typing changes
- expose realtime stream and typing routes while updating WAHA webhook status handling
- consume realtime events on the chat UI with a new hook, live typing indicator, and optimistic message/status merging

## Testing
- npm --prefix backend run build
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68ce191ac388832692b44ff1ecbd2569