### PR TITLE
Ensure situacao processo endpoints respect authenticated company

### DIFF
--- a/backend/src/controllers/situacaoProcessoController.ts
+++ b/backend/src/controllers/situacaoProcessoController.ts
@@ -1,10 +1,45 @@
 import { Request, Response } from 'express';
 import pool from '../services/db';
+import { fetchAuthenticatedUserEmpresa } from '../utils/authUser';
 
-export const listSituacoesProcesso = async (_req: Request, res: Response) => {
+const getAuthenticatedUser = (
+  req: Request,
+  res: Response
+): NonNullable<Request['auth']> | null => {
+  if (!req.auth) {
+    res.status(401).json({ error: 'Token inválido.' });
+    return null;
+  }
+
+  return req.auth;
+};
+
+export const listSituacoesProcesso = async (req: Request, res: Response) => {
   try {
+    const auth = getAuthenticatedUser(req, res);
+    if (!auth) {
+      return;
+    }
+
+    const empresaLookup = await fetchAuthenticatedUserEmpresa(auth.userId);
+
+    if (!empresaLookup.success) {
+      res
+        .status(empresaLookup.status)
+        .json({ error: empresaLookup.message });
+      return;
+    }
+
+    const { empresaId } = empresaLookup;
+
+    if (empresaId === null) {
+      res.json([]);
+      return;
+    }
+
     const result = await pool.query(
-      'SELECT id, nome, ativo, datacriacao FROM public.situacao_processo'
+      'SELECT id, nome, ativo, datacriacao FROM public.situacao_processo WHERE idempresa = $1',
+      [empresaId]
     );
     res.json(result.rows);
   } catch (error) {
@@ -15,10 +50,34 @@ export const listSituacoesProcesso = async (_req: Request, res: Response) => {
 
 export const createSituacaoProcesso = async (req: Request, res: Response) => {
   const { nome, ativo } = req.body;
+  const ativoValue = typeof ativo === 'boolean' ? ativo : true;
   try {
+    const auth = getAuthenticatedUser(req, res);
+    if (!auth) {
+      return;
+    }
+
+    const empresaLookup = await fetchAuthenticatedUserEmpresa(auth.userId);
+
+    if (!empresaLookup.success) {
+      res
+        .status(empresaLookup.status)
+        .json({ error: empresaLookup.message });
+      return;
+    }
+
+    const { empresaId } = empresaLookup;
+
+    if (empresaId === null) {
+      res
+        .status(400)
+        .json({ error: 'Usuário autenticado não possui empresa vinculada.' });
+      return;
+    }
+
     const result = await pool.query(
-      'INSERT INTO public.situacao_processo (nome, ativo, datacriacao) VALUES ($1, $2, NOW()) RETURNING id, nome, ativo, datacriacao',
-      [nome, ativo]
+      'INSERT INTO public.situacao_processo (nome, ativo, datacriacao, idempresa) VALUES ($1, $2, NOW(), $3) RETURNING id, nome, ativo, datacriacao',
+      [nome, ativoValue, empresaId]
     );
     res.status(201).json(result.rows[0]);
   } catch (error) {


### PR DESCRIPTION
## Summary
- require authentication before listing or creating situações de processo
- fetch the authenticated user's empresa and filter list results by its identifier
- attach the empresa identifier to new situações de processo and validate missing vínculo

## Testing
- `npm test` *(fails: Database connection string not provided. Set DATABASE_URL or add appsettings.json.)*


------
https://chatgpt.com/codex/tasks/task_e_68cefa72ef788326abc7ceb6ccbf4243