### PR TITLE
Add Asaas integration defaults and UI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,25 @@ O serviço executa uma rotina periódica para autenticar, consultar novas
 intimações e gravá-las na tabela `intimacoes`. É possível monitorar ou
 acionar a sincronização manualmente via `GET /api/notificacoes/projudi/sync`.
 
+### Integração com Asaas
+
+Para consumir a API de cobranças do Asaas por meio das credenciais gerenciadas
+em `integration_api_keys`:
+
+1. Execute novamente o script `psql -f sql/integration_api_keys.sql` para
+   garantir a presença da coluna `url_api` e do provedor `asaas` no `CHECK`.
+2. Cadastre uma chave com `provider` igual a `asaas` (via API ou tela de
+   configurações) informando o token de acesso do Asaas.
+3. Se o campo `url_api` não for preenchido, o backend assumirá automaticamente
+   os endpoints padrão:
+   - Produção: `https://api.asaas.com/api/v3`
+   - Homologação: `https://sandbox.asaas.com/api/v3`
+4. Utilize o endpoint `POST /api/integrations/providers/asaas/validate` para
+   testar a conexão após o cadastro da chave.
+
+Não são necessárias variáveis de ambiente adicionais além das credenciais
+registradas na tabela.
+
 ## Frontend
 
 ```bash

--- a/backend/sql/integration_api_keys.sql
+++ b/backend/sql/integration_api_keys.sql
@@ -1,14 +1,25 @@
 -- Estrutura para armazenamento de chaves de API das integrações
 CREATE TABLE IF NOT EXISTS integration_api_keys (
   id BIGSERIAL PRIMARY KEY,
-  provider TEXT NOT NULL CHECK (provider IN ('gemini', 'openai')),
+  provider TEXT NOT NULL CHECK (provider IN ('gemini', 'openai', 'asaas')),
   key_value TEXT NOT NULL,
+  url_api TEXT NULL,
   environment TEXT NOT NULL CHECK (environment IN ('producao', 'homologacao')),
   active BOOLEAN NOT NULL DEFAULT TRUE,
   last_used TIMESTAMPTZ NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+ALTER TABLE integration_api_keys
+  ADD COLUMN IF NOT EXISTS url_api TEXT;
+
+ALTER TABLE integration_api_keys
+  DROP CONSTRAINT IF EXISTS integration_api_keys_provider_check;
+
+ALTER TABLE integration_api_keys
+  ADD CONSTRAINT integration_api_keys_provider_check
+  CHECK (provider IN ('gemini', 'openai', 'asaas'));
 
 CREATE INDEX IF NOT EXISTS idx_integration_api_keys_provider
   ON integration_api_keys (provider);

--- a/backend/src/controllers/integrationApiKeyController.ts
+++ b/backend/src/controllers/integrationApiKeyController.ts
@@ -4,8 +4,10 @@ import IntegrationApiKeyService, {
   UpdateIntegrationApiKeyInput,
   ValidationError,
 } from '../services/integrationApiKeyService';
+import IntegrationApiKeyValidationService from '../services/integrationApiKeyValidationService';
 
 const service = new IntegrationApiKeyService();
+const validationService = new IntegrationApiKeyValidationService();
 
 function parseIdParam(param: string): number | null {
   const value = Number(param);
@@ -198,6 +200,29 @@ export async function deleteIntegrationApiKey(req: Request, res: Response) {
     return res.status(204).send();
   } catch (error) {
     console.error('Failed to delete integration API key:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}
+
+export async function validateAsaasIntegration(req: Request, res: Response) {
+  const { apiKeyId } = req.body as { apiKeyId?: unknown };
+
+  const parsedId =
+    typeof apiKeyId === 'number'
+      ? apiKeyId
+      : typeof apiKeyId === 'string'
+        ? Number(apiKeyId)
+        : Number.NaN;
+
+  try {
+    const result = await validationService.validateAsaas(parsedId);
+    return res.json(result);
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return res.status(400).json({ error: error.message });
+    }
+
+    console.error('Failed to validate Asaas integration API key:', error);
     return res.status(500).json({ error: 'Internal server error' });
   }
 }

--- a/backend/src/routes/integrationApiKeyRoutes.ts
+++ b/backend/src/routes/integrationApiKeyRoutes.ts
@@ -68,7 +68,7 @@ router.get('/integrations/api-keys/:id', getIntegrationApiKey);
  *             properties:
  *               provider:
  *                 type: string
- *                 enum: [gemini, openai]
+ *                 enum: [gemini, openai, asaas]
  *               apiUrl:
  *                 type: string
  *                 format: uri
@@ -110,7 +110,7 @@ router.post('/integrations/api-keys', createIntegrationApiKey);
  *             properties:
  *               provider:
  *                 type: string
- *                 enum: [gemini, openai]
+ *                 enum: [gemini, openai, asaas]
  *               apiUrl:
  *                 type: string
  *                 format: uri

--- a/backend/src/routes/integrationApiKeyRoutes.ts
+++ b/backend/src/routes/integrationApiKeyRoutes.ts
@@ -5,6 +5,7 @@ import {
   getIntegrationApiKey,
   listIntegrationApiKeys,
   updateIntegrationApiKey,
+  validateAsaasIntegration,
 } from '../controllers/integrationApiKeyController';
 import { generateTextWithIntegration } from '../controllers/aiGenerationController';
 
@@ -151,6 +152,31 @@ router.patch('/integrations/api-keys/:id', updateIntegrationApiKey);
  *         description: Chave não encontrada
  */
 router.delete('/integrations/api-keys/:id', deleteIntegrationApiKey);
+
+/**
+ * @swagger
+ * /api/integrations/providers/asaas/validate:
+ *   post:
+ *     summary: Testa a conexão com o Asaas utilizando uma chave cadastrada
+ *     tags: [Integrações]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - apiKeyId
+ *             properties:
+ *               apiKeyId:
+ *                 type: integer
+ *     responses:
+ *       200:
+ *         description: Resultado da validação da chave
+ *       400:
+ *         description: Requisição inválida ou chave inexistente
+ */
+router.post('/integrations/providers/asaas/validate', validateAsaasIntegration);
 
 /**
  * @swagger

--- a/backend/src/services/integrationApiKeyService.ts
+++ b/backend/src/services/integrationApiKeyService.ts
@@ -61,7 +61,7 @@ interface IntegrationApiKeyRow extends QueryResultRow {
   updated_at: string | Date;
 }
 
-const ASAAS_DEFAULT_API_URLS: Record<ApiKeyEnvironment, string> = {
+export const ASAAS_DEFAULT_API_URLS: Record<ApiKeyEnvironment, string> = {
   producao: 'https://api.asaas.com/api/v3',
   homologacao: 'https://sandbox.asaas.com/api/v3',
 };

--- a/backend/src/services/integrationApiKeyValidationService.ts
+++ b/backend/src/services/integrationApiKeyValidationService.ts
@@ -1,0 +1,153 @@
+import IntegrationApiKeyService, {
+  ApiKeyEnvironment,
+  IntegrationApiKey,
+  ValidationError,
+  ASAAS_DEFAULT_API_URLS,
+} from './integrationApiKeyService';
+
+export interface ValidateAsaasIntegrationResult {
+  success: boolean;
+  message?: string;
+}
+
+type FetchFn = (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => Promise<{
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+}>;
+
+function resolveAsaasApiUrl(environment: string, apiUrl: string | null): string {
+  if (typeof apiUrl === 'string') {
+    const trimmed = apiUrl.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  if (typeof environment === 'string') {
+    const normalized = environment.trim().toLowerCase();
+    if (normalized && normalized in ASAAS_DEFAULT_API_URLS) {
+      return ASAAS_DEFAULT_API_URLS[normalized as ApiKeyEnvironment];
+    }
+  }
+
+  throw new ValidationError('Unable to determine Asaas API URL for this integration');
+}
+
+function buildValidationUrl(baseUrl: string): string {
+  const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+
+  try {
+    const url = new URL('customers?limit=1', normalizedBase);
+    return url.toString();
+  } catch (error) {
+    throw new ValidationError('Invalid Asaas API URL configured');
+  }
+}
+
+function parseErrorMessage(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== 'object') {
+    if (typeof payload === 'string' && payload.trim()) {
+      return payload.trim();
+    }
+    return undefined;
+  }
+
+  if ('message' in payload && typeof (payload as any).message === 'string' && (payload as any).message.trim()) {
+    return ((payload as any).message as string).trim();
+  }
+
+  if ('error' in payload && typeof (payload as any).error === 'string' && (payload as any).error.trim()) {
+    return ((payload as any).error as string).trim();
+  }
+
+  if (Array.isArray((payload as any).errors)) {
+    for (const item of (payload as any).errors) {
+      if (!item) {
+        continue;
+      }
+      if (typeof item === 'string' && item.trim()) {
+        return item.trim();
+      }
+      if (typeof item === 'object') {
+        if ('description' in item && typeof (item as any).description === 'string' && (item as any).description.trim()) {
+          return ((item as any).description as string).trim();
+        }
+        if ('message' in item && typeof (item as any).message === 'string' && (item as any).message.trim()) {
+          return ((item as any).message as string).trim();
+        }
+        if ('error' in item && typeof (item as any).error === 'string' && (item as any).error.trim()) {
+          return ((item as any).error as string).trim();
+        }
+      }
+    }
+  }
+
+  return undefined;
+}
+
+export default class IntegrationApiKeyValidationService {
+  constructor(
+    private readonly apiKeyService: Pick<IntegrationApiKeyService, 'findById'> = new IntegrationApiKeyService(),
+    private readonly fetchImpl: FetchFn = (globalThis.fetch as FetchFn) ?? (async () => {
+      throw new Error('Fetch API is not available');
+    })
+  ) {}
+
+  async validateAsaas(apiKeyId: number): Promise<ValidateAsaasIntegrationResult> {
+    if (!Number.isInteger(apiKeyId) || apiKeyId <= 0) {
+      throw new ValidationError('Invalid API key id');
+    }
+
+    const apiKey = await this.apiKeyService.findById(apiKeyId);
+    if (!apiKey) {
+      throw new ValidationError('Asaas API key not found');
+    }
+
+    if (apiKey.provider !== 'asaas') {
+      throw new ValidationError('API key provider must be Asaas');
+    }
+
+    const baseUrl = resolveAsaasApiUrl(apiKey.environment, apiKey.apiUrl);
+    const requestUrl = buildValidationUrl(baseUrl);
+
+    const headers = {
+      Accept: 'application/json',
+      access_token: typeof apiKey.key === 'string' ? apiKey.key : '',
+    } as Record<string, string>;
+
+    try {
+      const response = await this.fetchImpl(requestUrl, {
+        method: 'GET',
+        headers,
+      });
+
+      if (response.ok) {
+        return { success: true };
+      }
+
+      try {
+        const payload = await response.json();
+        const message = parseErrorMessage(payload);
+        if (message) {
+          return { success: false, message };
+        }
+      } catch (error) {
+        // Ignore body parsing issues and fall back to default message
+      }
+
+      return {
+        success: false,
+        message: `Asaas API request failed with status ${response.status}`,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        success: false,
+        message: `Unable to connect to Asaas API: ${message}`,
+      };
+    }
+  }
+}
+
+export type { IntegrationApiKey };

--- a/backend/tests/integrationApiKeyValidationService.test.ts
+++ b/backend/tests/integrationApiKeyValidationService.test.ts
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import IntegrationApiKeyValidationService, {
+  ValidateAsaasIntegrationResult,
+} from '../src/services/integrationApiKeyValidationService';
+import {
+  IntegrationApiKey,
+  ValidationError,
+  ASAAS_DEFAULT_API_URLS,
+} from '../src/services/integrationApiKeyService';
+
+class FakeIntegrationApiKeyService {
+  constructor(private readonly items: Map<number, IntegrationApiKey> = new Map()) {}
+
+  async findById(id: number): Promise<IntegrationApiKey | null> {
+    return this.items.get(id) ?? null;
+  }
+}
+
+type FetchCall = { input: Parameters<typeof fetch>[0]; init?: Parameters<typeof fetch>[1] };
+
+test('validateAsaas rejects invalid identifiers', async () => {
+  const service = new IntegrationApiKeyValidationService(new FakeIntegrationApiKeyService(), async () => {
+    throw new Error('fetch should not be called');
+  });
+
+  await assert.rejects(() => service.validateAsaas(0), ValidationError);
+  await assert.rejects(() => service.validateAsaas(-1), ValidationError);
+  await assert.rejects(() => service.validateAsaas(Number.NaN), ValidationError);
+});
+
+function createApiKey(overrides: Partial<IntegrationApiKey> = {}): IntegrationApiKey {
+  return {
+    id: 1,
+    provider: 'asaas',
+    apiUrl: 'https://api.asaas.com/api/v3',
+    key: 'asaas_token',
+    environment: 'producao',
+    active: true,
+    lastUsed: null,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+test('validateAsaas rejects when API key does not exist', async () => {
+  const fakeService = new FakeIntegrationApiKeyService(new Map());
+  const validator = new IntegrationApiKeyValidationService(fakeService, async () => {
+    throw new Error('fetch should not be called');
+  });
+
+  await assert.rejects(() => validator.validateAsaas(42), ValidationError);
+});
+
+test('validateAsaas rejects when provider is not Asaas', async () => {
+  const apiKey = createApiKey({ provider: 'openai' });
+  const fakeService = new FakeIntegrationApiKeyService(new Map([[apiKey.id, apiKey]]));
+  const validator = new IntegrationApiKeyValidationService(fakeService, async () => {
+    throw new Error('fetch should not be called');
+  });
+
+  await assert.rejects(() => validator.validateAsaas(apiKey.id), ValidationError);
+});
+
+test('validateAsaas uses stored URL when present and returns success on OK response', async () => {
+  const apiKey = createApiKey();
+  const fakeService = new FakeIntegrationApiKeyService(new Map([[apiKey.id, apiKey]]));
+  const calls: FetchCall[] = [];
+  const validator = new IntegrationApiKeyValidationService(fakeService, async (input, init) => {
+    calls.push({ input, init });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error('JSON body should not be read on success');
+      },
+    };
+  });
+
+  const result = await validator.validateAsaas(apiKey.id);
+  assert.deepEqual(result, { success: true } satisfies ValidateAsaasIntegrationResult);
+  assert.equal(calls.length, 1);
+  const call = calls[0];
+  const url = typeof call.input === 'string' ? call.input : call.input.toString();
+  assert.equal(url, 'https://api.asaas.com/api/v3/customers?limit=1');
+  assert.ok(call.init);
+  assert.equal(call.init?.method, 'GET');
+  assert.equal((call.init?.headers as Record<string, string>).access_token, 'asaas_token');
+});
+
+test('validateAsaas falls back to default URL when apiUrl is null', async () => {
+  const apiKey = createApiKey({ apiUrl: null, environment: 'homologacao' });
+  const fakeService = new FakeIntegrationApiKeyService(new Map([[apiKey.id, apiKey]]));
+  const calls: FetchCall[] = [];
+  const validator = new IntegrationApiKeyValidationService(fakeService, async (input, init) => {
+    calls.push({ input, init });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    };
+  });
+
+  const result = await validator.validateAsaas(apiKey.id);
+  assert.equal(result.success, true);
+  const expectedBase = ASAAS_DEFAULT_API_URLS.homologacao;
+  const call = calls[0];
+  const url = typeof call.input === 'string' ? call.input : call.input.toString();
+  assert.equal(url, `${expectedBase}/customers?limit=1`);
+});
+
+test('validateAsaas returns failure with message from API payload', async () => {
+  const apiKey = createApiKey();
+  const fakeService = new FakeIntegrationApiKeyService(new Map([[apiKey.id, apiKey]]));
+  const validator = new IntegrationApiKeyValidationService(fakeService, async () => ({
+    ok: false,
+    status: 401,
+    json: async () => ({ message: 'Token inválido' }),
+  }));
+
+  const result = await validator.validateAsaas(apiKey.id);
+  assert.deepEqual(result, { success: false, message: 'Token inválido' });
+});
+
+test('validateAsaas extracts first validation error when response contains an array', async () => {
+  const apiKey = createApiKey();
+  const fakeService = new FakeIntegrationApiKeyService(new Map([[apiKey.id, apiKey]]));
+  const validator = new IntegrationApiKeyValidationService(fakeService, async () => ({
+    ok: false,
+    status: 400,
+    json: async () => ({
+      errors: [
+        { description: 'Primeiro erro' },
+        { message: 'Segundo erro' },
+      ],
+    }),
+  }));
+
+  const result = await validator.validateAsaas(apiKey.id);
+  assert.deepEqual(result, { success: false, message: 'Primeiro erro' });
+});
+
+test('validateAsaas returns default message when API payload is empty', async () => {
+  const apiKey = createApiKey();
+  const fakeService = new FakeIntegrationApiKeyService(new Map([[apiKey.id, apiKey]]));
+  const validator = new IntegrationApiKeyValidationService(fakeService, async () => ({
+    ok: false,
+    status: 502,
+    json: async () => ({}),
+  }));
+
+  const result = await validator.validateAsaas(apiKey.id);
+  assert.deepEqual(result, { success: false, message: 'Asaas API request failed with status 502' });
+});
+
+test('validateAsaas returns connection failure when fetch rejects', async () => {
+  const apiKey = createApiKey();
+  const fakeService = new FakeIntegrationApiKeyService(new Map([[apiKey.id, apiKey]]));
+  const validator = new IntegrationApiKeyValidationService(fakeService, async () => {
+    throw new Error('timeout');
+  });
+
+  const result = await validator.validateAsaas(apiKey.id);
+  assert.equal(result.success, false);
+  assert.ok(result.message?.includes('timeout'));
+});
+
+test('validateAsaas throws when API URL is invalid', async () => {
+  const apiKey = createApiKey({ apiUrl: 'notaurl' });
+  const fakeService = new FakeIntegrationApiKeyService(new Map([[apiKey.id, apiKey]]));
+  const validator = new IntegrationApiKeyValidationService(fakeService, async () => {
+    throw new Error('fetch should not be reached');
+  });
+
+  await assert.rejects(() => validator.validateAsaas(apiKey.id), ValidationError);
+});


### PR DESCRIPTION
## Summary
- allow registering Asaas API keys by extending the database schema, provider validation and automatic URL defaults
- expand service tests and OpenAPI docs to cover Asaas including default URL handling
- surface the Asaas option in the integrations UI with tooltips, default placeholders and a "Testar conexão" action that hits the new validation endpoint, and document setup steps in the README

## Testing
- DATABASE_URL=postgres://user:pass@localhost:5432/test npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf1223a0248326a8c3a9736bafdd76