### PR TITLE
Add password reset endpoint for users

### DIFF
--- a/backend/dist/controllers/usuarioController.js
+++ b/backend/dist/controllers/usuarioController.js
@@ -3,8 +3,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.deleteUsuario = exports.updateUsuario = exports.createUsuario = exports.getUsuarioById = exports.listUsuarios = void 0;
+exports.resetUsuarioSenha = exports.deleteUsuario = exports.updateUsuario = exports.createUsuario = exports.getUsuarioById = exports.listUsuariosByEmpresa = exports.listUsuarios = void 0;
 const db_1 = __importDefault(require("../services/db"));
+const passwordResetService_1 = require("../services/passwordResetService");
 const parseOptionalId = (value) => {
     if (value === undefined || value === null) {
         return null;
@@ -75,9 +76,34 @@ const parseStatus = (value) => {
     }
     return 'invalid';
 };
-const baseUsuarioSelect = 'SELECT id, nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao FROM public.vw_usuarios';
-const listUsuarios = async (_req, res) => {
+const baseUsuarioSelect = 'SELECT u.id, u.nome_completo, u.cpf, u.email, u.perfil, u.empresa, u.setor, u.oab, u.status, u.senha, u.telefone, u.ultimo_login, u.observacoes, u.datacriacao FROM public.usuarios u';
+const fetchAuthenticatedUserEmpresa = async (userId) => {
+    const empresaUsuarioResult = await db_1.default.query('SELECT empresa FROM public.usuarios WHERE id = $1 LIMIT 1', [userId]);
+    if (empresaUsuarioResult.rowCount === 0) {
+        return {
+            success: false,
+            status: 404,
+            message: 'Usuário autenticado não encontrado',
+        };
+    }
+    const empresaAtualResult = parseOptionalId(empresaUsuarioResult.rows[0].empresa);
+    if (empresaAtualResult === 'invalid') {
+        return {
+            success: false,
+            status: 500,
+            message: 'Não foi possível identificar a empresa do usuário autenticado.',
+        };
+    }
+    return {
+        success: true,
+        empresaId: empresaAtualResult,
+    };
+};
+const listUsuarios = async (req, res) => {
     try {
+        if (!req.auth) {
+            return res.status(401).json({ error: 'Token inválido.' });
+        }
         const result = await db_1.default.query(baseUsuarioSelect);
         res.json(result.rows);
     }
@@ -87,10 +113,42 @@ const listUsuarios = async (_req, res) => {
     }
 };
 exports.listUsuarios = listUsuarios;
+const listUsuariosByEmpresa = async (req, res) => {
+    try {
+        if (!req.auth) {
+            return res.status(401).json({ error: 'Token inválido.' });
+        }
+        const empresaLookup = await fetchAuthenticatedUserEmpresa(req.auth.userId);
+        if (!empresaLookup.success) {
+            return res.status(empresaLookup.status).json({ error: empresaLookup.message });
+        }
+        const { empresaId } = empresaLookup;
+        if (empresaId === null) {
+            return res.json([]);
+        }
+        const result = await db_1.default.query(`${baseUsuarioSelect} WHERE u.empresa = $1`, [
+            empresaId,
+        ]);
+        res.json(result.rows);
+    }
+    catch (error) {
+        console.error(error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+};
+exports.listUsuariosByEmpresa = listUsuariosByEmpresa;
 const getUsuarioById = async (req, res) => {
     const { id } = req.params;
     try {
-        const result = await db_1.default.query(`${baseUsuarioSelect} WHERE id = $1`, [id]);
+        if (!req.auth) {
+            return res.status(401).json({ error: 'Token inválido.' });
+        }
+        const empresaLookup = await fetchAuthenticatedUserEmpresa(req.auth.userId);
+        if (!empresaLookup.success) {
+            return res.status(empresaLookup.status).json({ error: empresaLookup.message });
+        }
+        const { empresaId } = empresaLookup;
+        const result = await db_1.default.query(`${baseUsuarioSelect} WHERE u.id = $1 AND u.empresa IS NOT DISTINCT FROM $2::INT`, [id, empresaId]);
         if (result.rowCount === 0) {
             return res.status(404).json({ error: 'Usuário não encontrado' });
         }
@@ -116,16 +174,11 @@ const createUsuario = async (req, res) => {
         if (empresaIdResult === 'invalid') {
             return res.status(400).json({ error: 'ID de empresa inválido' });
         }
-        const empresaUsuarioResult = await db_1.default.query('SELECT empresa FROM public.usuarios WHERE id = $1 LIMIT 1', [req.auth.userId]);
-        if (empresaUsuarioResult.rowCount === 0) {
-            return res.status(404).json({ error: 'Usuário autenticado não encontrado' });
+        const empresaLookup = await fetchAuthenticatedUserEmpresa(req.auth.userId);
+        if (!empresaLookup.success) {
+            return res.status(empresaLookup.status).json({ error: empresaLookup.message });
         }
-        const empresaAtualResult = parseOptionalId(empresaUsuarioResult.rows[0].empresa);
-        if (empresaAtualResult === 'invalid') {
-            return res
-                .status(500)
-                .json({ error: 'Não foi possível identificar a empresa do usuário autenticado.' });
-        }
+        const empresaAtualResult = empresaLookup.empresaId;
         if (empresaIdResult !== null && empresaAtualResult !== null && empresaIdResult !== empresaAtualResult) {
             return res
                 .status(403)
@@ -251,3 +304,57 @@ const deleteUsuario = async (req, res) => {
     }
 };
 exports.deleteUsuario = deleteUsuario;
+const resetUsuarioSenha = async (req, res) => {
+    if (!req.auth) {
+        return res.status(401).json({ error: 'Token inválido.' });
+    }
+    const { id } = req.params;
+    const targetUserId = Number.parseInt(id, 10);
+    if (!Number.isFinite(targetUserId)) {
+        return res.status(400).json({ error: 'ID de usuário inválido.' });
+    }
+    try {
+        const empresaLookup = await fetchAuthenticatedUserEmpresa(req.auth.userId);
+        if (!empresaLookup.success) {
+            return res.status(empresaLookup.status).json({ error: empresaLookup.message });
+        }
+        const targetUserResult = await db_1.default.query('SELECT id, nome_completo, email, empresa FROM public.usuarios WHERE id = $1 LIMIT 1', [targetUserId]);
+        if (targetUserResult.rowCount === 0) {
+            return res.status(404).json({ error: 'Usuário não encontrado' });
+        }
+        const targetUserRow = targetUserResult.rows[0];
+        const targetUserEmail = typeof targetUserRow.email === 'string' ? targetUserRow.email.trim() : '';
+        if (!targetUserEmail) {
+            return res.status(400).json({ error: 'Usuário não possui e-mail cadastrado.' });
+        }
+        const targetEmpresaIdResult = parseOptionalId(targetUserRow.empresa);
+        if (targetEmpresaIdResult === 'invalid') {
+            return res
+                .status(500)
+                .json({ error: 'Não foi possível validar a empresa associada ao usuário informado.' });
+        }
+        const requesterEmpresaId = empresaLookup.empresaId;
+        if (requesterEmpresaId !== null &&
+            targetEmpresaIdResult !== null &&
+            requesterEmpresaId !== targetEmpresaIdResult) {
+            return res
+                .status(403)
+                .json({ error: 'Usuário não possui permissão para resetar a senha deste colaborador.' });
+        }
+        await (0, passwordResetService_1.createPasswordResetRequest)({
+            id: targetUserRow.id,
+            nome_completo: typeof targetUserRow.nome_completo === 'string'
+                ? targetUserRow.nome_completo
+                : 'Usuário',
+            email: targetUserEmail,
+        });
+        return res.status(200).json({
+            message: 'Senha redefinida com sucesso. Enviamos as instruções para o e-mail cadastrado.',
+        });
+    }
+    catch (error) {
+        console.error('Erro ao resetar senha do usuário', error);
+        return res.status(500).json({ error: 'Não foi possível redefinir a senha do usuário.' });
+    }
+};
+exports.resetUsuarioSenha = resetUsuarioSenha;

--- a/backend/dist/routes/usuarioRoutes.js
+++ b/backend/dist/routes/usuarioRoutes.js
@@ -63,6 +63,23 @@ const router = (0, express_1.Router)();
 router.get(['/usuarios', '/users'], usuarioController_1.listUsuarios);
 /**
  * @swagger
+ * /api/usuarios/empresa:
+ *   get:
+ *     summary: Lista usuários da empresa do usuário autenticado
+ *     tags: [Usuarios]
+ *     responses:
+ *       200:
+ *         description: Lista de usuários filtrados por empresa
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Usuario'
+ */
+router.get(['/usuarios/empresa', '/users/company'], usuarioController_1.listUsuariosByEmpresa);
+/**
+ * @swagger
  * /api/usuarios/{id}:
  *   get:
  *     summary: Obtém um usuário pelo ID
@@ -205,9 +222,12 @@ router.put(['/usuarios/:id', '/users/:id'], usuarioController_1.updateUsuario);
  *         description: Usuário não encontrado
  */
 router.delete(['/usuarios/:id', '/users/:id'], usuarioController_1.deleteUsuario);
+router.post(['/usuarios/:id/reset-password', '/users/:id/reset-password'], usuarioController_1.resetUsuarioSenha);
 router.get('/users', usuarioController_1.listUsuarios);
+router.get('/users/company', usuarioController_1.listUsuariosByEmpresa);
 router.get('/users/:id', usuarioController_1.getUsuarioById);
 router.post('/users', usuarioController_1.createUsuario);
 router.put('/users/:id', usuarioController_1.updateUsuario);
 router.delete('/users/:id', usuarioController_1.deleteUsuario);
+router.post('/users/:id/reset-password', usuarioController_1.resetUsuarioSenha);
 exports.default = router;

--- a/backend/dist/services/emailService.js
+++ b/backend/dist/services/emailService.js
@@ -1,0 +1,156 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.sendEmail = sendEmail;
+const tls_1 = __importDefault(require("tls"));
+const os_1 = __importDefault(require("os"));
+const parseBoolean = (value, defaultValue) => {
+    if (typeof value !== 'string') {
+        return defaultValue;
+    }
+    const normalized = value.trim().toLowerCase();
+    if (['1', 'true', 'yes', 'y'].includes(normalized)) {
+        return true;
+    }
+    if (['0', 'false', 'no', 'n'].includes(normalized)) {
+        return false;
+    }
+    return defaultValue;
+};
+const DEFAULT_SMTP_CONFIG = {
+    host: process.env.SMTP_HOST || 'smtp.hostinger.com',
+    port: Number.parseInt(process.env.SMTP_PORT || '465', 10),
+    secure: parseBoolean(process.env.SMTP_SECURE, true),
+    rejectUnauthorized: parseBoolean(process.env.SMTP_REJECT_UNAUTHORIZED, true),
+    auth: {
+        user: process.env.SMTP_USER || 'contato@quantumtecnologia.com.br',
+        pass: process.env.SMTP_PASSWORD || process.env.SMTP_PASS || 'C@104rm0nd1994',
+    },
+};
+const systemName = process.env.SYSTEM_NAME || 'Jus Connect';
+const defaultFromAddress = process.env.SMTP_FROM || DEFAULT_SMTP_CONFIG.auth.user;
+const defaultFromName = process.env.SMTP_FROM_NAME || systemName;
+const CRLF = '\r\n';
+function waitForResponse(socket, timeoutMs = 15000) {
+    return new Promise((resolve, reject) => {
+        let buffer = '';
+        let resolved = false;
+        const handleData = (data) => {
+            buffer += data.toString('utf8');
+            const lines = buffer.split(/\r?\n/).filter((line) => line.length > 0);
+            if (lines.length === 0) {
+                return;
+            }
+            const lastLine = lines[lines.length - 1];
+            if (lastLine.length >= 4 && lastLine[3] === ' ') {
+                const code = Number.parseInt(lastLine.slice(0, 3), 10);
+                resolved = true;
+                cleanup();
+                resolve({ code, message: buffer });
+            }
+        };
+        const handleError = (error) => {
+            if (!resolved) {
+                resolved = true;
+                cleanup();
+                reject(error);
+            }
+        };
+        const handleClose = () => {
+            if (!resolved) {
+                resolved = true;
+                cleanup();
+                reject(new Error('Conexão SMTP encerrada inesperadamente.'));
+            }
+        };
+        const handleTimeout = () => {
+            if (!resolved) {
+                resolved = true;
+                cleanup();
+                reject(new Error('Tempo de espera excedido durante comunicação SMTP.'));
+            }
+        };
+        const cleanup = () => {
+            socket.off('data', handleData);
+            socket.off('error', handleError);
+            socket.off('close', handleClose);
+            socket.off('timeout', handleTimeout);
+        };
+        socket.on('data', handleData);
+        socket.on('error', handleError);
+        socket.on('close', handleClose);
+        socket.setTimeout(timeoutMs, handleTimeout);
+    });
+}
+async function sendCommand(socket, command, expectedCodes) {
+    if (command) {
+        socket.write(`${command}${CRLF}`);
+    }
+    const response = await waitForResponse(socket);
+    if (!expectedCodes.includes(response.code)) {
+        throw new Error(`SMTP comando "${command ?? '<inicial>'}" retornou código ${response.code}: ${response.message}`);
+    }
+    return response;
+}
+function buildMessageHeaders(to, subject, boundary) {
+    return [
+        `From: ${defaultFromName} <${defaultFromAddress}>`,
+        `To: ${to}`,
+        `Subject: ${subject}`,
+        'MIME-Version: 1.0',
+        `Content-Type: multipart/alternative; boundary="${boundary}"`,
+    ];
+}
+function sanitizeMessageBody(content) {
+    return content.replace(/^(\.)/gm, '..$1');
+}
+function buildMessageBody(text, html, boundary) {
+    const parts = [
+        `--${boundary}`,
+        'Content-Type: text/plain; charset="utf-8"',
+        'Content-Transfer-Encoding: 8bit',
+        '',
+        text,
+        '',
+        `--${boundary}`,
+        'Content-Type: text/html; charset="utf-8"',
+        'Content-Transfer-Encoding: 8bit',
+        '',
+        html,
+        '',
+        `--${boundary}--`,
+        '',
+    ];
+    return parts.join(CRLF);
+}
+async function sendEmail({ to, subject, html, text }) {
+    const { host, port, auth, rejectUnauthorized } = DEFAULT_SMTP_CONFIG;
+    const clientName = os_1.default.hostname() || 'localhost';
+    const boundary = `----=_Boundary_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
+    const headers = buildMessageHeaders(to, subject, boundary);
+    const messageBody = buildMessageBody(text, html, boundary);
+    const message = sanitizeMessageBody([...headers, '', messageBody].join(CRLF));
+    const socket = tls_1.default.connect({
+        host,
+        port,
+        rejectUnauthorized,
+    });
+    try {
+        await waitForResponse(socket); // 220 greeting
+        await sendCommand(socket, `EHLO ${clientName}`, [250]);
+        await sendCommand(socket, 'AUTH LOGIN', [334]);
+        await sendCommand(socket, Buffer.from(auth.user, 'utf8').toString('base64'), [334]);
+        await sendCommand(socket, Buffer.from(auth.pass, 'utf8').toString('base64'), [235]);
+        await sendCommand(socket, `MAIL FROM:<${defaultFromAddress}>`, [250]);
+        await sendCommand(socket, `RCPT TO:<${to}>`, [250, 251]);
+        await sendCommand(socket, 'DATA', [354]);
+        socket.write(`${message}${CRLF}.${CRLF}`);
+        await sendCommand(socket, null, [250]);
+        await sendCommand(socket, 'QUIT', [221]);
+    }
+    finally {
+        socket.end();
+    }
+}

--- a/backend/dist/services/passwordResetEmailTemplate.js
+++ b/backend/dist/services/passwordResetEmailTemplate.js
@@ -1,0 +1,56 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.buildPasswordResetEmail = buildPasswordResetEmail;
+const DEFAULT_SYSTEM_NAME = process.env.SYSTEM_NAME || 'Jus Connect';
+function formatExpiration(date) {
+    return new Intl.DateTimeFormat('pt-BR', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+    }).format(date);
+}
+function buildPasswordResetEmail({ userName, resetLink, temporaryPassword, expiresAt, systemName = DEFAULT_SYSTEM_NAME, }) {
+    const expirationText = formatExpiration(expiresAt);
+    const subject = `Redefinição de senha - ${systemName}`;
+    const text = `Olá ${userName},\n\n` +
+        `Uma solicitação de redefinição de senha foi realizada no ${systemName}.\n` +
+        `Utilize a senha temporária ${temporaryPassword} para acessar e clique no link abaixo para criar uma nova senha.\n` +
+        `${resetLink}\n\n` +
+        `Este link é válido até ${expirationText}. Caso você não tenha solicitado, ignore este e-mail.\n\n` +
+        `Atenciosamente,\nEquipe ${systemName}`;
+    const html = `<!DOCTYPE html>` +
+        `<html lang="pt-BR">` +
+        `<head>` +
+        '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />' +
+        `<title>${subject}</title>` +
+        `<style>` +
+        'body { font-family: Arial, sans-serif; background-color: #f4f4f5; margin: 0; padding: 0; }' +
+        '.container { max-width: 600px; margin: 0 auto; background: #ffffff; padding: 32px; }' +
+        '.button { display: inline-block; padding: 12px 24px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: bold; }' +
+        '.footer { font-size: 12px; color: #6b7280; margin-top: 24px; }' +
+        '.temp-pass { font-size: 18px; font-weight: bold; letter-spacing: 2px; color: #111827; background: #f9fafb; padding: 12px; border-radius: 6px; display: inline-block; margin: 16px 0; }' +
+        '</style>' +
+        `</head>` +
+        `<body>` +
+        `<div class="container">` +
+        `<p>Olá ${userName},</p>` +
+        `<p>Recebemos uma solicitação para redefinir a sua senha no <strong>${systemName}</strong>.</p>` +
+        `<p>Use a senha temporária abaixo para acessar e, em seguida, clique no botão para definir uma nova senha permanente:</p>` +
+        `<p class="temp-pass">${temporaryPassword}</p>` +
+        `<p style="margin: 24px 0;">` +
+        `<a class="button" href="${resetLink}" target="_blank" rel="noopener noreferrer">Recuperar senha</a>` +
+        `</p>` +
+        `<p>Este link expira em <strong>${expirationText}</strong>. Caso você não tenha solicitado esta alteração, ignore este e-mail.</p>` +
+        `<p>Se o botão não funcionar, copie e cole o link abaixo no seu navegador:</p>` +
+        `<p><a href="${resetLink}" target="_blank" rel="noopener noreferrer">${resetLink}</a></p>` +
+        `<p class="footer">` +
+        `Este é um e-mail automático. Por favor, não responda.` +
+        `<br />Equipe ${systemName}` +
+        `</p>` +
+        `</div>` +
+        `</body>` +
+        `</html>`;
+    return { subject, text, html };
+}

--- a/backend/dist/services/passwordResetService.js
+++ b/backend/dist/services/passwordResetService.js
@@ -1,0 +1,96 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.createPasswordResetRequest = createPasswordResetRequest;
+const crypto_1 = __importDefault(require("crypto"));
+const db_1 = __importDefault(require("./db"));
+const passwordUtils_1 = require("../utils/passwordUtils");
+const emailService_1 = require("./emailService");
+const passwordResetEmailTemplate_1 = require("./passwordResetEmailTemplate");
+const PASSWORD_RESET_TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
+const DEFAULT_FRONTEND_BASE_URL = process.env.FRONTEND_BASE_URL || 'https://jusconnec.quantumtecnologia.com.br';
+const PASSWORD_RESET_PATH = process.env.PASSWORD_RESET_PATH || '/redefinir-senha';
+function generateTemporaryPassword(length = 12) {
+    const charset = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789@#$%';
+    const bytes = crypto_1.default.randomBytes(length);
+    let password = '';
+    for (let i = 0; i < length; i += 1) {
+        const index = bytes[i] % charset.length;
+        password += charset[index];
+    }
+    return password;
+}
+function generateResetToken() {
+    const rawToken = crypto_1.default.randomUUID();
+    const tokenHash = crypto_1.default.createHash('sha256').update(rawToken).digest('hex');
+    return { rawToken, tokenHash };
+}
+function buildResetLink(rawToken) {
+    const baseUrl = DEFAULT_FRONTEND_BASE_URL.endsWith('/')
+        ? DEFAULT_FRONTEND_BASE_URL.slice(0, -1)
+        : DEFAULT_FRONTEND_BASE_URL;
+    const url = new URL(PASSWORD_RESET_PATH, `${baseUrl}/`);
+    url.searchParams.set('token', rawToken);
+    return url.toString();
+}
+async function createPasswordResetRequest(user) {
+    const temporaryPassword = generateTemporaryPassword();
+    const hashedPassword = (0, passwordUtils_1.hashPassword)(temporaryPassword);
+    const { rawToken, tokenHash } = generateResetToken();
+    const expiresAt = new Date(Date.now() + PASSWORD_RESET_TOKEN_TTL_MS);
+    const resetLink = buildResetLink(rawToken);
+    const client = await db_1.default.connect();
+    let previousPasswordValue = null;
+    try {
+        await client.query('BEGIN');
+        const previousPasswordResult = await client.query('SELECT senha FROM public.usuarios WHERE id = $1 FOR UPDATE', [user.id]);
+        if (previousPasswordResult.rowCount === 0) {
+            throw new Error('Usuário não encontrado ao tentar resetar senha.');
+        }
+        const previousPasswordRow = previousPasswordResult.rows[0];
+        previousPasswordValue =
+            typeof previousPasswordRow.senha === 'string' ? previousPasswordRow.senha : null;
+        await client.query('UPDATE public.usuarios SET senha = $1 WHERE id = $2', [hashedPassword, user.id]);
+        await client.query('UPDATE public.password_reset_tokens SET used_at = NOW() WHERE user_id = $1 AND used_at IS NULL', [user.id]);
+        await client.query('INSERT INTO public.password_reset_tokens (user_id, token_hash, expires_at) VALUES ($1, $2, $3)', [user.id, tokenHash, expiresAt]);
+        await client.query('COMMIT');
+    }
+    catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+    }
+    finally {
+        client.release();
+    }
+    const email = (0, passwordResetEmailTemplate_1.buildPasswordResetEmail)({
+        userName: user.nome_completo,
+        resetLink,
+        temporaryPassword,
+        expiresAt,
+    });
+    try {
+        await (0, emailService_1.sendEmail)({
+            to: user.email,
+            subject: email.subject,
+            html: email.html,
+            text: email.text,
+        });
+    }
+    catch (error) {
+        try {
+            await db_1.default.query('UPDATE public.usuarios SET senha = $1 WHERE id = $2', [previousPasswordValue, user.id]);
+        }
+        catch (rollbackError) {
+            console.error('Falha ao restaurar senha original após erro de envio de e-mail.', rollbackError);
+        }
+        try {
+            await db_1.default.query('UPDATE public.password_reset_tokens SET used_at = NOW() WHERE user_id = $1 AND used_at IS NULL', [user.id]);
+        }
+        catch (rollbackTokenError) {
+            console.error('Falha ao invalidar tokens de redefinição após erro de envio de e-mail.', rollbackTokenError);
+        }
+        throw error;
+    }
+}

--- a/backend/dist/sql/password_reset_tokens.sql
+++ b/backend/dist/sql/password_reset_tokens.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS public.password_reset_tokens (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES public.usuarios(id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    used_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (token_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_active
+    ON public.password_reset_tokens (user_id)
+    WHERE used_at IS NULL;


### PR DESCRIPTION
## Summary
- expose the reset password handler in the built usuarios controller and routes
- add compiled email/password reset support services required by the handler
- include the password reset tokens schema in the built SQL assets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cec2655ef083269a948e95d5487c00