### PR TITLE
feat: filter tipo eventos by empresa

### DIFF
--- a/backend/dist/controllers/tipoEventoController.js
+++ b/backend/dist/controllers/tipoEventoController.js
@@ -5,10 +5,22 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.deleteTipoEvento = exports.updateTipoEvento = exports.createTipoEvento = exports.listTiposEvento = void 0;
 const db_1 = __importDefault(require("../services/db"));
-const listTiposEvento = async (_req, res) => {
+const authUser_1 = require("../utils/authUser");
+const listTiposEvento = async (req, res) => {
     try {
-        const result = await db_1.default.query('SELECT id, nome, ativo, datacriacao, agenda, tarefa FROM public.tipo_evento');
-        res.json(result.rows);
+        if (!req.auth) {
+            return res.status(401).json({ error: 'Token inválido.' });
+        }
+        const empresaLookup = await (0, authUser_1.fetchAuthenticatedUserEmpresa)(req.auth.userId);
+        if (!empresaLookup.success) {
+            return res.status(empresaLookup.status).json({ error: empresaLookup.message });
+        }
+        const { empresaId } = empresaLookup;
+        if (empresaId === null) {
+            return res.json([]);
+        }
+        const result = await db_1.default.query('SELECT id, nome, ativo, datacriacao, agenda, tarefa FROM public.tipo_evento WHERE idempresa IS NOT DISTINCT FROM $1', [empresaId]);
+        return res.json(result.rows);
     }
     catch (error) {
         console.error(error);
@@ -19,7 +31,20 @@ exports.listTiposEvento = listTiposEvento;
 const createTipoEvento = async (req, res) => {
     const { nome, ativo, agenda = true, tarefa = true } = req.body;
     try {
-        const result = await db_1.default.query('INSERT INTO public.tipo_evento (nome, ativo, agenda, tarefa, datacriacao) VALUES ($1, $2, $3, $4, NOW()) RETURNING id, nome, ativo, agenda, tarefa, datacriacao', [nome, ativo, agenda, tarefa]);
+        if (!req.auth) {
+            return res.status(401).json({ error: 'Token inválido.' });
+        }
+        const empresaLookup = await (0, authUser_1.fetchAuthenticatedUserEmpresa)(req.auth.userId);
+        if (!empresaLookup.success) {
+            return res.status(empresaLookup.status).json({ error: empresaLookup.message });
+        }
+        const { empresaId } = empresaLookup;
+        if (empresaId === null) {
+            return res
+                .status(400)
+                .json({ error: 'Usuário autenticado não possui empresa vinculada.' });
+        }
+        const result = await db_1.default.query('INSERT INTO public.tipo_evento (nome, ativo, agenda, tarefa, datacriacao, idempresa) VALUES ($1, $2, $3, $4, NOW(), $5) RETURNING id, nome, ativo, agenda, tarefa, datacriacao', [nome, ativo, agenda, tarefa, empresaId]);
         res.status(201).json(result.rows[0]);
     }
     catch (error) {
@@ -32,7 +57,20 @@ const updateTipoEvento = async (req, res) => {
     const { id } = req.params;
     const { nome, ativo, agenda = true, tarefa = true } = req.body;
     try {
-        const result = await db_1.default.query('UPDATE public.tipo_evento SET nome = $1, ativo = $2, agenda = $3, tarefa = $4 WHERE id = $5 RETURNING id, nome, ativo, agenda, tarefa, datacriacao', [nome, ativo, agenda, tarefa, id]);
+        if (!req.auth) {
+            return res.status(401).json({ error: 'Token inválido.' });
+        }
+        const empresaLookup = await (0, authUser_1.fetchAuthenticatedUserEmpresa)(req.auth.userId);
+        if (!empresaLookup.success) {
+            return res.status(empresaLookup.status).json({ error: empresaLookup.message });
+        }
+        const { empresaId } = empresaLookup;
+        if (empresaId === null) {
+            return res
+                .status(400)
+                .json({ error: 'Usuário autenticado não possui empresa vinculada.' });
+        }
+        const result = await db_1.default.query('UPDATE public.tipo_evento SET nome = $1, ativo = $2, agenda = $3, tarefa = $4 WHERE id = $5 AND idempresa IS NOT DISTINCT FROM $6 RETURNING id, nome, ativo, agenda, tarefa, datacriacao', [nome, ativo, agenda, tarefa, id, empresaId]);
         if (result.rowCount === 0) {
             return res.status(404).json({ error: 'Tipo de evento não encontrado' });
         }
@@ -47,7 +85,20 @@ exports.updateTipoEvento = updateTipoEvento;
 const deleteTipoEvento = async (req, res) => {
     const { id } = req.params;
     try {
-        const result = await db_1.default.query('DELETE FROM public.tipo_evento WHERE id = $1', [id]);
+        if (!req.auth) {
+            return res.status(401).json({ error: 'Token inválido.' });
+        }
+        const empresaLookup = await (0, authUser_1.fetchAuthenticatedUserEmpresa)(req.auth.userId);
+        if (!empresaLookup.success) {
+            return res.status(empresaLookup.status).json({ error: empresaLookup.message });
+        }
+        const { empresaId } = empresaLookup;
+        if (empresaId === null) {
+            return res
+                .status(400)
+                .json({ error: 'Usuário autenticado não possui empresa vinculada.' });
+        }
+        const result = await db_1.default.query('DELETE FROM public.tipo_evento WHERE id = $1 AND idempresa IS NOT DISTINCT FROM $2', [id, empresaId]);
         if (result.rowCount === 0) {
             return res.status(404).json({ error: 'Tipo de evento não encontrado' });
         }


### PR DESCRIPTION
## Summary
- ensure API handlers for tipo-eventos read the authenticated user's company id
- persist the idempresa on creation and restrict reads, updates, and deletes to that company

## Testing
- npm test *(fails: database connection string not provided)*

------
https://chatgpt.com/codex/tasks/task_e_68cee887f49c832688350d00de2937c3