### PR TITLE
Handle local DB host fallback

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -17,8 +17,12 @@ Estrutura inicial do backend usando Express e TypeScript.
 1. Certifique-se de ter o **Node.js 20** (ou superior) e um banco de dados
    **PostgreSQL** acessível. O projeto já inclui um `appsettings.json`
    configurado para a stack de desenvolvimento utilizada no Docker Compose da
-   Quantum, mas você pode sobrescrever a conexão usando a variável
-   `DATABASE_URL`. Para o ambiente de testes/homologação padrão utilize:
+   Quantum. Ao executar o backend fora de containers, a aplicação substitui
+   automaticamente o host `base-de-dados_postgres` por `localhost`.
+   Caso precise utilizar outro hostname local, defina `LOCAL_DB_HOST` antes de
+   iniciar o servidor. Você também pode sobrescrever toda a conexão usando a
+   variável `DATABASE_URL`. Para o ambiente de testes/homologação padrão
+   utilize:
 
    ```bash
    export DATABASE_URL="postgres://postgres:C@104rm0nd1994@easypanel02.quantumtecnologia.com.br:5438/quantumtecnologia?sslmode=disable"

--- a/backend/src/services/db.ts
+++ b/backend/src/services/db.ts
@@ -27,6 +27,22 @@ if (!connectionString) {
   }
 }
 
+const dockerDbHost = 'base-de-dados_postgres';
+const isRunningInsideContainer = existsSync('/.dockerenv');
+const localDbHostOverride = process.env.LOCAL_DB_HOST;
+
+if (
+  connectionString &&
+  connectionString.includes(dockerDbHost) &&
+  !process.env.DATABASE_URL
+) {
+  const replacementHost = localDbHostOverride || (isRunningInsideContainer ? '' : 'localhost');
+
+  if (replacementHost) {
+    connectionString = connectionString.replace(dockerDbHost, replacementHost);
+  }
+}
+
 if (!connectionString) {
   throw new Error(
     'Database connection string not provided. Set DATABASE_URL or add appsettings.json.'


### PR DESCRIPTION
## Summary
- ensure the backend replaces the Docker-specific database hostname with localhost when running outside containers
- allow overriding the fallback hostname through the LOCAL_DB_HOST environment variable
- document the new behavior and configuration option in the backend README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cedd899170832693256aae9de0b2a9