### PR TITLE
Filtrar fluxos de trabalho por empresa do usuário

### DIFF
--- a/backend/src/controllers/fluxoTrabalhoController.ts
+++ b/backend/src/controllers/fluxoTrabalhoController.ts
@@ -1,10 +1,45 @@
 import { Request, Response } from 'express';
 import pool from '../services/db';
+import { fetchAuthenticatedUserEmpresa } from '../utils/authUser';
 
-export const listFluxosTrabalho = async (_req: Request, res: Response) => {
+const getAuthenticatedUser = (
+  req: Request,
+  res: Response
+): NonNullable<Request['auth']> | null => {
+  if (!req.auth) {
+    res.status(401).json({ error: 'Token inválido.' });
+    return null;
+  }
+
+  return req.auth;
+};
+
+export const listFluxosTrabalho = async (req: Request, res: Response) => {
   try {
+    const auth = getAuthenticatedUser(req, res);
+    if (!auth) {
+      return;
+    }
+
+    const empresaLookup = await fetchAuthenticatedUserEmpresa(auth.userId);
+
+    if (!empresaLookup.success) {
+      res
+        .status(empresaLookup.status)
+        .json({ error: empresaLookup.message });
+      return;
+    }
+
+    const { empresaId } = empresaLookup;
+
+    if (empresaId === null) {
+      res.json([]);
+      return;
+    }
+
     const result = await pool.query(
-      'SELECT id, nome, ativo, datacriacao, exibe_menu, ordem FROM public.fluxo_trabalho'
+      'SELECT id, nome, ativo, datacriacao, exibe_menu, ordem FROM public.fluxo_trabalho WHERE idempresa = $1',
+      [empresaId]
     );
     res.json(result.rows);
   } catch (error) {
@@ -13,13 +48,35 @@ export const listFluxosTrabalho = async (_req: Request, res: Response) => {
   }
 };
 
-export const listFluxoTrabalhoMenus = async (_req: Request, res: Response) => {
+export const listFluxoTrabalhoMenus = async (req: Request, res: Response) => {
   try {
+    const auth = getAuthenticatedUser(req, res);
+    if (!auth) {
+      return;
+    }
+
+    const empresaLookup = await fetchAuthenticatedUserEmpresa(auth.userId);
+
+    if (!empresaLookup.success) {
+      res
+        .status(empresaLookup.status)
+        .json({ error: empresaLookup.message });
+      return;
+    }
+
+    const { empresaId } = empresaLookup;
+
+    if (empresaId === null) {
+      res.json([]);
+      return;
+    }
+
     const result = await pool.query(
       `SELECT id, nome, ordem
        FROM public.fluxo_trabalho
-       WHERE ativo IS TRUE AND exibe_menu IS TRUE
-       ORDER BY ordem ASC`
+       WHERE idempresa = $1 AND ativo IS TRUE AND exibe_menu IS TRUE
+       ORDER BY ordem ASC`,
+      [empresaId]
     );
     res.json(result.rows);
   } catch (error) {
@@ -30,10 +87,35 @@ export const listFluxoTrabalhoMenus = async (_req: Request, res: Response) => {
 
 export const createFluxoTrabalho = async (req: Request, res: Response) => {
   const { nome, ativo, exibe_menu = true, ordem } = req.body;
+  const ativoValue = typeof ativo === 'boolean' ? ativo : true;
+
   try {
+    const auth = getAuthenticatedUser(req, res);
+    if (!auth) {
+      return;
+    }
+
+    const empresaLookup = await fetchAuthenticatedUserEmpresa(auth.userId);
+
+    if (!empresaLookup.success) {
+      res
+        .status(empresaLookup.status)
+        .json({ error: empresaLookup.message });
+      return;
+    }
+
+    const { empresaId } = empresaLookup;
+
+    if (empresaId === null) {
+      res
+        .status(400)
+        .json({ error: 'Usuário autenticado não possui empresa vinculada.' });
+      return;
+    }
+
     const result = await pool.query(
-      'INSERT INTO public.fluxo_trabalho (nome, ativo, exibe_menu, ordem, datacriacao) VALUES ($1, $2, $3, $4, NOW()) RETURNING id, nome, ativo, exibe_menu, ordem, datacriacao',
-      [nome, ativo, exibe_menu, ordem]
+      'INSERT INTO public.fluxo_trabalho (nome, ativo, exibe_menu, ordem, datacriacao, idempresa) VALUES ($1, $2, $3, $4, NOW(), $5) RETURNING id, nome, ativo, exibe_menu, ordem, datacriacao',
+      [nome, ativoValue, exibe_menu, ordem, empresaId]
     );
     res.status(201).json(result.rows[0]);
   } catch (error) {


### PR DESCRIPTION
## Summary
- valida o token e identifica a empresa do usuário antes de listar fluxos de trabalho
- limita as consultas de listagem de fluxos e menus à empresa vinculada ao usuário
- garante que novos fluxos de trabalho sejam criados com o idempresa do usuário autenticado

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cefe06da5883268ea8b3bb24e51b41