### PR TITLE
Hide proposal and process status menu items

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -153,11 +153,6 @@ export function Sidebar() {
                 moduleId: "configuracoes-parametros-area-atuacao",
               },
               {
-                name: "Situação do Processo",
-                href: "/configuracoes/parametros/situacao-processo",
-                moduleId: "configuracoes-parametros-situacao-processo",
-              },
-              {
                 name: "Tipo de Processo",
                 href: "/configuracoes/parametros/tipo-processo",
                 moduleId: "configuracoes-parametros-tipo-processo",
@@ -166,11 +161,6 @@ export function Sidebar() {
                 name: "Tipo de Evento",
                 href: "/configuracoes/parametros/tipo-evento",
                 moduleId: "configuracoes-parametros-tipo-evento",
-              },
-              {
-                name: "Situação da Proposta",
-                href: "/configuracoes/parametros/situacao-proposta",
-                moduleId: "configuracoes-parametros-situacao-proposta",
               },
               {
                 name: "Etiquetas",


### PR DESCRIPTION
## Summary
- remove the configuration sidebar entries for "Situação da Proposta" and "Situação do Processo"

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ceff2f6bb48326bbe8e047e9c1b967