### PR TITLE
Add Swagger spec download endpoint for Postman import

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -178,7 +178,23 @@ cronJobs.startProjudiSyncJob();
 
 // Swagger
 const specs = swaggerJsdoc(swaggerOptions);
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(specs));
+
+const swaggerUiOptions = {
+  explorer: true,
+  swaggerOptions: {
+    url: '/api-docs/swagger.json',
+  },
+};
+
+app.get('/api-docs/swagger.json', (_req, res) => {
+  res.json(specs);
+});
+
+app.use(
+  '/api-docs',
+  swaggerUi.serveFiles(undefined, swaggerUiOptions),
+  swaggerUi.setup(undefined, swaggerUiOptions)
+);
 
 // Static frontend (when available)
 const frontendDistPath = path.resolve(__dirname, '../../frontend/dist');


### PR DESCRIPTION
## Summary
- expose the generated OpenAPI document at /api-docs/swagger.json for download
- configure Swagger UI to load the spec from that URL, enabling Postman import payload download via the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cee22e065c8326b5b594a945b331e8