### PR TITLE
Fix created_by payload for new opportunities

### DIFF
--- a/frontend/src/pages/NovaOportunidade.tsx
+++ b/frontend/src/pages/NovaOportunidade.tsx
@@ -369,13 +369,32 @@ export default function NovaOportunidade() {
   }, [processoDistribuido, form]);
 
   useEffect(() => {
-    if (user?.nome_completo) {
-      form.setValue("criado_por", user.nome_completo, {
+    if (typeof user?.id === "number") {
+      form.setValue("criado_por", String(user.id), {
         shouldDirty: false,
         shouldTouch: false,
       });
     }
   }, [user, form]);
+
+  const parseOptionalInteger = (value: string | null | undefined) => {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const parsed = Number(trimmed);
+    if (!Number.isFinite(parsed)) {
+      return null;
+    }
+
+    const normalized = Math.trunc(parsed);
+    return normalized > 0 ? normalized : null;
+  };
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     try {
@@ -436,7 +455,10 @@ export default function NovaOportunidade() {
         contingenciamento: values.contingenciamento || null,
         detalhes: values.detalhes || null,
         documentos_anexados: null,
-        criado_por: user?.nome_completo || values.criado_por || null,
+        criado_por:
+          typeof user?.id === "number"
+            ? user.id
+            : parseOptionalInteger(values.criado_por),
         envolvidos: envolvidosFiltrados,
       };
 


### PR DESCRIPTION
## Summary
- ensure the new opportunity form stores the authenticated user's id when filling the `criado_por` field
- convert the submitted `criado_por` value into a positive integer before sending it to the API to avoid type errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf0f2895108326b3b0798812fbf6f1