### PR TITLE
Restrict tarefa listing to assigned user

### DIFF
--- a/backend/src/controllers/tarefaController.ts
+++ b/backend/src/controllers/tarefaController.ts
@@ -38,9 +38,15 @@ export const listTarefas = async (req: Request, res: Response) => {
        LEFT JOIN public.usuarios u ON u.id = tr.id_usuario
        WHERE t.ativo IS TRUE
          AND t.idempresa IS NOT DISTINCT FROM $1
+         AND EXISTS (
+           SELECT 1
+             FROM public.tarefas_responsaveis trf
+            WHERE trf.id_tarefa = t.id
+              AND trf.id_usuario = $2
+         )
        GROUP BY t.id
 ORDER BY t.concluido ASC, t.data ASC, t.prioridade ASC`,
-      [empresaId]
+      [empresaId, req.auth.userId]
     );
     res.json(result.rows);
   } catch (error) {


### PR DESCRIPTION
## Summary
- ensure the tarefas listing endpoint only returns tasks where the logged-in user is a responsável

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cef8e6f36c8326a49a3b16534d9c9c