### PR TITLE
Implement password reset flow via email

### DIFF
--- a/backend/sql/password_reset_tokens.sql
+++ b/backend/sql/password_reset_tokens.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS public.password_reset_tokens (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES public.usuarios(id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    used_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (token_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_active
+    ON public.password_reset_tokens (user_id)
+    WHERE used_at IS NULL;

--- a/backend/src/routes/usuarioRoutes.ts
+++ b/backend/src/routes/usuarioRoutes.ts
@@ -6,6 +6,7 @@ import {
   createUsuario,
   updateUsuario,
   deleteUsuario,
+  resetUsuarioSenha,
 } from '../controllers/usuarioController';
 
 const router = Router();
@@ -236,12 +237,15 @@ router.put(['/usuarios/:id', '/users/:id'], updateUsuario);
  */
 router.delete(['/usuarios/:id', '/users/:id'], deleteUsuario);
 
+router.post(['/usuarios/:id/reset-password', '/users/:id/reset-password'], resetUsuarioSenha);
+
 router.get('/users', listUsuarios);
 router.get('/users/company', listUsuariosByEmpresa);
 router.get('/users/:id', getUsuarioById);
 router.post('/users', createUsuario);
 router.put('/users/:id', updateUsuario);
 router.delete('/users/:id', deleteUsuario);
+router.post('/users/:id/reset-password', resetUsuarioSenha);
 
 export default router;
 

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -1,0 +1,203 @@
+import tls from 'tls';
+import os from 'os';
+
+interface SmtpAuthConfig {
+  user: string;
+  pass: string;
+}
+
+interface SmtpConfig {
+  host: string;
+  port: number;
+  secure: boolean;
+  auth: SmtpAuthConfig;
+  rejectUnauthorized: boolean;
+}
+
+const parseBoolean = (value: string | undefined, defaultValue: boolean): boolean => {
+  if (typeof value !== 'string') {
+    return defaultValue;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'y'].includes(normalized)) {
+    return true;
+  }
+
+  if (['0', 'false', 'no', 'n'].includes(normalized)) {
+    return false;
+  }
+
+  return defaultValue;
+};
+
+const DEFAULT_SMTP_CONFIG: SmtpConfig = {
+  host: process.env.SMTP_HOST || 'smtp.hostinger.com',
+  port: Number.parseInt(process.env.SMTP_PORT || '465', 10),
+  secure: parseBoolean(process.env.SMTP_SECURE, true),
+  rejectUnauthorized: parseBoolean(process.env.SMTP_REJECT_UNAUTHORIZED, true),
+  auth: {
+    user: process.env.SMTP_USER || 'contato@quantumtecnologia.com.br',
+    pass: process.env.SMTP_PASSWORD || process.env.SMTP_PASS || 'C@104rm0nd1994',
+  },
+};
+
+const systemName = process.env.SYSTEM_NAME || 'Jus Connect';
+const defaultFromAddress = process.env.SMTP_FROM || DEFAULT_SMTP_CONFIG.auth.user;
+const defaultFromName = process.env.SMTP_FROM_NAME || systemName;
+
+export interface SendEmailParams {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+}
+
+interface SmtpResponse {
+  code: number;
+  message: string;
+}
+
+const CRLF = '\r\n';
+
+function waitForResponse(socket: tls.TLSSocket, timeoutMs = 15000): Promise<SmtpResponse> {
+  return new Promise((resolve, reject) => {
+    let buffer = '';
+    let resolved = false;
+
+    const handleData = (data: Buffer) => {
+      buffer += data.toString('utf8');
+      const lines = buffer.split(/\r?\n/).filter((line) => line.length > 0);
+      if (lines.length === 0) {
+        return;
+      }
+      const lastLine = lines[lines.length - 1];
+      if (lastLine.length >= 4 && lastLine[3] === ' ') {
+        const code = Number.parseInt(lastLine.slice(0, 3), 10);
+        resolved = true;
+        cleanup();
+        resolve({ code, message: buffer });
+      }
+    };
+
+    const handleError = (error: Error) => {
+      if (!resolved) {
+        resolved = true;
+        cleanup();
+        reject(error);
+      }
+    };
+
+    const handleClose = () => {
+      if (!resolved) {
+        resolved = true;
+        cleanup();
+        reject(new Error('Conexão SMTP encerrada inesperadamente.'));
+      }
+    };
+
+    const handleTimeout = () => {
+      if (!resolved) {
+        resolved = true;
+        cleanup();
+        reject(new Error('Tempo de espera excedido durante comunicação SMTP.'));
+      }
+    };
+
+    const cleanup = () => {
+      socket.off('data', handleData);
+      socket.off('error', handleError);
+      socket.off('close', handleClose);
+      socket.off('timeout', handleTimeout);
+    };
+
+    socket.on('data', handleData);
+    socket.on('error', handleError);
+    socket.on('close', handleClose);
+    socket.setTimeout(timeoutMs, handleTimeout);
+  });
+}
+
+async function sendCommand(
+  socket: tls.TLSSocket,
+  command: string | null,
+  expectedCodes: number[]
+): Promise<SmtpResponse> {
+  if (command) {
+    socket.write(`${command}${CRLF}`);
+  }
+
+  const response = await waitForResponse(socket);
+
+  if (!expectedCodes.includes(response.code)) {
+    throw new Error(`SMTP comando "${command ?? '<inicial>'}" retornou código ${response.code}: ${response.message}`);
+  }
+
+  return response;
+}
+
+function buildMessageHeaders(to: string, subject: string, boundary: string): string[] {
+  return [
+    `From: ${defaultFromName} <${defaultFromAddress}>`,
+    `To: ${to}`,
+    `Subject: ${subject}`,
+    'MIME-Version: 1.0',
+    `Content-Type: multipart/alternative; boundary="${boundary}"`,
+  ];
+}
+
+function sanitizeMessageBody(content: string): string {
+  return content.replace(/^(\.)/gm, '..$1');
+}
+
+function buildMessageBody(text: string, html: string, boundary: string): string {
+  const parts = [
+    `--${boundary}`,
+    'Content-Type: text/plain; charset="utf-8"',
+    'Content-Transfer-Encoding: 8bit',
+    '',
+    text,
+    '',
+    `--${boundary}`,
+    'Content-Type: text/html; charset="utf-8"',
+    'Content-Transfer-Encoding: 8bit',
+    '',
+    html,
+    '',
+    `--${boundary}--`,
+    '',
+  ];
+
+  return parts.join(CRLF);
+}
+
+export async function sendEmail({ to, subject, html, text }: SendEmailParams): Promise<void> {
+  const { host, port, auth, rejectUnauthorized } = DEFAULT_SMTP_CONFIG;
+  const clientName = os.hostname() || 'localhost';
+  const boundary = `----=_Boundary_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
+  const headers = buildMessageHeaders(to, subject, boundary);
+  const messageBody = buildMessageBody(text, html, boundary);
+  const message = sanitizeMessageBody([...headers, '', messageBody].join(CRLF));
+
+  const socket = tls.connect({
+    host,
+    port,
+    rejectUnauthorized,
+  });
+
+  try {
+    await waitForResponse(socket); // 220 greeting
+    await sendCommand(socket, `EHLO ${clientName}`, [250]);
+    await sendCommand(socket, 'AUTH LOGIN', [334]);
+    await sendCommand(socket, Buffer.from(auth.user, 'utf8').toString('base64'), [334]);
+    await sendCommand(socket, Buffer.from(auth.pass, 'utf8').toString('base64'), [235]);
+    await sendCommand(socket, `MAIL FROM:<${defaultFromAddress}>`, [250]);
+    await sendCommand(socket, `RCPT TO:<${to}>`, [250, 251]);
+    await sendCommand(socket, 'DATA', [354]);
+    socket.write(`${message}${CRLF}.${CRLF}`);
+    await sendCommand(socket, null, [250]);
+    await sendCommand(socket, 'QUIT', [221]);
+  } finally {
+    socket.end();
+  }
+}

--- a/backend/src/services/passwordResetEmailTemplate.ts
+++ b/backend/src/services/passwordResetEmailTemplate.ts
@@ -1,0 +1,76 @@
+interface PasswordResetEmailParams {
+  userName: string;
+  resetLink: string;
+  temporaryPassword: string;
+  expiresAt: Date;
+  systemName?: string;
+}
+
+interface PasswordResetEmailContent {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+const DEFAULT_SYSTEM_NAME = process.env.SYSTEM_NAME || 'Jus Connect';
+
+function formatExpiration(date: Date): string {
+  return new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+export function buildPasswordResetEmail({
+  userName,
+  resetLink,
+  temporaryPassword,
+  expiresAt,
+  systemName = DEFAULT_SYSTEM_NAME,
+}: PasswordResetEmailParams): PasswordResetEmailContent {
+  const expirationText = formatExpiration(expiresAt);
+  const subject = `Redefinição de senha - ${systemName}`;
+  const text = `Olá ${userName},\n\n` +
+    `Uma solicitação de redefinição de senha foi realizada no ${systemName}.\n` +
+    `Utilize a senha temporária ${temporaryPassword} para acessar e clique no link abaixo para criar uma nova senha.\n` +
+    `${resetLink}\n\n` +
+    `Este link é válido até ${expirationText}. Caso você não tenha solicitado, ignore este e-mail.\n\n` +
+    `Atenciosamente,\nEquipe ${systemName}`;
+  const html = `<!DOCTYPE html>` +
+    `<html lang="pt-BR">` +
+    `<head>` +
+    '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />' +
+    `<title>${subject}</title>` +
+    `<style>` +
+    'body { font-family: Arial, sans-serif; background-color: #f4f4f5; margin: 0; padding: 0; }' +
+    '.container { max-width: 600px; margin: 0 auto; background: #ffffff; padding: 32px; }' +
+    '.button { display: inline-block; padding: 12px 24px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: bold; }' +
+    '.footer { font-size: 12px; color: #6b7280; margin-top: 24px; }' +
+    '.temp-pass { font-size: 18px; font-weight: bold; letter-spacing: 2px; color: #111827; background: #f9fafb; padding: 12px; border-radius: 6px; display: inline-block; margin: 16px 0; }' +
+    '</style>' +
+    `</head>` +
+    `<body>` +
+    `<div class="container">` +
+    `<p>Olá ${userName},</p>` +
+    `<p>Recebemos uma solicitação para redefinir a sua senha no <strong>${systemName}</strong>.</p>` +
+    `<p>Use a senha temporária abaixo para acessar e, em seguida, clique no botão para definir uma nova senha permanente:</p>` +
+    `<p class="temp-pass">${temporaryPassword}</p>` +
+    `<p style="margin: 24px 0;">` +
+    `<a class="button" href="${resetLink}" target="_blank" rel="noopener noreferrer">Recuperar senha</a>` +
+    `</p>` +
+    `<p>Este link expira em <strong>${expirationText}</strong>. Caso você não tenha solicitado esta alteração, ignore este e-mail.</p>` +
+    `<p>Se o botão não funcionar, copie e cole o link abaixo no seu navegador:</p>` +
+    `<p><a href="${resetLink}" target="_blank" rel="noopener noreferrer">${resetLink}</a></p>` +
+    `<p class="footer">` +
+    `Este é um e-mail automático. Por favor, não responda.` +
+    `<br />Equipe ${systemName}` +
+    `</p>` +
+    `</div>` +
+    `</body>` +
+    `</html>`;
+
+  return { subject, text, html };
+}

--- a/backend/src/services/passwordResetService.ts
+++ b/backend/src/services/passwordResetService.ts
@@ -1,0 +1,128 @@
+import crypto from 'crypto';
+import pool from './db';
+import { hashPassword } from '../utils/passwordUtils';
+import { sendEmail } from './emailService';
+import { buildPasswordResetEmail } from './passwordResetEmailTemplate';
+
+const PASSWORD_RESET_TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
+const DEFAULT_FRONTEND_BASE_URL = process.env.FRONTEND_BASE_URL || 'https://jusconnec.quantumtecnologia.com.br';
+const PASSWORD_RESET_PATH = process.env.PASSWORD_RESET_PATH || '/redefinir-senha';
+
+interface TargetUser {
+  id: number;
+  nome_completo: string;
+  email: string;
+}
+
+function generateTemporaryPassword(length = 12): string {
+  const charset = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789@#$%';
+  const bytes = crypto.randomBytes(length);
+  let password = '';
+
+  for (let i = 0; i < length; i += 1) {
+    const index = bytes[i] % charset.length;
+    password += charset[index];
+  }
+
+  return password;
+}
+
+function generateResetToken(): { rawToken: string; tokenHash: string } {
+  const rawToken = crypto.randomUUID();
+  const tokenHash = crypto.createHash('sha256').update(rawToken).digest('hex');
+  return { rawToken, tokenHash };
+}
+
+function buildResetLink(rawToken: string): string {
+  const baseUrl = DEFAULT_FRONTEND_BASE_URL.endsWith('/')
+    ? DEFAULT_FRONTEND_BASE_URL.slice(0, -1)
+    : DEFAULT_FRONTEND_BASE_URL;
+  const url = new URL(PASSWORD_RESET_PATH, `${baseUrl}/`);
+  url.searchParams.set('token', rawToken);
+  return url.toString();
+}
+
+export async function createPasswordResetRequest(user: TargetUser): Promise<void> {
+  const temporaryPassword = generateTemporaryPassword();
+  const hashedPassword = hashPassword(temporaryPassword);
+  const { rawToken, tokenHash } = generateResetToken();
+  const expiresAt = new Date(Date.now() + PASSWORD_RESET_TOKEN_TTL_MS);
+  const resetLink = buildResetLink(rawToken);
+
+  const client = await pool.connect();
+  let previousPasswordValue: string | null = null;
+
+  try {
+    await client.query('BEGIN');
+    const previousPasswordResult = await client.query(
+      'SELECT senha FROM public.usuarios WHERE id = $1 FOR UPDATE',
+      [user.id]
+    );
+
+    if (previousPasswordResult.rowCount === 0) {
+      throw new Error('Usuário não encontrado ao tentar resetar senha.');
+    }
+
+    const previousPasswordRow = previousPasswordResult.rows[0] as { senha: unknown };
+    previousPasswordValue =
+      typeof previousPasswordRow.senha === 'string' ? previousPasswordRow.senha : null;
+
+    await client.query(
+      'UPDATE public.usuarios SET senha = $1 WHERE id = $2',
+      [hashedPassword, user.id]
+    );
+
+    await client.query(
+      'UPDATE public.password_reset_tokens SET used_at = NOW() WHERE user_id = $1 AND used_at IS NULL',
+      [user.id]
+    );
+
+    await client.query(
+      'INSERT INTO public.password_reset_tokens (user_id, token_hash, expires_at) VALUES ($1, $2, $3)',
+      [user.id, tokenHash, expiresAt]
+    );
+
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+
+  const email = buildPasswordResetEmail({
+    userName: user.nome_completo,
+    resetLink,
+    temporaryPassword,
+    expiresAt,
+  });
+
+  try {
+    await sendEmail({
+      to: user.email,
+      subject: email.subject,
+      html: email.html,
+      text: email.text,
+    });
+  } catch (error) {
+    try {
+      await pool.query(
+        'UPDATE public.usuarios SET senha = $1 WHERE id = $2',
+        [previousPasswordValue, user.id]
+      );
+    } catch (rollbackError) {
+      console.error('Falha ao restaurar senha original após erro de envio de e-mail.', rollbackError);
+    }
+
+    try {
+      await pool.query(
+        'UPDATE public.password_reset_tokens SET used_at = NOW() WHERE user_id = $1 AND used_at IS NULL',
+        [user.id]
+      );
+    } catch (rollbackTokenError) {
+      console.error('Falha ao invalidar tokens de redefinição após erro de envio de e-mail.', rollbackTokenError);
+    }
+
+    throw error;
+  }
+}

--- a/backend/src/utils/passwordUtils.ts
+++ b/backend/src/utils/passwordUtils.ts
@@ -44,3 +44,13 @@ export const verifyPassword = async (
 
   return safeCompare(providedPassword, storedValue);
 };
+
+export const hashPassword = (password: string): string => {
+  const salt = crypto.randomBytes(16).toString('hex');
+  const digest = crypto
+    .createHash('sha256')
+    .update(`${salt}:${password}`)
+    .digest('hex');
+
+  return `${SHA256_PREFIX}${salt}:${digest}`;
+};


### PR DESCRIPTION
## Summary
- add password reset token persistence and service to generate temporary passwords, links and send SMTP emails
- expose a reset-password endpoint for users and integrate it with the configurations users UI action
- provide a HTML/text email template with recovery instructions and one-hour expiration notice

## Testing
- npm run build (backend)
- npm run build (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68cebe9c5c04832680c9d50c87c71992