### PR TITLE
Refresh auth session based on activity

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -100,6 +100,34 @@ export const login = async (req: Request, res: Response) => {
   }
 };
 
+export const refreshToken = (req: Request, res: Response) => {
+  if (!req.auth) {
+    res.status(401).json({ error: 'Token inválido.' });
+    return;
+  }
+
+  try {
+    const payload = (req.auth.payload ?? {}) as Record<string, unknown>;
+    const refreshedToken = signToken(
+      {
+        sub: req.auth.userId,
+        email: typeof payload.email === 'string' ? payload.email : undefined,
+        name: typeof payload.name === 'string' ? payload.name : undefined,
+      },
+      authConfig.secret,
+      authConfig.expirationSeconds
+    );
+
+    res.json({
+      token: refreshedToken,
+      expiresIn: authConfig.expirationSeconds,
+    });
+  } catch (error) {
+    console.error('Erro ao renovar token de autenticação', error);
+    res.status(500).json({ error: 'Não foi possível renovar o token de acesso.' });
+  }
+};
+
 export const getCurrentUser = async (req: Request, res: Response) => {
   if (!req.auth) {
     res.status(401).json({ error: 'Token inválido.' });

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { getCurrentUser, login } from '../controllers/authController';
+import { getCurrentUser, login, refreshToken } from '../controllers/authController';
 import { authenticateRequest } from '../middlewares/authMiddleware';
 
 const router = Router();
@@ -96,5 +96,31 @@ router.post('/auth/login', login);
  *         description: Usuário não encontrado
  */
 router.get('/auth/me', authenticateRequest, getCurrentUser);
+
+/**
+ * @swagger
+ * /api/auth/refresh:
+ *   post:
+ *     summary: Renova o token de acesso do usuário autenticado
+ *     tags: [Autenticação]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Novo token de acesso gerado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 token:
+ *                   type: string
+ *                 expiresIn:
+ *                   type: integer
+ *                   description: Expiração do token em segundos
+ *       401:
+ *         description: Token ausente ou inválido
+ */
+router.post('/auth/refresh', authenticateRequest, refreshToken);
 
 export default router;

--- a/frontend/src/features/auth/AuthProvider.tsx
+++ b/frontend/src/features/auth/AuthProvider.tsx
@@ -9,14 +9,15 @@ import {
   useState,
 } from "react";
 import { getApiBaseUrl } from "@/lib/api";
-import { LAST_ACTIVITY_KEY } from "@/hooks/useAutoLogout";
-import { ApiError, fetchCurrentUser, loginRequest } from "./api";
+import { DEFAULT_TIMEOUT_MS, LAST_ACTIVITY_KEY } from "@/hooks/useAutoLogout";
+import { ApiError, fetchCurrentUser, loginRequest, refreshTokenRequest } from "./api";
 import type { AuthUser, LoginCredentials, LoginResponse } from "./types";
 
 interface StoredAuthData {
   token: string;
   user?: AuthUser;
   timestamp: number;
+  expiresAt?: number;
 }
 
 interface AuthContextValue {
@@ -49,6 +50,102 @@ const sanitizeAuthUser = (user: AuthUser | undefined | null): AuthUser | null =>
   } satisfies AuthUser;
 };
 
+const TOKEN_REFRESH_THRESHOLD_MS = 5 * 60 * 1000;
+const TOKEN_REFRESH_RETRY_DELAY_MS = 30 * 1000;
+
+const decodeBase64Url = (value: string): string | null => {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = normalized.length % 4;
+  const padded = normalized + "=".repeat((4 - padding) % 4);
+
+  if (typeof atob === "function") {
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+
+    if (typeof TextDecoder === "function") {
+      return new TextDecoder().decode(bytes);
+    }
+
+    let result = "";
+    for (let index = 0; index < bytes.length; index += 1) {
+      result += String.fromCharCode(bytes[index]);
+    }
+    return result;
+  }
+
+  const globalBuffer = (globalThis as { Buffer?: { from: (data: string, encoding: string) => { toString: (encoding: string) => string } } }).Buffer;
+  if (globalBuffer) {
+    try {
+      return globalBuffer.from(padded, "base64").toString("utf-8");
+    } catch (error) {
+      console.warn("Falha ao decodificar base64 utilizando Buffer", error);
+    }
+  }
+
+  return null;
+};
+
+const decodeTokenExpiration = (token: string): number | null => {
+  const parts = token.split(".");
+  if (parts.length < 2) {
+    return null;
+  }
+
+  try {
+    const decoded = decodeBase64Url(parts[1]);
+    if (!decoded) {
+      return null;
+    }
+
+    const payload = JSON.parse(decoded) as { exp?: unknown };
+    if (typeof payload.exp === "number" && Number.isFinite(payload.exp)) {
+      return payload.exp * 1000;
+    }
+  } catch (error) {
+    console.warn("Falha ao decodificar expiração do token", error);
+  }
+
+  return null;
+};
+
+const resolveTokenExpiration = (
+  token: string,
+  expiresIn?: number,
+  baseTimestamp = Date.now(),
+): number | null => {
+  if (typeof expiresIn === "number" && Number.isFinite(expiresIn) && expiresIn > 0) {
+    return baseTimestamp + expiresIn * 1000;
+  }
+
+  return decodeTokenExpiration(token);
+};
+
+const readLastActivityTimestamp = (): number | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(LAST_ACTIVITY_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed)) {
+      return null;
+    }
+
+    return parsed;
+  } catch (error) {
+    console.warn("Falha ao ler registro de atividade", error);
+    return null;
+  }
+};
+
 const readStoredAuth = (): StoredAuthData | null => {
   if (typeof window === "undefined") {
     return null;
@@ -67,9 +164,15 @@ const readStoredAuth = (): StoredAuthData | null => {
 
     const sanitizedUser = sanitizeAuthUser(parsed.user ?? null) ?? undefined;
 
+    const expiresAt =
+      typeof parsed.expiresAt === "number" && Number.isFinite(parsed.expiresAt)
+        ? parsed.expiresAt
+        : decodeTokenExpiration(parsed.token) ?? undefined;
+
     return {
       ...parsed,
       user: sanitizedUser,
+      expiresAt,
     };
   } catch (error) {
     console.warn("Failed to parse stored auth data", error);
@@ -88,7 +191,14 @@ const writeStoredAuth = (data: StoredAuthData | null) => {
   }
 
   const user = sanitizeAuthUser(data.user ?? null) ?? undefined;
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...data, user }));
+  const expiresAt =
+    typeof data.expiresAt === "number" && Number.isFinite(data.expiresAt)
+      ? data.expiresAt
+      : undefined;
+  window.localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ ...data, user, expiresAt }),
+  );
 };
 
 const shouldAttachAuthHeader = (requestUrl: string, apiBaseUrl: string): boolean => {
@@ -115,20 +225,44 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [token, setToken] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [sessionExpiresAt, setSessionExpiresAt] = useState<number | null>(null);
   const tokenRef = useRef<string | null>(null);
+  const userRef = useRef<AuthUser | null>(null);
   const hasUnauthorizedErrorRef = useRef(false);
   const apiBaseUrlRef = useRef(getApiBaseUrl());
+  const refreshTimeoutIdRef = useRef<number>();
+  const isRefreshingTokenRef = useRef(false);
+  const scheduleRefreshCallbackRef = useRef<() => void>(() => {});
 
   useEffect(() => {
     tokenRef.current = token;
   }, [token]);
 
+  useEffect(() => {
+    userRef.current = user;
+  }, [user]);
+
+  const clearRefreshTimeout = useCallback(() => {
+    if (typeof window === "undefined") {
+      refreshTimeoutIdRef.current = undefined;
+      return;
+    }
+
+    if (refreshTimeoutIdRef.current !== undefined) {
+      window.clearTimeout(refreshTimeoutIdRef.current);
+      refreshTimeoutIdRef.current = undefined;
+    }
+  }, []);
+
   const handleLogout = useCallback(() => {
     setUser(null);
     setToken(null);
+    setSessionExpiresAt(null);
     setIsLoading(false);
     hasUnauthorizedErrorRef.current = false;
     tokenRef.current = null;
+    userRef.current = null;
+    clearRefreshTimeout();
     writeStoredAuth(null);
     if (typeof window !== "undefined") {
       try {
@@ -137,7 +271,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         console.warn("Falha ao limpar registro de atividade", error);
       }
     }
-  }, []);
+  }, [clearRefreshTimeout]);
 
   const logoutRef = useRef(handleLogout);
   useEffect(() => {
@@ -153,6 +287,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
     setToken(stored.token);
     tokenRef.current = stored.token;
+    const initialExpiresAt = stored.expiresAt ?? decodeTokenExpiration(stored.token);
+    setSessionExpiresAt(initialExpiresAt ?? null);
     if (stored.user) {
       setUser(stored.user);
     }
@@ -161,7 +297,14 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       try {
         const currentUser = await fetchCurrentUser(stored.token);
         setUser(currentUser);
-        writeStoredAuth({ token: stored.token, user: currentUser, timestamp: Date.now() });
+        userRef.current = currentUser;
+        const persistedExpiresAt = stored.expiresAt ?? decodeTokenExpiration(stored.token);
+        writeStoredAuth({
+          token: stored.token,
+          user: currentUser,
+          timestamp: Date.now(),
+          expiresAt: persistedExpiresAt ?? undefined,
+        });
       } catch (error) {
         if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
           console.warn("Stored authentication token is no longer valid", error);
@@ -225,12 +368,123 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     };
   }, []);
 
