### PR TITLE
Move Próximo Prazo field into Honorários section

### DIFF
--- a/frontend/src/pages/NovaOportunidade.tsx
+++ b/frontend/src/pages/NovaOportunidade.tsx
@@ -606,20 +606,6 @@ export default function NovaOportunidade() {
 
                       <FormField
                         control={form.control}
-                        name="prazo_proximo"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Próximo Prazo</FormLabel>
-                            <FormControl>
-                              <Input type="date" {...field} />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      <FormField
-                        control={form.control}
                         name="status"
                         render={({ field }) => (
                           <FormItem>
@@ -826,6 +812,20 @@ export default function NovaOportunidade() {
                                 <SelectItem value="Sucumbência">Sucumbência</SelectItem>
                               </SelectContent>
                             </Select>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+
+                      <FormField
+                        control={form.control}
+                        name="prazo_proximo"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Data da Cobrança</FormLabel>
+                            <FormControl>
+                              <Input type="date" {...field} />
+                            </FormControl>
                             <FormMessage />
                           </FormItem>
                         )}


### PR DESCRIPTION
## Summary
- move the Próximo Prazo date input from the opportunity details accordion into the Honorários section
- relabel the field to “Data da Cobrança” to reflect its new purpose

## Testing
- npm run lint *(fails with existing warnings about react-refresh/only-export-components and react-hooks/exhaustive-deps)*

------
https://chatgpt.com/codex/tasks/task_e_68cf11efe2c48326aeab8d6e2139d202