### PR TITLE
feat: sync Asaas charges with scheduled job

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -239,6 +239,7 @@ app.use('/api/v1', authenticateRequest, usuarioRoutes);
 
 // Background jobs
 cronJobs.startProjudiSyncJob();
+cronJobs.startAsaasChargeSyncJob();
 
 // Swagger
 const specs = swaggerJsdoc(swaggerOptions);

--- a/backend/src/services/asaasChargeSync.ts
+++ b/backend/src/services/asaasChargeSync.ts
@@ -1,0 +1,303 @@
+import { URLSearchParams } from 'url';
+import type { QueryResultRow } from 'pg';
+import pool from './db';
+
+export const OPEN_PAYMENT_STATUSES = [
+  'PENDING',
+  'PENDING_RETRY',
+  'AWAITING_RISK_ANALYSIS',
+  'AUTHORIZED',
+  'BANK_SLIP_VIEWED',
+  'OVERDUE',
+] as const;
+
+export const PAID_PAYMENT_STATUSES = ['RECEIVED', 'RECEIVED_IN_CASH', 'CONFIRMED'] as const;
+
+const OPEN_PAYMENT_STATUS_SET = new Set(OPEN_PAYMENT_STATUSES);
+const PAID_PAYMENT_STATUS_SET = new Set(PAID_PAYMENT_STATUSES);
+
+const DEFAULT_PAGE_SIZE = 100;
+
+export class AsaasConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AsaasConfigurationError';
+  }
+}
+
+type Queryable = {
+  query: (text: string, params?: unknown[]) => Promise<{ rows: QueryResultRow[]; rowCount: number }>;
+};
+
+export interface AsaasPayment {
+  id: string;
+  status: string;
+  value?: number;
+  dueDate?: string | null;
+  paymentDate?: string | null;
+  externalReference?: string | null;
+}
+
+export interface ListPaymentsParams {
+  status: string[];
+  limit?: number;
+  offset?: number;
+  updatedSince?: string;
+}
+
+export interface AsaasPaymentsResponse {
+  data: AsaasPayment[];
+  hasMore?: boolean;
+  totalCount?: number;
+  limit?: number;
+  offset?: number;
+}
+
+export interface AsaasClient {
+  hasValidConfiguration(): boolean;
+  listPayments(params: ListPaymentsParams): Promise<AsaasPaymentsResponse>;
+}
+
+interface AsaasChargeRow extends QueryResultRow {
+  id: number;
+  asaas_id: string;
+  financial_flow_id: number | null;
+  status: string;
+}
+
+export interface AsaasSyncResult {
+  totalCharges: number;
+  paymentsRetrieved: number;
+  chargesUpdated: number;
+  flowsUpdated: number;
+  fetchedStatuses: string[];
+}
+
+function normalizeStatus(value: string | null | undefined): string {
+  if (!value) {
+    return '';
+  }
+  return value.trim().toUpperCase();
+}
+
+function parseDate(value: string | null | undefined): Date | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed;
+}
+
+class HttpAsaasClient implements AsaasClient {
+  private readonly apiKey: string | null;
+  private readonly apiUrl: string;
+
+  constructor(apiKey = process.env.ASAAS_API_KEY ?? null, apiUrl = process.env.ASAAS_API_URL ?? 'https://www.asaas.com/api/v3') {
+    this.apiKey = apiKey && apiKey.trim() ? apiKey.trim() : null;
+    this.apiUrl = apiUrl && apiUrl.trim() ? apiUrl.trim() : 'https://www.asaas.com/api/v3';
+  }
+
+  hasValidConfiguration(): boolean {
+    return Boolean(this.apiKey);
+  }
+
+  async listPayments(params: ListPaymentsParams): Promise<AsaasPaymentsResponse> {
+    if (!this.hasValidConfiguration()) {
+      throw new AsaasConfigurationError(
+        'Integração com o Asaas não está configurada. Defina ASAAS_API_KEY e ASAAS_API_URL conforme necessário.',
+      );
+    }
+
+    const statuses = Array.from(new Set(params.status.map((status) => normalizeStatus(status)))).filter(Boolean);
+    if (statuses.length === 0) {
+      return { data: [], hasMore: false, totalCount: 0, limit: params.limit, offset: params.offset };
+    }
+
+    const searchParams = new URLSearchParams();
+    for (const status of statuses) {
+      searchParams.append('status', status);
+    }
+    if (typeof params.limit === 'number') {
+      searchParams.set('limit', String(params.limit));
+    }
+    if (typeof params.offset === 'number') {
+      searchParams.set('offset', String(params.offset));
+    }
+    if (params.updatedSince) {
+      searchParams.set('updatedSince', params.updatedSince);
+    }
+
+    const url = `${this.apiUrl.replace(/\/$/, '')}/payments?${searchParams.toString()}`;
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Falha ao consultar cobranças no Asaas: ${response.status} ${response.statusText}`);
+    }
+
+    const body = (await response.json()) as AsaasPaymentsResponse;
+    if (!body || !Array.isArray(body.data)) {
+      return { data: [], hasMore: false, totalCount: 0, limit: body?.limit, offset: body?.offset };
+    }
+
+    return {
+      data: body.data.map((item) => ({
+        ...item,
+        status: normalizeStatus(item.status),
+      })),
+      hasMore: Boolean(body.hasMore),
+      totalCount: typeof body.totalCount === 'number' ? body.totalCount : body.data.length,
+      limit: typeof body.limit === 'number' ? body.limit : params.limit,
+      offset: typeof body.offset === 'number' ? body.offset : params.offset,
+    };
+  }
+}
+
+export const createDefaultAsaasClient = () => new HttpAsaasClient();
+
+export class AsaasChargeSyncService {
+  private readonly db: Queryable;
+  private readonly client: AsaasClient;
+  private readonly pageSize: number;
+
+  constructor(db: Queryable = pool, client: AsaasClient = createDefaultAsaasClient(), pageSize = DEFAULT_PAGE_SIZE) {
+    this.db = db;
+    this.client = client;
+    this.pageSize = pageSize;
+  }
+
+  hasValidConfiguration(): boolean {
+    return this.client.hasValidConfiguration();
+  }
+
+  async syncPendingCharges(): Promise<AsaasSyncResult> {
+    if (!this.hasValidConfiguration()) {
+      throw new AsaasConfigurationError(
+        'Integração com o Asaas não está configurada. Defina ASAAS_API_KEY e ASAAS_API_URL conforme necessário.',
+      );
+    }
+
+    const charges = await this.loadPendingCharges();
+    if (charges.length === 0) {
+      return {
+        totalCharges: 0,
+        paymentsRetrieved: 0,
+        chargesUpdated: 0,
+        flowsUpdated: 0,
+        fetchedStatuses: this.statusesToFetch,
+      };
+    }
+
+    const payments = await this.fetchPayments();
+    const paymentsById = new Map(payments.map((payment) => [payment.id, payment]));
+
+    let chargesUpdated = 0;
+    let flowsUpdated = 0;
+
+    for (const charge of charges) {
+      const payment = paymentsById.get(charge.asaas_id);
+      if (!payment) {
+        continue;
+      }
+
+      const paymentStatus = normalizeStatus(payment.status);
+      if (paymentStatus && paymentStatus !== normalizeStatus(charge.status)) {
+        await this.db.query('UPDATE asaas_charges SET status = $1 WHERE id = $2', [paymentStatus, charge.id]);
+        chargesUpdated += 1;
+      }
+
+      if (charge.financial_flow_id) {
+        const flowUpdate = this.buildFinancialFlowUpdate(paymentStatus, payment.paymentDate);
+        if (flowUpdate) {
+          const [flowStatus, paymentDate] = flowUpdate;
+          await this.db.query(
+            'UPDATE financial_flows SET status = $1, pagamento = $2 WHERE id = $3',
+            [flowStatus, paymentDate, charge.financial_flow_id],
+          );
+          flowsUpdated += 1;
+        }
+      }
+    }
+
+    return {
+      totalCharges: charges.length,
+      paymentsRetrieved: payments.length,
+      chargesUpdated,
+      flowsUpdated,
+      fetchedStatuses: this.statusesToFetch,
+    };
+  }
+
+  private get statusesToFetch(): string[] {
+    return [...OPEN_PAYMENT_STATUSES, ...PAID_PAYMENT_STATUSES];
+  }
+
+  private async loadPendingCharges(): Promise<AsaasChargeRow[]> {
+    const { rows } = await this.db.query(
+      'SELECT id, asaas_id, financial_flow_id, status FROM asaas_charges WHERE status = ANY($1)',
+      [OPEN_PAYMENT_STATUSES],
+    );
+
+    return rows as AsaasChargeRow[];
+  }
+
+  private async fetchPayments(): Promise<AsaasPayment[]> {
+    const statuses = this.statusesToFetch;
+    const payments: AsaasPayment[] = [];
+    let offset = 0;
+
+    while (true) {
+      const response = await this.client.listPayments({ status: statuses, limit: this.pageSize, offset });
+      if (Array.isArray(response.data)) {
+        for (const payment of response.data) {
+          payments.push({
+            ...payment,
+            status: normalizeStatus(payment.status),
+          });
+        }
+      }
+
+      const hasMore = Boolean(response.hasMore);
+      const limit = typeof response.limit === 'number' && response.limit > 0 ? response.limit : this.pageSize;
+
+      if (!hasMore) {
+        break;
+      }
+
+      offset += limit;
+
+      if (limit <= 0) {
+        break;
+      }
+    }
+
+    return payments;
+  }
+
+  private buildFinancialFlowUpdate(status: string, paymentDate: string | null | undefined): [string, Date | null] | null {
+    const normalizedStatus = normalizeStatus(status);
+
+    if (PAID_PAYMENT_STATUS_SET.has(normalizedStatus)) {
+      return ['pago', parseDate(paymentDate)];
+    }
+
+    if (OPEN_PAYMENT_STATUS_SET.has(normalizedStatus)) {
+      return ['pendente', null];
+    }
+
+    return null;
+  }
+}
+
+export const asaasChargeSyncService = new AsaasChargeSyncService();
+
+export default asaasChargeSyncService;

--- a/backend/tests/asaasChargeSync.test.ts
+++ b/backend/tests/asaasChargeSync.test.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  AsaasChargeSyncService,
+  AsaasConfigurationError,
+  OPEN_PAYMENT_STATUSES,
+  PAID_PAYMENT_STATUSES,
+  type AsaasPaymentsResponse,
+  type AsaasPayment,
+} from '../src/services/asaasChargeSync';
+
+type QueryCall = { text: string; values?: unknown[] };
+
+type QueryResponse = { rows: any[]; rowCount: number };
+
+class FakeDb {
+  public readonly calls: QueryCall[] = [];
+
+  constructor(private readonly responses: QueryResponse[] = []) {}
+
+  async query(text: string, values?: unknown[]) {
+    this.calls.push({ text, values });
+    if (this.responses.length > 0) {
+      return this.responses.shift()!;
+    }
+    return { rows: [], rowCount: 0 };
+  }
+}
+
+class FakeClient {
+  public readonly calls: Array<{ status: string[]; limit?: number; offset?: number }> = [];
+
+  constructor(
+    private readonly responses: AsaasPaymentsResponse[] = [],
+    private readonly configured = true
+  ) {}
+
+  hasValidConfiguration(): boolean {
+    return this.configured;
+  }
+
+  async listPayments(params: { status: string[]; limit?: number; offset?: number }): Promise<AsaasPaymentsResponse> {
+    this.calls.push(params);
+    if (this.responses.length > 0) {
+      return this.responses.shift()!;
+    }
+    return { data: [], hasMore: false, totalCount: 0, limit: params.limit, offset: params.offset };
+  }
+}
+
+test('syncPendingCharges consults only pending charges when querying storage', async () => {
+  const db = new FakeDb([
+    { rows: [], rowCount: 0 },
+  ]);
+  const client = new FakeClient([]);
+  const service = new AsaasChargeSyncService(db as any, client as any);
+
+  const result = await service.syncPendingCharges();
+
+  assert.equal(result.totalCharges, 0);
+  assert.equal(db.calls.length, 1);
+  assert.ok(/FROM\s+asaas_charges/i.test(db.calls[0].text));
+  assert.deepEqual(db.calls[0].values?.[0], OPEN_PAYMENT_STATUSES);
+  assert.equal(client.calls.length, 0);
+});
+
+test('syncPendingCharges propagates status changes to asaas_charges and financial_flows', async () => {
+  const storedCharges = [
+    { id: 1, asaas_id: 'pay_1', financial_flow_id: 10, status: 'PENDING' },
+    { id: 2, asaas_id: 'pay_2', financial_flow_id: 20, status: 'PENDING' },
+  ];
+
+  const db = new FakeDb([
+    { rows: storedCharges, rowCount: storedCharges.length },
+  ]);
+
+  const remotePayments: AsaasPayment[] = [
+    { id: 'pay_1', status: 'OVERDUE' },
+    { id: 'pay_2', status: 'RECEIVED', paymentDate: '2024-04-01' },
+    { id: 'other', status: 'PENDING' },
+  ];
+
+  const client = new FakeClient([
+    { data: remotePayments, hasMore: false, limit: 100, offset: 0 },
+  ]);
+
+  const service = new AsaasChargeSyncService(db as any, client as any, 50);
+
+  const result = await service.syncPendingCharges();
+
+  assert.equal(result.totalCharges, 2);
+  assert.equal(result.paymentsRetrieved, remotePayments.length);
+  assert.equal(result.chargesUpdated, 2);
+  assert.equal(result.flowsUpdated, 2);
+  assert.deepEqual(result.fetchedStatuses, [...OPEN_PAYMENT_STATUSES, ...PAID_PAYMENT_STATUSES]);
+
+  assert.equal(client.calls.length, 1);
+  assert.deepEqual(client.calls[0].status, [...OPEN_PAYMENT_STATUSES, ...PAID_PAYMENT_STATUSES]);
+  assert.equal(client.calls[0].limit, 50);
+  assert.equal(client.calls[0].offset, 0);
+
+  // First call is the SELECT used to load the pending charges
+  const updateCalls = db.calls.slice(1);
+  assert.equal(updateCalls.length, 4);
+
+  const [updateCharge1, updateFlow1, updateCharge2, updateFlow2] = updateCalls;
+
+  assert.match(updateCharge1.text, /UPDATE\s+asaas_charges/i);
+  assert.deepEqual(updateCharge1.values, ['OVERDUE', 1]);
+
+  assert.match(updateFlow1.text, /UPDATE\s+financial_flows/i);
+  assert.deepEqual(updateFlow1.values, ['pendente', null, 10]);
+
+  assert.deepEqual(updateCharge2.values, ['RECEIVED', 2]);
+
+  assert.equal(updateFlow2.values?.[0], 'pago');
+  assert.ok(updateFlow2.values?.[1] instanceof Date);
+  assert.equal(updateFlow2.values?.[2], 20);
+});
+
+test('syncPendingCharges fails fast when credentials are not configured', async () => {
+  const db = new FakeDb();
+  const client = new FakeClient([], false);
+  const service = new AsaasChargeSyncService(db as any, client as any);
+
+  await assert.rejects(() => service.syncPendingCharges(), AsaasConfigurationError);
+  assert.equal(db.calls.length, 0);
+});


### PR DESCRIPTION
## Summary
- add Asaas charge sync service that normalizes API responses, updates charge and financial records, and exposes configuration checks
- extend CronJobsService with an Asaas scheduler, manual trigger, and status reporting while wiring the job into the app bootstrap
- cover the sync logic with unit tests using mocked clients and database layers

## Testing
- `cd backend && export DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cf122d685c832693e87dc85bce5d3f