+  const refreshAuthToken = useCallback(async () => {
+    if (!tokenRef.current || isRefreshingTokenRef.current) {
+      return;
+    }
+
+    const lastActivity = readLastActivityTimestamp();
+    const now = Date.now();
+
+    if (lastActivity !== null && now - lastActivity >= DEFAULT_TIMEOUT_MS) {
+      handleLogout();
+      return;
+    }
+
+    isRefreshingTokenRef.current = true;
+    let handledScheduling = false;
+
+    try {
+      const response = await refreshTokenRequest(tokenRef.current);
+      const refreshTimestamp = Date.now();
+      const newExpiresAt = resolveTokenExpiration(response.token, response.expiresIn, refreshTimestamp);
+
+      setToken(response.token);
+      tokenRef.current = response.token;
+      setSessionExpiresAt(newExpiresAt ?? null);
+      writeStoredAuth({
+        token: response.token,
+        user: userRef.current ?? undefined,
+        timestamp: refreshTimestamp,
+        expiresAt: newExpiresAt ?? undefined,
+      });
+    } catch (error) {
+      if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
+        console.warn("Token de autenticação expirado durante a renovação", error);
+        handleLogout();
+        handledScheduling = true;
+      } else {
+        console.error("Falha ao renovar token de autenticação", error);
+        if (typeof window !== "undefined") {
+          const retryDelay = (() => {
+            if (sessionExpiresAt === null) {
+              return TOKEN_REFRESH_RETRY_DELAY_MS;
+            }
+            const timeUntilExpiration = sessionExpiresAt - Date.now();
+            if (!Number.isFinite(timeUntilExpiration) || timeUntilExpiration <= 1_000) {
+              return 1_000;
+            }
+            return Math.max(
+              1_000,
+              Math.min(TOKEN_REFRESH_RETRY_DELAY_MS, timeUntilExpiration - 1_000),
+            );
+          })();
+          clearRefreshTimeout();
+          refreshTimeoutIdRef.current = window.setTimeout(() => {
+            void refreshAuthToken();
+          }, retryDelay);
+          handledScheduling = true;
+        }
+      }
+    } finally {
+      isRefreshingTokenRef.current = false;
+      if (!handledScheduling) {
+        scheduleRefreshCallbackRef.current();
+      }
+    }
+  }, [handleLogout, clearRefreshTimeout, sessionExpiresAt]);
+
+  const scheduleTokenRefresh = useCallback(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    clearRefreshTimeout();
+
+    if (!tokenRef.current || !sessionExpiresAt) {
+      return;
+    }
+
+    const now = Date.now();
+    const refreshAt = sessionExpiresAt - TOKEN_REFRESH_THRESHOLD_MS;
+    const delay = refreshAt - now;
+
+    if (delay <= 0) {
+      void refreshAuthToken();
+      return;
+    }
+
+    refreshTimeoutIdRef.current = window.setTimeout(() => {
+      void refreshAuthToken();
+    }, delay);
+  }, [sessionExpiresAt, clearRefreshTimeout, refreshAuthToken]);
+
+  useEffect(() => {
+    scheduleRefreshCallbackRef.current = scheduleTokenRefresh;
+  }, [scheduleTokenRefresh]);
+
+  useEffect(() => {
+    scheduleTokenRefresh();
+    return () => {
+      clearRefreshTimeout();
+    };
+  }, [scheduleTokenRefresh, clearRefreshTimeout]);
+
   const login = useCallback(async (credentials: LoginCredentials) => {
     const response = await loginRequest(credentials);
+    const loginTimestamp = Date.now();
+    const expiresAt = resolveTokenExpiration(response.token, response.expiresIn, loginTimestamp);
     setToken(response.token);
     setUser(response.user);
     tokenRef.current = response.token;
-    writeStoredAuth({ token: response.token, user: response.user, timestamp: Date.now() });
+    userRef.current = response.user;
+    setSessionExpiresAt(expiresAt ?? null);
+    writeStoredAuth({
+      token: response.token,
+      user: response.user,
+      timestamp: loginTimestamp,
+      expiresAt: expiresAt ?? undefined,
+    });
     return response;
   }, []);
 
