### PR TITLE
feat: add Asaas webhook integration

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true });\"",
     "build": "npm run clean && tsc -p tsconfig.build.json && node ./scripts/copy-sql.js",
     "start": "node dist/index.js",
-    "test": "node --test --import tsx tests/*.test.ts"
+    "test": "node --test --import tsx --import ./tests/testSetup.ts tests/*.test.ts"
 
   },
   "dependencies": {

--- a/backend/src/controllers/asaasIntegrationController.ts
+++ b/backend/src/controllers/asaasIntegrationController.ts
@@ -1,0 +1,395 @@
+import crypto from 'crypto';
+import type { Request, Response } from 'express';
+import pool from '../services/db';
+
+interface RawBodyRequest extends Request {
+  rawBody?: string;
+}
+
+interface AsaasPaymentPayload {
+  id?: string;
+  chargeId?: string;
+  subscription?: string;
+  status?: string;
+  dueDate?: string;
+  paymentDate?: string;
+  clientPaymentDate?: string;
+  confirmedDate?: string;
+  creditDate?: string;
+  updatedDate?: string;
+  [key: string]: unknown;
+}
+
+interface AsaasWebhookBody {
+  event?: string;
+  dateCreated?: string;
+  payment?: AsaasPaymentPayload | null;
+  [key: string]: unknown;
+}
+
+type ChargeRecord = {
+  id: number;
+  credential_id: number | null;
+  financial_flow_id: number | null;
+};
+
+type CredentialRecord = {
+  webhook_secret: string | null;
+};
+
+const HANDLED_EVENTS = new Set([
+  'PAYMENT_RECEIVED',
+  'PAYMENT_CONFIRMED',
+  'PAYMENT_OVERDUE',
+]);
+
+function extractSignature(req: Request): string | null {
+  const headerNames = ['asaas-signature', 'x-hub-signature', 'x-hub-signature-256'];
+
+  for (const header of headerNames) {
+    const value = req.headers[header];
+    if (!value) {
+      continue;
+    }
+
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+
+    if (Array.isArray(value)) {
+      const first = value.find((item) => typeof item === 'string' && item.trim());
+      if (first) {
+        return first.trim();
+      }
+    }
+  }
+
+  return null;
+}
+
+function decodeSignatureToBuffer(signature: string): Buffer | null {
+  const trimmed = signature.replace(/^sha256=/i, '').trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (/^[0-9a-f]+$/i.test(trimmed) && trimmed.length % 2 === 0) {
+    return Buffer.from(trimmed, 'hex');
+  }
+
+  if (/^[0-9a-z+/=]+$/i.test(trimmed)) {
+    try {
+      const buffer = Buffer.from(trimmed, 'base64');
+      if (buffer.length > 0) {
+        return buffer;
+      }
+    } catch (error) {
+      console.warn('[AsaasWebhook] Failed to decode base64 signature', error);
+    }
+  }
+
+  return null;
+}
+
+function computeExpectedSignature(secret: string, payload: string): Buffer {
+  return crypto.createHmac('sha256', secret).update(payload).digest();
+}
+
+function extractChargeId(payment: AsaasPaymentPayload | null | undefined): string | null {
+  if (!payment || typeof payment !== 'object') {
+    return null;
+  }
+
+  const idCandidates = [payment.id, payment.chargeId];
+  for (const candidate of idCandidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+
+  return null;
+}
+
+function normalizeEventName(event: string | null | undefined): string | null {
+  if (typeof event !== 'string') {
+    return null;
+  }
+
+  const normalized = event.trim().toUpperCase();
+  return normalized || null;
+}
+
+function shouldMarkAsPaid(event: string): boolean {
+  return event === 'PAYMENT_RECEIVED' || event === 'PAYMENT_CONFIRMED';
+}
+
+function extractPaymentDate(payment: AsaasPaymentPayload | null | undefined): string | null {
+  if (!payment) {
+    return null;
+  }
+
+  const candidates = [
+    payment.clientPaymentDate,
+    payment.paymentDate,
+    payment.confirmedDate,
+    payment.creditDate,
+    payment.updatedDate,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') {
+      continue;
+    }
+
+    const trimmed = candidate.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    const parsed = new Date(trimmed);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString();
+    }
+  }
+
+  return null;
+}
+
+function extractChargeStatus(event: string, payment: AsaasPaymentPayload | null | undefined): string {
+  if (payment?.status && typeof payment.status === 'string') {
+    return payment.status.trim();
+  }
+
+  switch (event) {
+    case 'PAYMENT_RECEIVED':
+      return 'RECEIVED';
+    case 'PAYMENT_CONFIRMED':
+      return 'CONFIRMED';
+    case 'PAYMENT_OVERDUE':
+      return 'OVERDUE';
+    default:
+      return event;
+  }
+}
+
+async function findChargeByAsaasId(asaasChargeId: string): Promise<ChargeRecord | null> {
+  const result = await pool.query<ChargeRecord>(
+    'SELECT id, credential_id, financial_flow_id FROM asaas_charges WHERE asaas_charge_id = $1',
+    [asaasChargeId]
+  );
+
+  if (result.rowCount === 0) {
+    return null;
+  }
+
+  return result.rows[0] ?? null;
+}
+
+async function findCredentialSecret(credentialId: number): Promise<string | null> {
+  const result = await pool.query<CredentialRecord>(
+    'SELECT webhook_secret FROM asaas_credentials WHERE id = $1',
+    [credentialId]
+  );
+
+  if (result.rowCount === 0) {
+    return null;
+  }
+
+  const row = result.rows[0];
+  if (!row?.webhook_secret) {
+    return null;
+  }
+
+  return row.webhook_secret;
+}
+
+async function updateCharge(
+  asaasChargeId: string,
+  event: string,
+  status: string,
+  paymentDate: string | null,
+  payload: AsaasWebhookBody
+): Promise<void> {
+  await pool.query(
+    `UPDATE asaas_charges
+       SET status = $1,
+           last_event = $2,
+           payload = $3,
+           paid_at = $4,
+           updated_at = NOW()
+     WHERE asaas_charge_id = $5`,
+    [status, event, JSON.stringify(payload), paymentDate, asaasChargeId]
+  );
+}
+
+async function updateFinancialFlowAsPaid(financialFlowId: number, paymentDate: string | null): Promise<void> {
+  const paidAt = paymentDate ?? new Date().toISOString();
+  await pool.query(
+    "UPDATE financial_flows SET status = 'pago', pagamento = $1 WHERE id = $2",
+    [paidAt, financialFlowId]
+  );
+}
+
+function buildWebhookResponse() {
+  return { received: true };
+}
+
+function ensureHandledEvent(event: string | null): event is string {
+  return Boolean(event && HANDLED_EVENTS.has(event));
+}
+
+function resolveWebhookUrl(req: Request): string {
+  if (process.env.ASAAS_WEBHOOK_PUBLIC_URL && process.env.ASAAS_WEBHOOK_PUBLIC_URL.trim()) {
+    return process.env.ASAAS_WEBHOOK_PUBLIC_URL.trim();
+  }
+
+  const protocolHeader = req.headers['x-forwarded-proto'];
+  const proto = Array.isArray(protocolHeader)
+    ? protocolHeader[0]
+    : typeof protocolHeader === 'string'
+    ? protocolHeader
+    : req.protocol;
+
+  const hostHeader = req.headers['x-forwarded-host'] ?? req.headers.host;
+  const host = Array.isArray(hostHeader) ? hostHeader[0] : hostHeader;
+
+  if (typeof host === 'string' && host.trim()) {
+    const normalizedProto = typeof proto === 'string' && proto.trim() ? proto.trim() : 'https';
+    return `${normalizedProto}://${host.trim()}/api/integrations/asaas/webhook`;
+  }
+
+  return 'https://<SEU_BACKEND>/api/integrations/asaas/webhook';
+}
+
+export async function handleAsaasWebhook(req: Request, res: Response) {
+  const rawRequest = req as RawBodyRequest;
+  const payload = req.body as AsaasWebhookBody | null;
+  const normalizedEvent = normalizeEventName(payload?.event ?? null);
+
+  if (!ensureHandledEvent(normalizedEvent)) {
+    console.info('[AsaasWebhook] Ignoring unsupported event', payload?.event);
+    return res.status(202).json(buildWebhookResponse());
+  }
+
+  const payment = payload?.payment ?? null;
+  const asaasChargeId = extractChargeId(payment);
+
+  if (!asaasChargeId) {
+    console.error('[AsaasWebhook] Missing charge identifier in payload');
+    return res.status(202).json(buildWebhookResponse());
+  }
+
+  let charge: ChargeRecord | null = null;
+
+  try {
+    charge = await findChargeByAsaasId(asaasChargeId);
+  } catch (error) {
+    console.error('[AsaasWebhook] Failed to load charge', error);
+    return res.status(202).json(buildWebhookResponse());
+  }
+
+  if (!charge) {
+    console.warn('[AsaasWebhook] Charge not found for id', asaasChargeId);
+    return res.status(202).json(buildWebhookResponse());
+  }
+
+  if (!charge.credential_id) {
+    console.error('[AsaasWebhook] Charge without credential reference', charge.id);
+    return res.status(202).json(buildWebhookResponse());
+  }
+
+  let secret: string | null = null;
+
+  try {
+    secret = await findCredentialSecret(charge.credential_id);
+  } catch (error) {
+    console.error('[AsaasWebhook] Failed to load credential secret', error);
+    return res.status(202).json(buildWebhookResponse());
+  }
+
+  if (!secret) {
+    console.error('[AsaasWebhook] Missing webhook secret for credential', charge.credential_id);
+    return res.status(202).json(buildWebhookResponse());
+  }
+
+  const signature = extractSignature(req);
+  if (!signature) {
+    console.error('[AsaasWebhook] Missing signature header');
+    return res.status(202).json(buildWebhookResponse());
+  }
+
+  const rawBody = rawRequest.rawBody ?? JSON.stringify(payload ?? {});
+  const providedSignature = decodeSignatureToBuffer(signature);
+
+  if (!providedSignature) {
+    console.error('[AsaasWebhook] Unable to parse provided signature');
+    return res.status(202).json(buildWebhookResponse());
+  }
+
+  const expectedSignature = computeExpectedSignature(secret, rawBody);
+
+  if (providedSignature.length !== expectedSignature.length) {
+    console.error('[AsaasWebhook] Signature length mismatch');
+    return res.status(202).json(buildWebhookResponse());
+  }
+
+  const isValidSignature = crypto.timingSafeEqual(providedSignature, expectedSignature);
+  if (!isValidSignature) {
+    console.error('[AsaasWebhook] Invalid signature for charge', asaasChargeId);
+    return res.status(202).json(buildWebhookResponse());
+  }
+
+  const status = extractChargeStatus(normalizedEvent, payment);
+  const paymentDate = shouldMarkAsPaid(normalizedEvent) ? extractPaymentDate(payment) : null;
+
+  try {
+    await updateCharge(asaasChargeId, normalizedEvent, status, paymentDate, payload ?? {});
+
+    if (charge.financial_flow_id && shouldMarkAsPaid(normalizedEvent)) {
+      await updateFinancialFlowAsPaid(charge.financial_flow_id, paymentDate);
+    }
+  } catch (error) {
+    console.error('[AsaasWebhook] Failed to persist webhook payload', error);
+    return res.status(202).json(buildWebhookResponse());
+  }
+
+  console.info('[AsaasWebhook] Processed event', normalizedEvent, 'for charge', asaasChargeId);
+  return res.status(202).json(buildWebhookResponse());
+}
+
+export async function getAsaasWebhookSecret(req: Request, res: Response) {
+  const credentialId = Number(req.params.credentialId);
+  if (!Number.isInteger(credentialId) || credentialId <= 0) {
+    return res.status(400).json({ error: 'Parâmetro credentialId inválido' });
+  }
+
+  let secret: string | null = null;
+
+  try {
+    secret = await findCredentialSecret(credentialId);
+  } catch (error) {
+    console.error('[AsaasWebhook] Failed to load credential secret', error);
+    return res.status(500).json({ error: 'Erro ao recuperar o segredo do webhook' });
+  }
+
+  if (!secret) {
+    return res.status(404).json({ error: 'Credencial não localizada ou sem segredo configurado' });
+  }
+
+  const webhookUrl = resolveWebhookUrl(req);
+
+  const instructions = [
+    '1. Acesse o painel do Asaas e navegue até Configurações > Integrações > Webhooks.',
+    `2. Informe a URL ${webhookUrl} como destino do webhook e selecione os eventos de pagamento desejados (ex.: PAYMENT_RECEIVED, PAYMENT_CONFIRMED, PAYMENT_OVERDUE).`,
+    '3. Copie o valor de webhookSecret informado abaixo e utilize-o no campo de assinatura compartilhada do Asaas.',
+    '4. Salve a configuração e realize um pagamento de teste para validar o fluxo de confirmação automática.'
+  ];
+
+  return res.json({
+    credentialId,
+    webhookUrl,
+    webhookSecret: secret,
+    instructions,
+  });
+}
+

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,4 @@
-import express, { Router } from 'express';
+import express, { Request, Router } from 'express';
 import { AddressInfo } from 'net';
 import path from 'path';
 import { existsSync } from 'fs';
