### PR TITLE
feat(backend): add Asaas client integration services

### DIFF
--- a/backend/src/services/asaas/asaasClient.ts
+++ b/backend/src/services/asaas/asaasClient.ts
@@ -1,0 +1,301 @@
+import { URL } from 'url';
+
+export interface AsaasClientConfig {
+  baseUrl: string;
+  accessToken: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface CustomerPayload {
+  name: string;
+  cpfCnpj?: string;
+  email?: string;
+  phone?: string;
+  mobilePhone?: string;
+  address?: string;
+  addressNumber?: string;
+  complement?: string;
+  province?: string;
+  postalCode?: string;
+  externalReference?: string;
+  notificationDisabled?: boolean;
+  observations?: string;
+}
+
+export type UpdateCustomerPayload = Partial<CustomerPayload>;
+
+export interface CustomerResponse extends CustomerPayload {
+  id: string;
+  object: 'customer';
+  city?: string;
+  state?: string;
+  company?: string;
+  deleted?: boolean;
+  dateCreated?: string;
+}
+
+export type BillingType = 'BOLETO' | 'PIX' | 'CREDIT_CARD';
+
+export interface CreateChargePayload {
+  customer: string;
+  value: number;
+  description?: string;
+  dueDate?: string;
+  billingType?: BillingType;
+  externalReference?: string;
+  installmentCount?: number;
+  installmentValue?: number;
+  totalValue?: number;
+  interest?: number;
+  fine?: number;
+  postalService?: boolean;
+  creditCard?: CreditCardDetails;
+  creditCardHolderInfo?: CreditCardHolderInfo;
+  split?: SplitConfiguration[];
+}
+
+export interface SplitConfiguration {
+  walletId: string;
+  fixedValue?: number;
+  percentualValue?: number;
+}
+
+export interface CreditCardDetails {
+  holderName: string;
+  number: string;
+  expiryMonth: string;
+  expiryYear: string;
+  ccv: string;
+}
+
+export interface CreditCardHolderInfo {
+  name: string;
+  email: string;
+  cpfCnpj: string;
+  postalCode: string;
+  addressNumber: string;
+  addressComplement?: string;
+  phone?: string;
+  mobilePhone?: string;
+}
+
+export interface ChargeResponse {
+  id: string;
+  object: 'payment';
+  customer: string;
+  value: number;
+  netValue?: number;
+  billingType: BillingType;
+  status: string;
+  description?: string;
+  dueDate?: string;
+  originalDueDate?: string;
+  paymentDate?: string;
+  clientPaymentDate?: string;
+  confirmedDate?: string;
+  creditCard?: CreditCardDetails & { id?: string };
+  pixTransaction?: PixTransaction;
+  externalReference?: string;
+}
+
+export interface PixTransaction {
+  endToEndId?: string;
+  payload?: string;
+  encodedImage?: string;
+  originalValue?: number;
+  transactionDate?: string;
+  status?: string;
+}
+
+export interface PixChargePayload {
+  customer: string;
+  value: number;
+  description?: string;
+  externalReference?: string;
+  expirationSeconds?: number;
+}
+
+export interface PixChargeResponse {
+  id: string;
+  status: string;
+  payload: string;
+  encodedImage?: string;
+  qrCodeBase64?: string;
+  copyPasteCode?: string;
+  expirationDate?: string;
+}
+
+export interface AccountInformation {
+  object: 'account';
+  id: string;
+  name: string;
+  email: string;
+  cpfCnpj: string;
+  companyType?: string;
+  companyName?: string;
+  accountNumber?: string;
+  agency?: string;
+}
+
+export class AsaasApiError extends Error {
+  public readonly status: number;
+  public readonly responseBody: unknown;
+  public readonly errorCode?: string;
+
+  constructor(message: string, status: number, responseBody: unknown, errorCode?: string) {
+    super(message);
+    this.name = 'AsaasApiError';
+    this.status = status;
+    this.responseBody = responseBody;
+    this.errorCode = errorCode;
+  }
+}
+
+function isJsonContentType(headers: Headers): boolean {
+  const contentType = headers.get('content-type');
+  return Boolean(contentType && contentType.toLowerCase().includes('application/json'));
+}
+
+async function parseResponseBody(response: Response): Promise<unknown> {
+  if (response.status === 204) {
+    return null;
+  }
+
+  const cloned = response.clone();
+  try {
+    if (isJsonContentType(response.headers)) {
+      return await cloned.json();
+    }
+    const text = await cloned.text();
+    return text ? text : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+function buildUrl(baseUrl: string, path: string): string {
+  const base = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  const trimmedPath = path.startsWith('/') ? path.slice(1) : path;
+  return new URL(trimmedPath, base).toString();
+}
+
+function extractErrorDetails(body: unknown, status: number): { message: string; code?: string } {
+  if (!body || typeof body !== 'object') {
+    return { message: `Asaas API request failed with status ${status}` };
+  }
+
+  const payload = body as Record<string, unknown>;
+
+  if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+    const first = payload.errors[0] as Record<string, unknown>;
+    const description = typeof first.description === 'string' ? first.description : undefined;
+    const message = description || (typeof first.message === 'string' ? first.message : undefined);
+    const code = typeof first.code === 'string' ? first.code : undefined;
+    if (message) {
+      return { message, code };
+    }
+  }
+
+  if (typeof payload.message === 'string' && payload.message.trim()) {
+    return { message: payload.message.trim(), code: typeof payload.code === 'string' ? payload.code : undefined };
+  }
+
+  if (typeof payload.error === 'string' && payload.error.trim()) {
+    return { message: payload.error.trim() };
+  }
+
+  return { message: `Asaas API request failed with status ${status}` };
+}
+
+export class AsaasClient {
+  private readonly baseUrl: string;
+  private readonly accessToken: string;
+  private readonly fetch: typeof fetch;
+
+  constructor(config: AsaasClientConfig) {
+    if (!config.baseUrl) {
+      throw new Error('AsaasClient requires a baseUrl');
+    }
+    if (!config.accessToken) {
+      throw new Error('AsaasClient requires an accessToken');
+    }
+    this.baseUrl = config.baseUrl.replace(/\/$/, '');
+    this.accessToken = config.accessToken;
+    this.fetch = config.fetchImpl ?? fetch;
+  }
+
+  private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const url = buildUrl(this.baseUrl, path);
+    const headers = new Headers(init.headers);
+
+    headers.set('Authorization', `Bearer ${this.accessToken}`);
+    headers.set('access_token', this.accessToken);
+    headers.set('Accept', 'application/json');
+
+    const hasBody = typeof init.body !== 'undefined' && init.body !== null;
+    if (hasBody && !headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json');
+    }
+
+    const response = await this.fetch(url, {
+      ...init,
+      headers,
+    });
+
+    const responseBody = await parseResponseBody(response);
+
+    if (!response.ok) {
+      const { message, code } = extractErrorDetails(responseBody, response.status);
+      throw new AsaasApiError(message, response.status, responseBody, code);
+    }
+
+    return responseBody as T;
+  }
+
+  async createCustomer(payload: CustomerPayload): Promise<CustomerResponse> {
+    return this.request<CustomerResponse>('/customers', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  }
+
+  async updateCustomer(customerId: string, payload: UpdateCustomerPayload): Promise<CustomerResponse> {
+    return this.request<CustomerResponse>(`/customers/${customerId}`, {
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    });
+  }
+
+  async createCharge(payload: CreateChargePayload): Promise<ChargeResponse> {
+    return this.request<ChargeResponse>('/payments', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  }
+
+  async getCharge(chargeId: string): Promise<ChargeResponse> {
+    return this.request<ChargeResponse>(`/payments/${chargeId}`);
+  }
+
+  async createPix(payload: PixChargePayload): Promise<PixChargeResponse> {
+    return this.request<PixChargeResponse>('/pix/payments', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  }
+
+  async createCreditCardCharge(payload: Omit<CreateChargePayload, 'billingType'>): Promise<ChargeResponse> {
+    const normalizedPayload: CreateChargePayload = {
+      ...payload,
+      billingType: 'CREDIT_CARD',
+    };
+    return this.createCharge(normalizedPayload);
+  }
+
+  async validateCredentials(): Promise<AccountInformation> {
+    return this.request<AccountInformation>('/accounts');
+  }
+}
+
+export default AsaasClient;
+

--- a/backend/src/services/asaas/integrationResolver.ts
+++ b/backend/src/services/asaas/integrationResolver.ts
@@ -1,0 +1,101 @@
+import pool from '../db';
+import AsaasClient, { AsaasClientConfig } from './asaasClient';
+
+export type Queryable = {
+  query: (text: string, params?: unknown[]) => Promise<{ rows: any[]; rowCount: number }>;
+};
+
+export const ASAAS_DEFAULT_BASE_URLS = {
+  producao: 'https://www.asaas.com/api/v3',
+  homologacao: 'https://sandbox.asaas.com/api/v3',
+} as const;
+
+export type AsaasEnvironment = keyof typeof ASAAS_DEFAULT_BASE_URLS;
+
+export interface AsaasIntegration {
+  baseUrl: string;
+  accessToken: string;
+  environment: AsaasEnvironment;
+}
+
+export class AsaasIntegrationNotConfiguredError extends Error {
+  constructor(message = 'Asaas integration credentials are not configured') {
+    super(message);
+    this.name = 'AsaasIntegrationNotConfiguredError';
+  }
+}
+
+interface IntegrationRow {
+  id: number;
+  provider: string;
+  url_api: string | null;
+  key_value: string | null;
+  environment: string | null;
+  active: boolean;
+}
+
+function normalizeEnvironment(value: string | null): AsaasEnvironment {
+  if (value && value.trim().toLowerCase() === 'producao') {
+    return 'producao';
+  }
+  return 'homologacao';
+}
+
+function normalizeBaseUrl(environment: AsaasEnvironment, apiUrl: string | null): string {
+  if (apiUrl) {
+    const trimmed = apiUrl.trim();
+    if (trimmed) {
+      return trimmed.replace(/\/$/, '');
+    }
+  }
+  return ASAAS_DEFAULT_BASE_URLS[environment];
+}
+
+function normalizeToken(token: string | null): string {
+  if (!token) {
+    throw new AsaasIntegrationNotConfiguredError('Active Asaas credential is missing access token');
+  }
+  const trimmed = token.trim();
+  if (!trimmed) {
+    throw new AsaasIntegrationNotConfiguredError('Active Asaas credential is missing access token');
+  }
+  return trimmed;
+}
+
+export async function resolveAsaasIntegration(db: Queryable = pool): Promise<AsaasIntegration> {
+  const result = await db.query(
+    `SELECT id, provider, url_api, key_value, environment, active
+     FROM integration_api_keys
+     WHERE provider = $1 AND active = TRUE
+     ORDER BY updated_at DESC
+     LIMIT 1`,
+    ['asaas'],
+  );
+
+  if (!result.rowCount) {
+    throw new AsaasIntegrationNotConfiguredError();
+  }
+
+  const row = result.rows[0] as IntegrationRow;
+
+  const environment = normalizeEnvironment(row.environment);
+  const baseUrl = normalizeBaseUrl(environment, row.url_api);
+  const accessToken = normalizeToken(row.key_value);
+
+  return { baseUrl, accessToken, environment };
+}
+
+export async function createAsaasClient(
+  db: Queryable = pool,
+  overrides: Partial<Omit<AsaasClientConfig, 'accessToken' | 'baseUrl'>> = {},
+): Promise<AsaasClient> {
+  const integration = await resolveAsaasIntegration(db);
+  return new AsaasClient({
+    baseUrl: integration.baseUrl,
+    accessToken: integration.accessToken,
+    ...overrides,
+  });
+}
+
+export default resolveAsaasIntegration;
+

--- a/backend/tests/asaasClient.test.ts
+++ b/backend/tests/asaasClient.test.ts
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import test, { mock } from 'node:test';
+import AsaasClient, {
+  AsaasApiError,
+  ChargeResponse,
+  CreateChargePayload,
+} from '../src/services/asaas/asaasClient';
+
+const BASE_URL = 'https://sandbox.asaas.com/api/v3';
+const TOKEN = 'test-token';
+
+function createResponse(body: unknown, init?: ResponseInit): Response {
+  const payload = body === undefined ? undefined : JSON.stringify(body);
+  return new Response(payload, {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+}
+
+test('AsaasClient creates customer with authentication headers', async (t) => {
+  const fetchMock = mock.method(global, 'fetch', async (input, init) => {
+    assert.equal(input, `${BASE_URL}/customers`);
+    const headers = new Headers(init?.headers);
+    assert.equal(headers.get('Authorization'), `Bearer ${TOKEN}`);
+    assert.equal(headers.get('access_token'), TOKEN);
+    assert.equal(headers.get('Content-Type'), 'application/json');
+    const body = init?.body ? JSON.parse(init.body as string) : null;
+    assert.deepEqual(body, { name: 'Maria da Silva' });
+    return createResponse({ id: 'cus_123', object: 'customer', name: 'Maria da Silva' }, { status: 201 });
+  });
+
+  const client = new AsaasClient({ baseUrl: BASE_URL, accessToken: TOKEN });
+
+  t.after(() => fetchMock.mock.restore());
+
+  const response = await client.createCustomer({ name: 'Maria da Silva' });
+  assert.equal(response.id, 'cus_123');
+  assert.equal(fetchMock.mock.calls.length, 1);
+});
+
+test('AsaasClient normalizes API errors and exposes metadata', async (t) => {
+  const errorBody = {
+    errors: [
+      {
+        code: 'invalid_cpf',
+        description: 'CPF inválido',
+      },
+    ],
+  };
+
+  const fetchMock = mock.method(global, 'fetch', async () => {
+    return createResponse(errorBody, { status: 400 });
+  });
+
+  const client = new AsaasClient({ baseUrl: BASE_URL, accessToken: TOKEN });
+
+  t.after(() => fetchMock.mock.restore());
+
+  await assert.rejects(async () => client.getCharge('pay_123'), (error: unknown) => {
+    assert.ok(error instanceof AsaasApiError);
+    assert.equal(error.status, 400);
+    assert.equal(error.message, 'CPF inválido');
+    assert.equal(error.errorCode, 'invalid_cpf');
+    assert.deepEqual(error.responseBody, errorBody);
+    return true;
+  });
+});
+
+test('createCreditCardCharge forces billing type credit card', async (t) => {
+  const creditCardPayload: Omit<CreateChargePayload, 'billingType'> = {
+    customer: 'cus_123',
+    value: 100,
+    description: 'Plano mensal',
+    creditCard: {
+      holderName: 'Maria',
+      number: '4111111111111111',
+      expiryMonth: '12',
+      expiryYear: '2030',
+      ccv: '123',
+    },
+    creditCardHolderInfo: {
+      name: 'Maria',
+      email: 'maria@example.com',
+      cpfCnpj: '12345678901',
+      postalCode: '88000000',
+      addressNumber: '100',
+    },
+  };
+
+  const fetchMock = mock.method(global, 'fetch', async (_input, init) => {
+    const body = JSON.parse(init?.body as string);
+    assert.equal(body.billingType, 'CREDIT_CARD');
+    return createResponse({
+      id: 'pay_789',
+      object: 'payment',
+      customer: 'cus_123',
+      value: 100,
+      billingType: 'CREDIT_CARD',
+      status: 'PENDING',
+    } satisfies ChargeResponse);
+  });
+
+  const client = new AsaasClient({ baseUrl: BASE_URL, accessToken: TOKEN });
+  t.after(() => fetchMock.mock.restore());
+
+  const result = await client.createCreditCardCharge(creditCardPayload);
+  assert.equal(result.id, 'pay_789');
+  assert.equal(fetchMock.mock.calls.length, 1);
+});
+
+test('validateCredentials performs GET request to accounts endpoint', async (t) => {
+  const fetchMock = mock.method(global, 'fetch', async (input, init) => {
+    assert.equal(input, `${BASE_URL}/accounts`);
+    assert.equal(init?.method ?? 'GET', 'GET');
+    return createResponse({
+      object: 'account',
+      id: 'acc_1',
+      name: 'Conta Teste',
+      email: 'conta@example.com',
+      cpfCnpj: '00000000000',
+    });
+  });
+
+  const client = new AsaasClient({ baseUrl: BASE_URL, accessToken: TOKEN });
+  t.after(() => fetchMock.mock.restore());
+
+  const account = await client.validateCredentials();
+  assert.equal(account.object, 'account');
+  assert.equal(fetchMock.mock.calls.length, 1);
+});
+

--- a/backend/tests/asaasIntegrationResolver.test.ts
+++ b/backend/tests/asaasIntegrationResolver.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  ASAAS_DEFAULT_BASE_URLS,
+  AsaasIntegrationNotConfiguredError,
+  createAsaasClient,
+  resolveAsaasIntegration,
+} from '../src/services/asaas/integrationResolver';
+
+class FakePool {
+  public calls: { text: string; params?: unknown[] }[] = [];
+
+  constructor(private readonly responses: { rows: any[]; rowCount: number }[]) {}
+
+  async query(text: string, params?: unknown[]) {
+    this.calls.push({ text, params });
+    const response = this.responses.shift();
+    if (!response) {
+      throw new Error('No response configured');
+    }
+    return response;
+  }
+}
+
+test('resolveAsaasIntegration returns sandbox base URL when environment is homologacao', async () => {
+  const pool = new FakePool([
+    {
+      rowCount: 1,
+      rows: [
+        {
+          id: 1,
+          provider: 'asaas',
+          url_api: null,
+          key_value: '   sandbox-token   ',
+          environment: 'homologacao',
+          active: true,
+        },
+      ],
+    },
+  ]);
+
+  const integration = await resolveAsaasIntegration(pool as any);
+
+  assert.equal(integration.accessToken, 'sandbox-token');
+  assert.equal(integration.baseUrl, ASAAS_DEFAULT_BASE_URLS.homologacao);
+  assert.equal(integration.environment, 'homologacao');
+  assert.match(pool.calls[0].text, /FROM integration_api_keys/);
+  assert.deepEqual(pool.calls[0].params, ['asaas']);
+});
+
+test('resolveAsaasIntegration prioritizes custom API URL for production', async () => {
+  const pool = new FakePool([
+    {
+      rowCount: 1,
+      rows: [
+        {
+          id: 2,
+          provider: 'asaas',
+          url_api: ' https://custom.asaas.com/api/v3/ ',
+          key_value: 'live-token',
+          environment: 'producao',
+          active: true,
+        },
+      ],
+    },
+  ]);
+
+  const integration = await resolveAsaasIntegration(pool as any);
+
+  assert.equal(integration.accessToken, 'live-token');
+  assert.equal(integration.baseUrl, 'https://custom.asaas.com/api/v3');
+  assert.equal(integration.environment, 'producao');
+});
+
+test('resolveAsaasIntegration throws a specific error when no active credential exists', async () => {
+  const pool = new FakePool([
+    {
+      rowCount: 0,
+      rows: [],
+    },
+  ]);
+
+  await assert.rejects(() => resolveAsaasIntegration(pool as any), AsaasIntegrationNotConfiguredError);
+});
+
+test('createAsaasClient builds client instance with resolved credentials', async () => {
+  const pool = new FakePool([
+    {
+      rowCount: 1,
+      rows: [
+        {
+          id: 3,
+          provider: 'asaas',
+          url_api: null,
+          key_value: 'sandbox-token',
+          environment: 'homologacao',
+          active: true,
+        },
+      ],
+    },
+  ]);
+
+  const client = await createAsaasClient(pool as any, { fetchImpl: async () => new Response(null, { status: 204 }) });
+  assert.equal(typeof client, 'object');
+  assert.equal(pool.calls.length, 1);
+});
+


### PR DESCRIPTION
## Summary
- add a typed Asaas API client with helper methods for customers, charges, PIX, and credential validation
- introduce integration resolver to fetch active Asaas credentials and create configured clients
- cover client and resolver behaviors with node:test suites using mocked HTTP responses

## Testing
- DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf1223bc5483268a30bb086ff5d217