### PR TITLE
Ensure support schema columns exist before indexing

### DIFF
--- a/backend/sql/support.sql
+++ b/backend/sql/support.sql
@@ -12,6 +12,12 @@ CREATE TABLE IF NOT EXISTS support_requests (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+ALTER TABLE support_requests ADD COLUMN IF NOT EXISTS requester_id INTEGER;
+ALTER TABLE support_requests ADD COLUMN IF NOT EXISTS requester_name TEXT;
+ALTER TABLE support_requests ADD COLUMN IF NOT EXISTS requester_email TEXT;
+ALTER TABLE support_requests ADD COLUMN IF NOT EXISTS support_agent_id INTEGER;
+ALTER TABLE support_requests ADD COLUMN IF NOT EXISTS support_agent_name TEXT;
+
 CREATE INDEX IF NOT EXISTS idx_support_requests_status ON support_requests (status);
 CREATE INDEX IF NOT EXISTS idx_support_requests_created_at ON support_requests (created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_support_requests_requester ON support_requests (requester_id);


### PR DESCRIPTION
## Summary
- ensure support_requests table gains requester/support agent columns even when table already exists

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cec24230008326af74c74fefaac50c