@@ -35,6 +35,7 @@ import integrationApiKeyRoutes from './routes/integrationApiKeyRoutes';
 import chatRoutes from './routes/chatRoutes';
 import userProfileRoutes from './routes/userProfileRoutes';
 import wahaWebhookRoutes from './routes/wahaWebhookRoutes';
+import asaasWebhookRoutes from './routes/asaasWebhookRoutes';
 import authRoutes from './routes/authRoutes';
 import swaggerUi from 'swagger-ui-express';
 import swaggerJsdoc from 'swagger-jsdoc';
@@ -48,7 +49,16 @@ import { authorizeModules } from './middlewares/moduleAuthorization';
 const app = express();
 const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3001;
 
-app.use(express.json({ limit: '50mb' }));
+app.use(
+  express.json({
+    limit: '50mb',
+    verify: (req: Request & { rawBody?: string }, _res, buffer) => {
+      if (buffer?.length) {
+        req.rawBody = buffer.toString('utf-8');
+      }
+    },
+  })
+);
 app.use(express.urlencoded({ extended: true, limit: '50mb' }));
 
 const defaultAllowedOrigins = [
@@ -233,6 +243,7 @@ registerModuleRoutes('configuracoes-integracoes', integrationApiKeyRoutes);
 registerModuleRoutes('conversas', chatRoutes);
 protectedApiRouter.use(userProfileRoutes);
 app.use('/api', wahaWebhookRoutes);
+app.use('/api', asaasWebhookRoutes);
 app.use('/api', authRoutes);
 app.use('/api', protectedApiRouter);
 app.use('/api/v1', authenticateRequest, usuarioRoutes);

--- a/backend/src/routes/asaasWebhookRoutes.ts
+++ b/backend/src/routes/asaasWebhookRoutes.ts
@@ -1,0 +1,74 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { handleAsaasWebhook } from '../controllers/asaasIntegrationController';
+
+const router = Router();
+
+function normalizeIp(ip: string | null | undefined): string | null {
+  if (!ip) {
+    return null;
+  }
+
+  const trimmed = ip.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.replace(/^::ffff:/i, '');
+}
+
+function extractClientIp(req: Request): string | null {
+  const forwardedFor = req.headers['x-forwarded-for'];
+
+  if (typeof forwardedFor === 'string' && forwardedFor.trim()) {
+    const [first] = forwardedFor.split(',');
+    const normalized = normalizeIp(first);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  if (Array.isArray(forwardedFor) && forwardedFor.length > 0) {
+    const candidate = forwardedFor.find((item) => typeof item === 'string' && item.trim());
+    const normalized = normalizeIp(candidate ?? undefined);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  const remoteAddress = req.socket?.remoteAddress ?? req.ip;
+  return normalizeIp(remoteAddress ?? undefined);
+}
+
+function isIpAllowed(ip: string | null): boolean {
+  if (!ip) {
+    return false;
+  }
+
+  const rawList = process.env.ASAAS_WEBHOOK_ALLOWED_IPS ?? '';
+  const allowedIps = rawList
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+  if (allowedIps.length === 0) {
+    return true;
+  }
+
+  return allowedIps.includes(ip);
+}
+
+function ensureAllowedIp(req: Request, res: Response, next: NextFunction) {
+  const clientIp = extractClientIp(req);
+
+  if (!isIpAllowed(clientIp)) {
+    console.warn('[AsaasWebhook] Request blocked due to IP restriction', clientIp);
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  next();
+}
+
+router.post('/integrations/asaas/webhook', ensureAllowedIp, handleAsaasWebhook);
+
+export default router;
+

--- a/backend/src/routes/integrationApiKeyRoutes.ts
+++ b/backend/src/routes/integrationApiKeyRoutes.ts
@@ -7,6 +7,7 @@ import {
   updateIntegrationApiKey,
 } from '../controllers/integrationApiKeyController';
 import { generateTextWithIntegration } from '../controllers/aiGenerationController';
+import { getAsaasWebhookSecret } from '../controllers/asaasIntegrationController';
 
 const router = Router();
 
@@ -184,5 +185,7 @@ router.delete('/integrations/api-keys/:id', deleteIntegrationApiKey);
  *         description: Integração não encontrada ou inativa
  */
 router.post('/integrations/ai/generate', generateTextWithIntegration);
+
+router.get('/integrations/asaas/credentials/:credentialId/webhook-secret', getAsaasWebhookSecret);
 
 export default router;

--- a/backend/tests/asaasWebhookController.test.ts
+++ b/backend/tests/asaasWebhookController.test.ts
@@ -1,0 +1,192 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import test from 'node:test';
+import type { Request, Response } from 'express';
+import { Pool } from 'pg';
+
+process.env.DATABASE_URL ??= 'postgresql://user:pass@localhost:5432/testdb';
+
+type QueryCall = { text: string; values?: unknown[] };
+type QueryResponse = { rows: any[]; rowCount: number };
+
+const createMockResponse = () => {
+  const response: Partial<Response> & { statusCode: number; body: unknown } = {
+    statusCode: 200,
+    body: undefined,
+    status(code: number) {
+      this.statusCode = code;
+      return this as Response;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this as Response;
+    },
+  };
+
+  return response as Response & { statusCode: number; body: unknown };
+};
+
+const setupQueryMock = (responses: QueryResponse[]) => {
+  const calls: QueryCall[] = [];
+  const mock = test.mock.method(
+    Pool.prototype,
+    'query',
+    async function (this: Pool, text: string, values?: unknown[]) {
+      calls.push({ text, values });
+
+      if (responses.length === 0) {
+        throw new Error('Unexpected query invocation');
+      }
+
+      return responses.shift()!;
+    }
+  );
+
+  const restore = () => {
+    mock.mock.restore();
+  };
+
+  return { calls, restore };
+};
+
+let handleAsaasWebhook: typeof import('../src/controllers/asaasIntegrationController')['handleAsaasWebhook'];
+let getAsaasWebhookSecret: typeof import('../src/controllers/asaasIntegrationController')['getAsaasWebhookSecret'];
+
+test.before(async () => {
+  ({ handleAsaasWebhook, getAsaasWebhookSecret } = await import(
+    '../src/controllers/asaasIntegrationController'
+  ));
+});
+
+test('handleAsaasWebhook processes PAYMENT_RECEIVED and updates financial flow', async () => {
+  const secret = 'top-secret';
+  const webhookBody = {
+    event: 'PAYMENT_RECEIVED',
+    payment: {
+      id: 'pay_123',
+      status: 'RECEIVED',
+      paymentDate: '2024-05-05T10:20:30-03:00',
+    },
+  };
+  const rawBody = JSON.stringify(webhookBody);
+  const signature = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+
+  const { calls, restore } = setupQueryMock([
+    { rows: [{ id: 1, credential_id: 55, financial_flow_id: 90 }], rowCount: 1 },
+    { rows: [{ webhook_secret: secret }], rowCount: 1 },
+    { rows: [], rowCount: 1 },
+    { rows: [], rowCount: 1 },
+  ]);
+
+  const req = {
+    body: webhookBody,
+    rawBody,
+    headers: {
+      'asaas-signature': `sha256=${signature}`,
+      host: 'example.com',
+    },
+  } as unknown as Request & { rawBody?: string };
+
+  const res = createMockResponse();
+
+  try {
+    await handleAsaasWebhook(req, res);
+  } finally {
+    restore();
+  }
+
+  assert.equal(res.statusCode, 202);
+  assert.deepEqual(res.body, { received: true });
+  assert.equal(calls.length, 4);
+
+  assert.match(calls[0]?.text ?? '', /FROM asaas_charges/i);
+  assert.deepEqual(calls[0]?.values, ['pay_123']);
+
+  assert.match(calls[1]?.text ?? '', /FROM asaas_credentials/i);
+  assert.deepEqual(calls[1]?.values, [55]);
+
+  assert.match(calls[2]?.text ?? '', /UPDATE asaas_charges/i);
+  assert.equal(calls[2]?.values?.[0], 'RECEIVED');
+  assert.equal(calls[2]?.values?.[1], 'PAYMENT_RECEIVED');
+  assert.deepEqual(JSON.parse(String(calls[2]?.values?.[2])), webhookBody);
+  assert.ok(calls[2]?.values?.[3]);
+  assert.equal(calls[2]?.values?.[4], 'pay_123');
+
+  assert.match(calls[3]?.text ?? '', /UPDATE financial_flows/i);
+  assert.equal(calls[3]?.values?.[1], 90);
+});
+
+test('handleAsaasWebhook logs error and skips updates when signature is invalid', async () => {
+  const secret = 'invalid-test';
+  const webhookBody = {
+    event: 'PAYMENT_CONFIRMED',
+    payment: {
+      id: 'pay_999',
+      status: 'CONFIRMED',
+      confirmedDate: '2024-05-10T09:00:00Z',
+    },
+  };
+  const rawBody = JSON.stringify(webhookBody);
+  const wrongSignature = crypto.createHmac('sha256', 'other-secret').update(rawBody).digest('hex');
+
+  const { calls, restore } = setupQueryMock([
+    { rows: [{ id: 10, credential_id: 42, financial_flow_id: 77 }], rowCount: 1 },
+    { rows: [{ webhook_secret: secret }], rowCount: 1 },
+  ]);
+
+  const errorMock = test.mock.method(console, 'error');
+
+  const req = {
+    body: webhookBody,
+    rawBody,
+    headers: {
+      'asaas-signature': `sha256=${wrongSignature}`,
+    },
+  } as unknown as Request & { rawBody?: string };
+
+  const res = createMockResponse();
+
+  try {
+    await handleAsaasWebhook(req, res);
+  } finally {
+    restore();
+    errorMock.mock.restore();
+  }
+
+  assert.equal(res.statusCode, 202);
+  assert.deepEqual(res.body, { received: true });
+  assert.equal(calls.length, 2);
+  assert.equal(errorMock.mock.callCount(), 1);
+  assert.match(String(errorMock.mock.calls[0]?.arguments?.[0] ?? ''), /Invalid signature/i);
+});
+
+test('getAsaasWebhookSecret returns secret and setup instructions', async () => {
+  const { calls, restore } = setupQueryMock([
+    { rows: [{ webhook_secret: 'shared-secret' }], rowCount: 1 },
+  ]);
+
+  const req = {
+    params: { credentialId: '15' },
+    headers: { host: 'app.example.com' },
+    protocol: 'https',
+  } as unknown as Request;
+
+  const res = createMockResponse();
+
+  try {
+    await getAsaasWebhookSecret(req, res);
+  } finally {
+    restore();
+  }
+
+  assert.equal(res.statusCode, 200);
+  const responseBody = res.body as Record<string, unknown>;
+  assert.equal(responseBody.credentialId, 15);
+  assert.equal(responseBody.webhookSecret, 'shared-secret');
+  assert.equal(typeof responseBody.webhookUrl, 'string');
+  assert.ok(Array.isArray(responseBody.instructions));
+  assert.equal(calls.length, 1);
+  assert.match(calls[0]?.text ?? '', /FROM asaas_credentials/i);
+  assert.deepEqual(calls[0]?.values, [15]);
+});
+

--- a/backend/tests/testSetup.ts
+++ b/backend/tests/testSetup.ts
@@ -1,0 +1,1 @@
+process.env.DATABASE_URL ??= 'postgresql://user:pass@localhost:5432/testdb';


### PR DESCRIPTION
## Summary
- add controller and routes to process Asaas webhook events with IP filtering and signature validation
- update Asaas charges and related financial flows while exposing admin endpoint to retrieve webhook secret and setup steps
- ensure tests configure a default DATABASE_URL and cover valid/invalid webhook deliveries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf122cffe0832699ca17310a0f9f7e