### PR TITLE
Show support ticket conversation history when responding

### DIFF
--- a/frontend/src/features/chat/hooks/useChatRealtime.ts
+++ b/frontend/src/features/chat/hooks/useChatRealtime.ts
@@ -7,7 +7,7 @@ import type {
   MessageStatus,
 } from "../types";
 
-interface ConversationUpdatedPayload extends ConversationSummary {}
+type ConversationUpdatedPayload = ConversationSummary;
 
 interface MessageCreatedPayload {
   conversationId: string;


### PR DESCRIPTION
## Summary
- fetch support ticket messages when opening the response dialog and render the full conversation history
- add support message types and formatting helpers for the administrator support page
- fix the chat realtime hook type declaration to satisfy eslint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ceca847ba08326b7838e0a39a00089