@@ -241,11 +495,17 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const refreshUser = useCallback(async () => {
     const currentUser = await fetchCurrentUser(tokenRef.current ?? undefined);
     setUser(currentUser);
+    userRef.current = currentUser;
     if (tokenRef.current) {
-      writeStoredAuth({ token: tokenRef.current, user: currentUser, timestamp: Date.now() });
+      writeStoredAuth({
+        token: tokenRef.current,
+        user: currentUser,
+        timestamp: Date.now(),
+        expiresAt: sessionExpiresAt ?? undefined,
+      });
     }
     return currentUser;
-  }, []);
+  }, [sessionExpiresAt]);
 
   const value = useMemo<AuthContextValue>(
     () => ({

--- a/frontend/src/features/auth/api.ts
+++ b/frontend/src/features/auth/api.ts
@@ -98,3 +98,29 @@ export const fetchCurrentUser = async (token?: string): Promise<AuthUser> => {
     modulos: parseModules(data.modulos),
   } satisfies AuthUser;
 };
+
+export const refreshTokenRequest = async (
+  token: string,
+): Promise<{ token: string; expiresIn?: number }> => {
+  const response = await fetch(getApiUrl("auth/refresh"), {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw await buildApiError(response);
+  }
+
+  const data = (await response.json()) as { token?: unknown; expiresIn?: unknown };
+  if (typeof data?.token !== "string" || data.token.trim().length === 0) {
+    throw new Error("Resposta de renovação inválida.");
+  }
+
+  return {
+    token: data.token,
+    expiresIn: typeof data.expiresIn === "number" ? data.expiresIn : undefined,
+  };
+};

--- a/frontend/src/hooks/useAutoLogout.ts
+++ b/frontend/src/hooks/useAutoLogout.ts
@@ -9,7 +9,7 @@ const INACTIVITY_EVENTS: Array<keyof WindowEventMap> = [
   "focus",
 ];
 
-const DEFAULT_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutos
+export const DEFAULT_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutos
 const LAST_ACTIVITY_STORAGE_KEY = "jus-connect:last-activity";
 const ACTIVITY_PERSISTENCE_INTERVAL_MS = 5_000;
 


### PR DESCRIPTION
## Summary
- add a backend endpoint to refresh authentication tokens and expose it through the API routes
- enhance the frontend auth provider to track token expiration, persist it, and automatically refresh active sessions
- expose the inactivity timeout constant and add a client helper for requesting token refreshes

## Testing
- npm test *(fails: database connection string not provided)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf01a4d0b483268c3764247ecae5ce