### PR TITLE
feat: add Asaas charge dialog and tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -67,17 +68,23 @@
     "@types/node": "^22.16.5",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
+    "@types/testing-library__jest-dom": "^5.14.9",
     "@vitejs/plugin-react-swc": "^3.11.0",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.32.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^15.15.0",
+    "jsdom": "^24.0.0",
     "lovable-tagger": "^1.1.9",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "vitest": "^2.1.4",
+    "@testing-library/react": "^14.3.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@testing-library/jest-dom": "^6.6.3"
   }
 }

--- a/frontend/src/components/financial/AsaasChargeDialog.tsx
+++ b/frontend/src/components/financial/AsaasChargeDialog.tsx
@@ -1,0 +1,1083 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { format, parseISO, isValid } from 'date-fns';
+import {
+  AsaasCharge,
+  AsaasChargeStatus,
+  AsaasPaymentMethod,
+  CreateAsaasChargePayload,
+  CardTokenPayload,
+  CardTokenResponse,
+  Flow,
+  createAsaasCharge,
+  fetchChargeDetails,
+  listChargeStatus,
+  tokenizeCard,
+  fetchCustomerSyncStatus,
+  syncCustomerNow,
+} from '@/lib/flows';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2, RefreshCcw, Clipboard, Send, CreditCard, QrCode } from 'lucide-react';
+
+export type CustomerOption = {
+  id: string;
+  label: string;
+  email?: string;
+  document?: string;
+  raw: unknown;
+};
+
+type CardTokenDetails = {
+  token: string;
+  brand?: string;
+  last4Digits?: string;
+  holderName: string;
+  holderEmail: string;
+  document: string;
+  phone: string;
+  postalCode: string;
+  addressNumber: string;
+  addressComplement?: string;
+};
+
+type CardFormState = {
+  holderName: string;
+  holderEmail: string;
+  document: string;
+  number: string;
+  expiryMonth: string;
+  expiryYear: string;
+  cvv: string;
+  phone: string;
+  postalCode: string;
+  addressNumber: string;
+  addressComplement: string;
+};
+
+type CardFormErrors = Partial<Record<keyof CardFormState, string>>;
+
+const DEFAULT_INSTALLMENT_OPTIONS = [1, 2, 3, 6, 12];
+const DIGIT_ONLY_REGEX = /\D+/g;
+
+function sanitizeDigits(value: string): string {
+  return value.replace(DIGIT_ONLY_REGEX, '');
+}
+
+function validateCardForm(form: CardFormState): CardFormErrors {
+  const errors: CardFormErrors = {};
+
+  if (!form.holderName.trim()) {
+    errors.holderName = 'Informe o nome impresso no cartão.';
+  }
+
+  if (!form.holderEmail.trim() || !form.holderEmail.includes('@')) {
+    errors.holderEmail = 'Informe um e-mail válido.';
+  }
+
+  const documentDigits = sanitizeDigits(form.document);
+  if (documentDigits.length < 11) {
+    errors.document = 'Informe um CPF/CNPJ válido.';
+  }
+
+  const cardDigits = sanitizeDigits(form.number);
+  if (cardDigits.length < 13) {
+    errors.number = 'Número do cartão inválido.';
+  }
+
+  if (!form.expiryMonth || Number(form.expiryMonth) < 1 || Number(form.expiryMonth) > 12) {
+    errors.expiryMonth = 'Mês inválido.';
+  }
+
+  if (!form.expiryYear || form.expiryYear.length < 2) {
+    errors.expiryYear = 'Ano inválido.';
+  }
+
+  const cvvDigits = sanitizeDigits(form.cvv);
+  if (cvvDigits.length < 3 || cvvDigits.length > 4) {
+    errors.cvv = 'Código de segurança inválido.';
+  }
+
+  const phoneDigits = sanitizeDigits(form.phone);
+  if (phoneDigits.length < 8) {
+    errors.phone = 'Informe um telefone válido.';
+  }
+
+  const postalCodeDigits = sanitizeDigits(form.postalCode);
+  if (postalCodeDigits.length < 8) {
+    errors.postalCode = 'Informe um CEP válido.';
+  }
+
+  if (!form.addressNumber.trim()) {
+    errors.addressNumber = 'Informe o número do endereço.';
+  }
+
+  return errors;
+}
+
+function resolveSyncStatusInfo(status?: string | null): { label: string; variant: 'default' | 'secondary' | 'destructive' | 'outline' } {
+  if (!status) {
+    return { label: 'Nunca sincronizado', variant: 'outline' };
+  }
+
+  const normalized = status.toLowerCase();
+
+  if (normalized.includes('error') || normalized.includes('erro') || normalized.includes('fail')) {
+    return { label: 'Com erro', variant: 'destructive' };
+  }
+
+  if (normalized.includes('pending') || normalized.includes('aguard') || normalized.includes('processing')) {
+    return { label: 'Pendente', variant: 'outline' };
+  }
+
+  if (normalized.includes('sync') || normalized.includes('atualiz') || normalized.includes('ok')) {
+    return { label: 'Sincronizado', variant: 'secondary' };
+  }
+
+  return { label: status, variant: 'default' };
+}
+
+type AsaasChargeDialogProps = {
+  flow: Flow | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  customers: CustomerOption[];
+  customersLoading: boolean;
+  onChargeCreated: (flowId: number, charge: AsaasCharge) => void;
+  onStatusUpdated: (flowId: number, statuses: AsaasChargeStatus[]) => void;
+  persistedCharge?: AsaasCharge | null;
+  persistedStatuses?: AsaasChargeStatus[];
+};
+
+type CardModalState = {
+  flow: Flow;
+  payload: CreateAsaasChargePayload;
+};
+
+export const AsaasChargeDialog = ({
+  flow,
+  open,
+  onOpenChange,
+  customers,
+  customersLoading,
+  onChargeCreated,
+  onStatusUpdated,
+  persistedCharge = null,
+  persistedStatuses = [],
+}: AsaasChargeDialogProps) => {
+  const { toast } = useToast();
+  const currencyFormatter = useMemo(
+    () => new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }),
+    [],
+  );
+  const formatCurrency = useCallback(
+    (value: number | string | null | undefined) =>
+      currencyFormatter.format(Number.parseFloat(value ? value.toString() : '0') || 0),
+    [currencyFormatter],
+  );
+  const [customerId, setCustomerId] = useState('');
+  const [paymentMethod, setPaymentMethod] = useState<AsaasPaymentMethod>('PIX');
+  const [installments, setInstallments] = useState<number>(1);
+  const [dueDate, setDueDate] = useState('');
+  const [lastCharge, setLastCharge] = useState<AsaasCharge | null>(persistedCharge ?? null);
+  const [statuses, setStatuses] = useState<AsaasChargeStatus[]>(persistedStatuses ?? []);
+  const [cardModalState, setCardModalState] = useState<CardModalState | null>(null);
+  const [lastCardDetails, setLastCardDetails] = useState<CardTokenDetails | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setLastCharge(persistedCharge ?? null);
+      setStatuses(persistedStatuses ?? []);
+    }
+  }, [open, persistedCharge, persistedStatuses]);
+
+  useEffect(() => {
+    if (!open) {
+      setCustomerId('');
+      setPaymentMethod('PIX');
+      setInstallments(1);
+      setDueDate('');
+      setCardModalState(null);
+      setLastCardDetails(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (paymentMethod === 'PIX') {
+      setInstallments(1);
+    }
+  }, [paymentMethod]);
+
+  useEffect(() => {
+    if (paymentMethod !== 'BOLETO') {
+      setDueDate('');
+    }
+  }, [paymentMethod]);
+
+  useEffect(() => {
+    if (paymentMethod !== 'CREDIT_CARD') {
+      setLastCardDetails(null);
+    }
+  }, [paymentMethod]);
+
+  const selectedCustomer = useMemo(
+    () => customers.find((customer) => customer.id === customerId),
+    [customers, customerId],
+  );
+
+  const formatStatusDate = useCallback((value?: string) => {
+    if (!value) {
+      return null;
+    }
+    try {
+      const parsed = parseISO(value);
+      if (!isValid(parsed)) {
+        return value;
+      }
+      return format(parsed, 'dd/MM/yyyy HH:mm');
+    } catch (error) {
+      return value;
+    }
+  }, []);
+
+  const formatShortDate = useCallback((value?: string | null) => {
+    if (!value) {
+      return null;
+    }
+    try {
+      const parsed = parseISO(value);
+      if (!isValid(parsed)) {
+        return value;
+      }
+      return format(parsed, 'dd/MM/yyyy');
+    } catch (error) {
+      return value;
+    }
+  }, []);
+
+  const chargeDetailsQuery = useQuery({
+    queryKey: ['asaas-charge-details', flow?.id],
+    queryFn: () => (flow ? fetchChargeDetails(flow.id) : Promise.resolve(null)),
+    enabled: Boolean(flow?.id && open),
+    onSuccess: (charge) => {
+      if (charge && flow) {
+        setLastCharge(charge);
+        onChargeCreated(flow.id, charge);
+      }
+    },
+    onError: (error: unknown) => {
+      toast({
+        title: 'Erro ao carregar cobrança',
+        description:
+          error instanceof Error ? error.message : 'Não foi possível carregar os dados da cobrança.',
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const statusQuery = useQuery({
+    queryKey: ['asaas-charge-status', flow?.id],
+    queryFn: () => (flow ? listChargeStatus(flow.id) : Promise.resolve([])),
+    enabled: Boolean(flow?.id && open),
+    onSuccess: (data) => {
+      if (flow) {
+        setStatuses(data);
+        onStatusUpdated(flow.id, data);
+      }
+    },
+    onError: (error: unknown) => {
+      toast({
+        title: 'Erro ao carregar status',
+        description:
+          error instanceof Error ? error.message : 'Não foi possível carregar o status da cobrança.',
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const {
+    data: customerSyncStatus,
+    refetch: refetchCustomerSyncStatus,
+    isFetching: isFetchingCustomerSyncStatus,
+  } = useQuery({
+    queryKey: ['asaas-customer-status', customerId],
+    queryFn: () => (customerId && open ? fetchCustomerSyncStatus(customerId) : Promise.resolve(null)),
+    enabled: Boolean(customerId && open),
+    staleTime: 1000 * 30,
+    onError: (error: unknown) => {
+      toast({
+        title: 'Erro ao carregar status do cliente',
+        description:
+          error instanceof Error ? error.message : 'Não foi possível verificar o status do cliente.',
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const syncMutation = useMutation({
+    mutationFn: async () => {
+      if (!customerId) {
+        throw new Error('Selecione um cliente para sincronizar.');
+      }
+      return syncCustomerNow(customerId);
+    },
+    onSuccess: () => {
+      toast({
+        title: 'Sincronização iniciada',
+        description: 'A sincronização com o Asaas foi solicitada.',
+      });
+      refetchCustomerSyncStatus();
+    },
+    onError: (error: unknown) => {
+      toast({
+        title: 'Erro ao sincronizar cliente',
+        description: error instanceof Error ? error.message : 'Não foi possível iniciar a sincronização.',
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const chargeMutation = useMutation({
+    mutationFn: async (payload: CreateAsaasChargePayload) => {
+      if (!flow) {
+        throw new Error('Fluxo não selecionado.');
+      }
+      return createAsaasCharge(flow.id, payload);
+    },
+    onSuccess: (charge) => {
+      if (!flow) {
+        return;
+      }
+      setLastCharge(charge);
+      onChargeCreated(flow.id, charge);
+      toast({
+        title: 'Cobrança criada com sucesso',
+        description: 'Os dados foram enviados para o Asaas.',
+      });
+      statusQuery.refetch();
+    },
+    onError: (error: unknown) => {
+      toast({
+        title: 'Erro ao criar cobrança',
+        description: error instanceof Error ? error.message : 'Não foi possível criar a cobrança.',
+        variant: 'destructive',
+      });
+    },
+  });
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!flow) {
+      return;
+    }
+
+    if (!customerId) {
+      toast({
+        title: 'Selecione um cliente',
+        description: 'É necessário escolher um cliente para gerar a cobrança.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    const basePayload: CreateAsaasChargePayload = {
+      customerId,
+      paymentMethod,
+      installmentCount: paymentMethod === 'PIX' ? undefined : installments,
+      dueDate: paymentMethod === 'BOLETO' && dueDate ? dueDate : undefined,
+    };
+
+  if (paymentMethod === 'CREDIT_CARD') {
+    setCardModalState({ flow, payload: basePayload });
+    return;
+  }
+
+  setLastCardDetails(null);
+  await chargeMutation.mutateAsync(basePayload);
+};
+
+const handleCardTokenized = async (details: CardTokenDetails) => {
+  if (!cardModalState) {
+    return;
+  }
+
+  await chargeMutation.mutateAsync({
+    ...cardModalState.payload,
+    cardToken: details.token,
+    cardMetadata: {
+      brand: details.brand,
+      last4Digits: details.last4Digits,
+      holderName: details.holderName,
+    },
+    additionalData: {
+      email: details.holderEmail,
+      document: details.document,
+      phone: details.phone,
+      postalCode: details.postalCode,
+      addressNumber: details.addressNumber,
+      addressComplement: details.addressComplement,
+    },
+  });
+  setLastCardDetails(details);
+  setCardModalState(null);
+};
+
+  const handleSyncNow = () => {
+    if (!customerId) {
+      toast({
+        title: 'Selecione um cliente',
+        description: 'Escolha um cliente para sincronizar com o Asaas.',
+        variant: 'destructive',
+      });
+      return;
+    }
+    syncMutation.mutate();
+  };
+
+  const handleCopy = useCallback(
+    async (value: string | undefined) => {
+      if (!value) {
+        toast({
+          title: 'Conteúdo indisponível',
+          description: 'O Asaas ainda não retornou os dados necessários.',
+          variant: 'destructive',
+        });
+        return;
+      }
+      if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+        toast({
+          title: 'Copiar não suportado',
+          description: 'Seu navegador não permite copiar automaticamente.',
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      try {
+        await navigator.clipboard.writeText(value);
+        toast({
+          title: 'Conteúdo copiado',
+          description: 'Cole a informação onde desejar.',
+        });
+      } catch (error) {
+        toast({
+          title: 'Erro ao copiar',
+          description: error instanceof Error ? error.message : 'Não foi possível copiar o conteúdo.',
+          variant: 'destructive',
+        });
+      }
+    },
+    [toast],
+  );
+
+  const handleSendEmail = useCallback(
+    (value: string | undefined) => {
+      if (!value) {
+        toast({
+          title: 'Conteúdo indisponível',
+          description: 'O Asaas ainda não retornou os dados necessários.',
+          variant: 'destructive',
+        });
+        return;
+      }
+      if (!selectedCustomer?.email) {
+        toast({
+          title: 'E-mail não cadastrado',
+          description: 'Cadastre um e-mail para o cliente antes de enviar a cobrança.',
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      const subject = encodeURIComponent(`Cobrança ${flow?.descricao ?? ''}`);
+      const body = encodeURIComponent(
+        [
+          `Olá ${selectedCustomer.label},`,
+          '',
+          `Segue o link/código para pagamento do lançamento "${flow?.descricao ?? ''}" no valor de ${formatCurrency(flow?.valor)}.`,
+          '',
+          value,
+          '',
+          'Qualquer dúvida estamos à disposição.',
+        ].join('\n'),
+      );
+      window.open(`mailto:${selectedCustomer.email}?subject=${subject}&body=${body}`, '_blank');
+      toast({
+        title: 'E-mail preparado',
+        description: 'Utilize o seu cliente de e-mail para finalizar o envio.',
+      });
+    },
+    [selectedCustomer, flow, toast, formatCurrency],
+  );
+
+  const renderCopyActions = (value: string | undefined, copyLabel: string) => (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button type="button" variant="outline" size="sm" className="gap-2" onClick={() => handleCopy(value)}>
+        <Clipboard className="h-4 w-4" />
+        {copyLabel}
+      </Button>
+      <Button type="button" variant="ghost" size="sm" className="gap-2" onClick={() => handleSendEmail(value)}>
+        <Send className="h-4 w-4" />
+        Enviar por e-mail
+      </Button>
+    </div>
+  );
+
+  const renderChargeDetails = () => {
+    if (!lastCharge) {
+      return <p className="text-sm text-muted-foreground">Nenhuma cobrança gerada ainda.</p>;
+    }
+
+    if (lastCharge.paymentMethod === 'PIX') {
+      return (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 rounded-md border px-3 py-2">
+            <QrCode className="h-5 w-5" />
+            <div>
+              <p className="text-sm font-medium">Pagamento via PIX</p>
+              {lastCharge.dueDate ? (
+                <p className="text-xs text-muted-foreground">
+                  Expira em: {formatShortDate(lastCharge.dueDate)}
+                </p>
+              ) : null}
+            </div>
+          </div>
+          {lastCharge.pixPayload ? (
+            <div className="space-y-2 rounded-md border px-3 py-2">
+              <p className="text-sm font-medium">Código copia e cola</p>
+              <p className="break-all text-xs text-muted-foreground">{lastCharge.pixPayload}</p>
+              {renderCopyActions(lastCharge.pixPayload, 'Copiar código')}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              O Asaas ainda está gerando o código PIX para este lançamento.
+            </p>
+          )}
+        </div>
+      );
+    }
+
+    if (lastCharge.paymentMethod === 'BOLETO') {
+      return (
+        <div className="space-y-3">
+          {lastCharge.boletoUrl ? (
+            <div className="space-y-1 rounded-md border px-3 py-2">
+              <p className="text-sm font-medium">Link do boleto</p>
+              <a
+                href={lastCharge.boletoUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="break-all text-sm text-primary"
+              >
+                {lastCharge.boletoUrl}
+              </a>
+              {renderCopyActions(lastCharge.boletoUrl, 'Copiar link')}
+            </div>
+          ) : null}
+          {lastCharge.boletoBarcode ? (
+            <div className="space-y-1 rounded-md border px-3 py-2">
+              <p className="text-sm font-medium">Linha digitável</p>
+              <p className="break-all text-xs text-muted-foreground">{lastCharge.boletoBarcode}</p>
+              {renderCopyActions(lastCharge.boletoBarcode, 'Copiar linha digitável')}
+            </div>
+          ) : null}
+          {!lastCharge.boletoUrl && !lastCharge.boletoBarcode ? (
+            <p className="text-sm text-muted-foreground">Aguardando geração do boleto.</p>
+          ) : null}
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-2 rounded-md border px-3 py-2 text-sm">
+        <p>
+          Status da transação:{' '}
+          <span className="font-semibold">{lastCharge.status ?? 'Pendente'}</span>
+        </p>
+        {lastCharge.cardAuthorizationCode ? (
+          <p>
+            Código de autorização:{' '}
+            <span className="font-mono text-xs">{lastCharge.cardAuthorizationCode}</span>
+          </p>
+        ) : null}
+        {lastCardDetails?.last4Digits ? (
+          <p>
+            Cartão final {lastCardDetails.last4Digits}
+            {lastCardDetails.brand ? ` (${lastCardDetails.brand})` : ''}
+          </p>
+        ) : null}
+      </div>
+    );
+  };
+
+  const syncStatusInfo = isFetchingCustomerSyncStatus
+    ? { label: 'Carregando...', variant: 'outline' as const }
+    : resolveSyncStatusInfo(customerSyncStatus?.status);
+
+  const methodLabels: Record<AsaasPaymentMethod, string> = {
+    PIX: 'PIX',
+    BOLETO: 'Boleto',
+    CREDIT_CARD: 'Cartão de crédito',
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl space-y-6">
+        <DialogHeader>
+          <DialogTitle>Gerar cobrança</DialogTitle>
+          <DialogDescription>
+            Configure o envio da cobrança para o lançamento financeiro selecionado.
+          </DialogDescription>
+        </DialogHeader>
+
+        {flow ? (
+          <>
+            <div className="rounded-md border bg-muted/40 p-4 text-sm">
+              <p className="font-medium">{flow.descricao}</p>
+              <p className="text-muted-foreground">Valor: {formatCurrency(flow.valor)}</p>
+              {flow.vencimento ? (
+                <p className="text-muted-foreground">
+                  Vencimento: {formatShortDate(flow.vencimento) ?? flow.vencimento}
+                </p>
+              ) : (
+                <p className="text-muted-foreground">Sem vencimento definido.</p>
+              )}
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="asaas-customer-select">
+                    Cliente
+                  </label>
+                  <select
+                    id="asaas-customer-select"
+                    value={customerId}
+                    onChange={(event) => setCustomerId(event.target.value)}
+                    className="w-full rounded-md border px-3 py-2 text-sm"
+                    disabled={customersLoading}
+                  >
+                    <option value="">
+                      {customersLoading ? 'Carregando clientes...' : 'Selecione um cliente'}
+                    </option>
+                    {customers.map((customer) => (
+                      <option key={customer.id} value={customer.id}>
+                        {customer.label}
+                      </option>
+                    ))}
+                  </select>
+                  {selectedCustomer?.email ? (
+                    <p className="text-xs text-muted-foreground">E-mail: {selectedCustomer.email}</p>
+                  ) : null}
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="asaas-payment-method">
+                    Método de pagamento
+                  </label>
+                  <select
+                    id="asaas-payment-method"
+                    value={paymentMethod}
+                    onChange={(event) => setPaymentMethod(event.target.value as AsaasPaymentMethod)}
+                    className="w-full rounded-md border px-3 py-2 text-sm"
+                  >
+                    <option value="PIX">PIX</option>
+                    <option value="BOLETO">Boleto</option>
+                    <option value="CREDIT_CARD">Cartão de crédito</option>
+                  </select>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="asaas-installments">
+                    Parcelas / opções
+                  </label>
+                  <select
+                    id="asaas-installments"
+                    value={installments}
+                    onChange={(event) => setInstallments(Number(event.target.value))}
+                    className="w-full rounded-md border px-3 py-2 text-sm"
+                    disabled={paymentMethod === 'PIX'}
+                  >
+                    {DEFAULT_INSTALLMENT_OPTIONS.map((option) => (
+                      <option key={option} value={option}>
+                        {option}x
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {paymentMethod === 'BOLETO' ? (
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium" htmlFor="asaas-boleto-due">
+                      Vencimento do boleto
+                    </label>
+                    <Input
+                      id="asaas-boleto-due"
+                      type="date"
+                      value={dueDate}
+                      onChange={(event) => setDueDate(event.target.value)}
+                    />
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="rounded-md border p-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <p className="text-sm font-medium">Status do cliente no Asaas</p>
+                    {customerSyncStatus?.lastSyncedAt ? (
+                      <p className="text-xs text-muted-foreground">
+                        Última sincronização: {formatStatusDate(customerSyncStatus.lastSyncedAt)}
+                      </p>
+                    ) : (
+                      <p className="text-xs text-muted-foreground">Nenhum histórico de sincronização encontrado.</p>
+                    )}
+                    {customerSyncStatus?.message ? (
+                      <p className="text-xs text-muted-foreground">{customerSyncStatus.message}</p>
+                    ) : null}
+                  </div>
+                  <div className="flex flex-col items-end gap-2">
+                    <Badge variant={syncStatusInfo.variant}>{syncStatusInfo.label}</Badge>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      className="gap-2"
+                      onClick={handleSyncNow}
+                      disabled={!customerId || syncMutation.isPending}
+                    >
+                      {syncMutation.isPending ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <RefreshCcw className="h-3.5 w-3.5" />
+                      )}
+                      {syncMutation.isPending ? 'Sincronizando...' : 'Sincronizar agora'}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+
+              <DialogFooter className="gap-2 sm:justify-end">
+                <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={chargeMutation.isPending}>
+                  Cancelar
+                </Button>
+                <Button type="submit" className="gap-2" disabled={chargeMutation.isPending || customersLoading}>
+                  {paymentMethod === 'CREDIT_CARD' ? (
+                    <>
+                      <CreditCard className="h-4 w-4" /> Prosseguir para cartão
+                    </>
+                  ) : chargeMutation.isPending ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" /> Gerando...
+                    </>
+                  ) : (
+                    'Gerar cobrança'
+                  )}
+                </Button>
+              </DialogFooter>
+            </form>
+
+            <div className="space-y-4 rounded-md border p-4">
+              <div className="flex items-center justify-between gap-2">
+                <h4 className="font-semibold">Detalhes da cobrança</h4>
+                <span className="text-xs text-muted-foreground">
+                  Método selecionado: {methodLabels[lastCharge?.paymentMethod ?? paymentMethod]}
+                </span>
+              </div>
+              {chargeDetailsQuery.isFetching && !lastCharge ? (
+                <p className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" /> Carregando dados da cobrança...
+                </p>
+              ) : (
+                renderChargeDetails()
+              )}
+
+              <div className="space-y-2">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-sm font-medium">Histórico de status</p>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    className="gap-2"
+                    onClick={() => statusQuery.refetch()}
+                    disabled={statusQuery.isFetching}
+                  >
+                    {statusQuery.isFetching ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <RefreshCcw className="h-3.5 w-3.5" />
+                    )}
+                    {statusQuery.isFetching ? 'Atualizando...' : 'Atualizar'}
+                  </Button>
+                </div>
+                {statuses.length > 0 ? (
+                  <ul className="space-y-1 text-sm">
+                    {statuses.map((status) => {
+                      const date = formatStatusDate(status.updatedAt);
+                      return (
+                        <li
+                          key={`${status.status}-${status.updatedAt ?? ''}`}
+                          className="flex items-center justify-between gap-2 rounded border px-2 py-1"
+                        >
+                          <span>{status.status}</span>
+                          {date ? <span className="text-xs text-muted-foreground">{date}</span> : null}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                ) : (
+                  <p className="text-sm text-muted-foreground">Nenhuma atualização registrada até o momento.</p>
+                )}
+              </div>
+            </div>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">Selecione um lançamento para gerar a cobrança.</p>
+        )}
+
+        <CardTokenModal
+          flow={flow}
+          open={Boolean(cardModalState)}
+          onOpenChange={(isOpen) => {
+            if (!isOpen) {
+              setCardModalState(null);
+            }
+          }}
+          onTokenized={handleCardTokenized}
+          isSubmitting={chargeMutation.isPending}
+          installments={installments}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+type CardTokenModalProps = {
+  flow: Flow | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onTokenized: (details: CardTokenDetails) => Promise<void>;
+  isSubmitting: boolean;
+  installments: number;
+};
+
+const CardTokenModal = ({
+  flow,
+  open,
+  onOpenChange,
+  onTokenized,
+  isSubmitting,
+  installments,
+}: CardTokenModalProps) => {
+  const { toast } = useToast();
+  const [form, setForm] = useState<CardFormState>({
+    holderName: '',
+    holderEmail: '',
+    document: '',
+    number: '',
+    expiryMonth: '',
+    expiryYear: '',
+    cvv: '',
+    phone: '',
+    postalCode: '',
+    addressNumber: '',
+    addressComplement: '',
+  });
+  const [errors, setErrors] = useState<CardFormErrors>({});
+  const [isTokenizing, setIsTokenizing] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setForm({
+        holderName: '',
+        holderEmail: '',
+        document: '',
+        number: '',
+        expiryMonth: '',
+        expiryYear: '',
+        cvv: '',
+        phone: '',
+        postalCode: '',
+        addressNumber: '',
+        addressComplement: '',
+      });
+      setErrors({});
+      setIsTokenizing(false);
+    }
+  }, [open]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const validation = validateCardForm(form);
+    setErrors(validation);
+    if (Object.values(validation).some(Boolean)) {
+      toast({
+        title: 'Verifique os dados do cartão',
+        description: 'Preencha todos os campos obrigatórios para continuar.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    const payload: CardTokenPayload = {
+      holderName: form.holderName.trim(),
+      number: sanitizeDigits(form.number),
+      expiryMonth: form.expiryMonth.trim(),
+      expiryYear: form.expiryYear.trim(),
+      cvv: sanitizeDigits(form.cvv),
+      document: sanitizeDigits(form.document),
+      email: form.holderEmail.trim(),
+      phone: sanitizeDigits(form.phone),
+      postalCode: sanitizeDigits(form.postalCode),
+      addressNumber: form.addressNumber.trim(),
+      addressComplement: form.addressComplement.trim() || undefined,
+    };
+
+    try {
+      setIsTokenizing(true);
+      const tokenData: CardTokenResponse = await tokenizeCard(payload);
+      await onTokenized({
+        token: tokenData.token,
+        brand: tokenData.brand,
+        last4Digits: tokenData.last4Digits,
+        holderName: payload.holderName,
+        holderEmail: payload.email,
+        document: payload.document,
+        phone: payload.phone,
+        postalCode: payload.postalCode,
+        addressNumber: payload.addressNumber,
+        addressComplement: payload.addressComplement,
+      });
+      onOpenChange(false);
+      toast({
+        title: 'Cartão validado com sucesso',
+        description: 'O token foi gerado e a cobrança será criada.',
+      });
+    } catch (error) {
+      toast({
+        title: 'Erro ao processar cartão',
+        description: error instanceof Error ? error.message : 'Não foi possível tokenizar o cartão.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsTokenizing(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg space-y-4">
+        <DialogHeader>
+          <DialogTitle>Dados do cartão</DialogTitle>
+          <DialogDescription>
+            Informe os dados do titular para concluir a cobrança do lançamento "{flow?.descricao ?? ''}".
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid gap-3">
+            <Input
+              placeholder="Nome impresso no cartão"
+              value={form.holderName}
+              onChange={(event) => setForm((prev) => ({ ...prev, holderName: event.target.value }))}
+            />
+            {errors.holderName ? <p className="text-xs text-destructive">{errors.holderName}</p> : null}
+
+            <Input
+              type="email"
+              placeholder="E-mail do titular"
+              value={form.holderEmail}
+              onChange={(event) => setForm((prev) => ({ ...prev, holderEmail: event.target.value }))}
+            />
+            {errors.holderEmail ? <p className="text-xs text-destructive">{errors.holderEmail}</p> : null}
+
+            <Input
+              placeholder="CPF/CNPJ"
+              value={form.document}
+              onChange={(event) => setForm((prev) => ({ ...prev, document: event.target.value }))}
+            />
+            {errors.document ? <p className="text-xs text-destructive">{errors.document}</p> : null}
+
+            <Input
+              placeholder="Número do cartão"
+              value={form.number}
+              onChange={(event) => setForm((prev) => ({ ...prev, number: event.target.value }))}
+            />
+            {errors.number ? <p className="text-xs text-destructive">{errors.number}</p> : null}
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div className="space-y-1">
+                <Input
+                  placeholder="Mês"
+                  value={form.expiryMonth}
+                  onChange={(event) => setForm((prev) => ({ ...prev, expiryMonth: event.target.value }))}
+                />
+                {errors.expiryMonth ? <p className="text-xs text-destructive">{errors.expiryMonth}</p> : null}
+              </div>
+              <div className="space-y-1">
+                <Input
+                  placeholder="Ano"
+                  value={form.expiryYear}
+                  onChange={(event) => setForm((prev) => ({ ...prev, expiryYear: event.target.value }))}
+                />
+                {errors.expiryYear ? <p className="text-xs text-destructive">{errors.expiryYear}</p> : null}
+              </div>
+              <div className="space-y-1">
+                <Input
+                  placeholder="CVV"
+                  value={form.cvv}
+                  onChange={(event) => setForm((prev) => ({ ...prev, cvv: event.target.value }))}
+                />
+                {errors.cvv ? <p className="text-xs text-destructive">{errors.cvv}</p> : null}
+              </div>
+            </div>
+
+            <Input
+              placeholder="Telefone"
+              value={form.phone}
+              onChange={(event) => setForm((prev) => ({ ...prev, phone: event.target.value }))}
+            />
+            {errors.phone ? <p className="text-xs text-destructive">{errors.phone}</p> : null}
+
+            <Input
+              placeholder="CEP"
+              value={form.postalCode}
+              onChange={(event) => setForm((prev) => ({ ...prev, postalCode: event.target.value }))}
+            />
+            {errors.postalCode ? <p className="text-xs text-destructive">{errors.postalCode}</p> : null}
+
+            <Input
+              placeholder="Número do endereço"
+              value={form.addressNumber}
+              onChange={(event) => setForm((prev) => ({ ...prev, addressNumber: event.target.value }))}
+            />
+            {errors.addressNumber ? <p className="text-xs text-destructive">{errors.addressNumber}</p> : null}
+
+            <Input
+              placeholder="Complemento"
+              value={form.addressComplement}
+              onChange={(event) => setForm((prev) => ({ ...prev, addressComplement: event.target.value }))}
+            />
+          </div>
+
+          <DialogFooter className="gap-2">
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)} disabled={isTokenizing || isSubmitting}>
+              Cancelar
+            </Button>
+            <Button type="submit" className="gap-2" disabled={isTokenizing || isSubmitting}>
+              {(isTokenizing || isSubmitting) && <Loader2 className="h-4 w-4 animate-spin" />}
+              Confirmar pagamento
+            </Button>
+          </DialogFooter>
+        </form>
+
+        <p className="text-xs text-muted-foreground">
+          O valor será cobrado em {installments} parcela(s) para o lançamento "{flow?.descricao ?? ''}".
+        </p>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/financial/__tests__/AsaasChargeDialog.test.tsx
+++ b/frontend/src/components/financial/__tests__/AsaasChargeDialog.test.tsx
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createAsaasChargeMock = vi.fn();
+const fetchChargeDetailsMock = vi.fn().mockResolvedValue(null);
+const listChargeStatusMock = vi.fn().mockResolvedValue([]);
+const tokenizeCardMock = vi.fn();
+const fetchCustomerSyncStatusMock = vi.fn().mockResolvedValue(null);
+const syncCustomerNowMock = vi.fn().mockResolvedValue(null);
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('@/lib/flows', () => ({
+  createAsaasCharge: (...args: unknown[]) => createAsaasChargeMock(...args),
+  fetchChargeDetails: (...args: unknown[]) => fetchChargeDetailsMock(...args),
+  listChargeStatus: (...args: unknown[]) => listChargeStatusMock(...args),
+  tokenizeCard: (...args: unknown[]) => tokenizeCardMock(...args),
+  fetchCustomerSyncStatus: (...args: unknown[]) => fetchCustomerSyncStatusMock(...args),
+  syncCustomerNow: (...args: unknown[]) => syncCustomerNowMock(...args),
+}));
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { AsaasCharge, Flow } from '@/lib/flows';
+import { AsaasChargeDialog } from '../AsaasChargeDialog';
+
+describe('AsaasChargeDialog', () => {
+  beforeEach(() => {
+    createAsaasChargeMock.mockReset();
+    fetchChargeDetailsMock.mockReset().mockResolvedValue(null);
+    listChargeStatusMock.mockReset().mockResolvedValue([]);
+    tokenizeCardMock.mockReset();
+    fetchCustomerSyncStatusMock.mockReset().mockResolvedValue(null);
+    syncCustomerNowMock.mockReset().mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const flow: Flow = {
+    id: 42,
+    tipo: 'receita',
+    descricao: 'Mensalidade de assessoria',
+    vencimento: '2024-06-15',
+    pagamento: null,
+    valor: 1234.56,
+    status: 'pendente',
+  };
+
+  const customers = [
+    {
+      id: 'customer-1',
+      label: 'Empresa Exemplo',
+      email: 'contato@exemplo.com',
+      document: '12345678901',
+      raw: {},
+    },
+  ];
+
+  const createQueryClient = () =>
+    new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0, staleTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+
+  it('envia a criação de cobrança PIX quando o cliente é selecionado', async () => {
+    const onChargeCreated = vi.fn();
+    const sampleCharge: AsaasCharge = {
+      id: 'charge_pix',
+      paymentMethod: 'PIX',
+      status: 'PENDING',
+      pixPayload: '00020126580014BR.GOV.BCB.PIX0123abc123',
+    };
+
+    createAsaasChargeMock.mockResolvedValueOnce(sampleCharge);
+
+    render(
+      <QueryClientProvider client={createQueryClient()}>
+        <AsaasChargeDialog
+          flow={flow}
+          open
+          onOpenChange={() => {}}
+          customers={customers}
+          customersLoading={false}
+          onChargeCreated={onChargeCreated}
+          onStatusUpdated={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    const user = userEvent.setup();
+
+    await user.selectOptions(screen.getByLabelText('Cliente'), ['customer-1']);
+
+    await user.click(screen.getByRole('button', { name: 'Gerar cobrança' }));
+
+    await waitFor(() => expect(createAsaasChargeMock).toHaveBeenCalledTimes(1));
+    expect(createAsaasChargeMock).toHaveBeenCalledWith(flow.id, {
+      customerId: 'customer-1',
+      paymentMethod: 'PIX',
+      installmentCount: undefined,
+      dueDate: undefined,
+    });
+
+    await waitFor(() => expect(onChargeCreated).toHaveBeenCalledWith(flow.id, sampleCharge));
+  });
+
+  it('tokeniza o cartão antes de criar a cobrança de cartão', async () => {
+    const onChargeCreated = vi.fn();
+
+    const cardCharge: AsaasCharge = {
+      id: 'charge_card',
+      paymentMethod: 'CREDIT_CARD',
+      status: 'AUTHORIZED',
+      cardAuthorizationCode: 'ABC123',
+    };
+
+    tokenizeCardMock.mockResolvedValueOnce({ token: 'tok_123', brand: 'VISA', last4Digits: '4242' });
+    createAsaasChargeMock.mockResolvedValueOnce(cardCharge);
+
+    render(
+      <QueryClientProvider client={createQueryClient()}>
+        <AsaasChargeDialog
+          flow={flow}
+          open
+          onOpenChange={() => {}}
+          customers={customers}
+          customersLoading={false}
+          onChargeCreated={onChargeCreated}
+          onStatusUpdated={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    const user = userEvent.setup();
+
+    await user.selectOptions(screen.getByLabelText('Cliente'), ['customer-1']);
+    await user.selectOptions(screen.getByLabelText('Método de pagamento'), ['CREDIT_CARD']);
+
+    await user.click(screen.getByRole('button', { name: /prosseguir para cartão/i }));
+
+    const modal = await screen.findByRole('dialog', { name: 'Dados do cartão' });
+
+    await user.type(screen.getByPlaceholderText('Nome impresso no cartão'), 'Fulano de Tal');
+    await user.type(screen.getByPlaceholderText('E-mail do titular'), 'fulano@example.com');
+    await user.type(screen.getByPlaceholderText('CPF/CNPJ'), '123.456.789-01');
+    await user.type(screen.getByPlaceholderText('Número do cartão'), '4242 4242 4242 4242');
+    await user.type(screen.getByPlaceholderText('Mês'), '12');
+    await user.type(screen.getByPlaceholderText('Ano'), '34');
+    await user.type(screen.getByPlaceholderText('CVV'), '123');
+    await user.type(screen.getByPlaceholderText('Telefone'), '(11) 90000-0000');
+    await user.type(screen.getByPlaceholderText('CEP'), '01001-000');
+    await user.type(screen.getByPlaceholderText('Número do endereço'), '123');
+    await user.type(screen.getByPlaceholderText('Complemento'), 'Sala 5');
+
+    await user.click(within(modal).getByRole('button', { name: 'Confirmar pagamento' }));
+
+    await waitFor(() => expect(tokenizeCardMock).toHaveBeenCalledTimes(1));
+    expect(tokenizeCardMock).toHaveBeenCalledWith({
+      holderName: 'Fulano de Tal',
+      number: '4242424242424242',
+      expiryMonth: '12',
+      expiryYear: '34',
+      cvv: '123',
+      document: '12345678901',
+      email: 'fulano@example.com',
+      phone: '11900000000',
+      postalCode: '01001000',
+      addressNumber: '123',
+      addressComplement: 'Sala 5',
+    });
+
+    await waitFor(() => expect(createAsaasChargeMock).toHaveBeenCalledTimes(1));
+    expect(createAsaasChargeMock).toHaveBeenCalledWith(
+      flow.id,
+      expect.objectContaining({
+        customerId: 'customer-1',
+        paymentMethod: 'CREDIT_CARD',
+        cardToken: 'tok_123',
+        installmentCount: 1,
+      }),
+    );
+
+    await waitFor(() => expect(onChargeCreated).toHaveBeenCalledWith(flow.id, cardCharge));
+  });
+});

--- a/frontend/src/lib/flows.ts
+++ b/frontend/src/lib/flows.ts
@@ -1,5 +1,60 @@
 import { getApiUrl, joinUrl } from './api';
 
+export type AsaasPaymentMethod = 'PIX' | 'BOLETO' | 'CREDIT_CARD';
+
+export interface CreateAsaasChargePayload {
+  customerId: string;
+  paymentMethod: AsaasPaymentMethod;
+  installmentCount?: number;
+  dueDate?: string;
+  cardToken?: string;
+  cardMetadata?: Record<string, unknown>;
+  additionalData?: Record<string, unknown>;
+}
+
+export interface AsaasCharge {
+  id?: string;
+  flowId?: number;
+  paymentMethod: AsaasPaymentMethod;
+  value?: number;
+  status?: string;
+  dueDate?: string;
+  pixPayload?: string;
+  pixQrCode?: string;
+  boletoUrl?: string;
+  boletoBarcode?: string;
+  cardAuthorizationCode?: string;
+  raw?: unknown;
+}
+
+export interface AsaasChargeStatus {
+  status: string;
+  description?: string;
+  updatedAt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CardTokenPayload {
+  holderName: string;
+  number: string;
+  expiryMonth: string;
+  expiryYear: string;
+  cvv: string;
+  document: string;
+  email: string;
+  phone: string;
+  postalCode: string;
+  addressNumber: string;
+  addressComplement?: string;
+}
+
+export interface CardTokenResponse {
+  token: string;
+  brand?: string;
+  last4Digits?: string;
+  raw?: unknown;
+}
+
 export interface Flow {
   id: number;
   tipo: 'receita' | 'despesa';
@@ -36,4 +91,238 @@ export async function settleFlow(id: number, pagamentoData: string): Promise<Flo
   });
   const data = await res.json();
   return data.flow;
+}
+
+function ensureOkResponse(response: Response): Response {
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  return response;
+}
+
+function extractData<T>(payload: unknown, key: string): T | null {
+  if (payload && typeof payload === 'object' && key in payload) {
+    const value = (payload as Record<string, unknown>)[key];
+    return (value as T) ?? null;
+  }
+  return null;
+}
+
+function normalizePaymentMethod(method: unknown): AsaasPaymentMethod {
+  const normalized = String(method ?? '').toUpperCase();
+  if (normalized === 'PIX' || normalized === 'BOLETO' || normalized === 'CREDIT_CARD') {
+    return normalized;
+  }
+  if (normalized === 'CREDITCARD') {
+    return 'CREDIT_CARD';
+  }
+  if (normalized === 'BOLETO_BANCARIO' || normalized === 'BANK_SLIP') {
+    return 'BOLETO';
+  }
+  return 'PIX';
+}
+
+function normalizeCharge(raw: unknown): AsaasCharge | null {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+
+  const charge = (raw as { [key: string]: unknown }).charge ?? raw;
+  if (!charge || typeof charge !== 'object') {
+    return null;
+  }
+
+  const normalized: AsaasCharge = {
+    id:
+      (charge as { [key: string]: unknown }).id?.toString?.() ??
+      (charge as { [key: string]: unknown }).chargeId?.toString?.() ??
+      (charge as { [key: string]: unknown }).charge_id?.toString?.(),
+    flowId:
+      typeof (charge as { [key: string]: unknown }).flowId === 'number'
+        ? ((charge as { [key: string]: unknown }).flowId as number)
+        : undefined,
+    paymentMethod: normalizePaymentMethod(
+      (charge as { [key: string]: unknown }).paymentMethod ??
+        (charge as { [key: string]: unknown }).payment_method ??
+        (charge as { [key: string]: unknown }).billingType,
+    ),
+    value: Number((charge as { [key: string]: unknown }).value ?? (charge as { [key: string]: unknown }).amount),
+    status: (charge as { [key: string]: unknown }).status as string | undefined,
+    dueDate: (charge as { [key: string]: unknown }).dueDate as string | undefined,
+    pixPayload:
+      (charge as { [key: string]: unknown }).pixPayload as string | undefined ??
+      (charge as { [key: string]: unknown }).payload as string | undefined ??
+      (charge as { [key: string]: unknown }).copyPasteCode as string | undefined,
+    pixQrCode:
+      (charge as { [key: string]: unknown }).pixQrCode as string | undefined ??
+      (charge as { [key: string]: unknown }).encodedImage as string | undefined ??
+      (charge as { [key: string]: unknown }).qrCode as string | undefined,
+    boletoUrl:
+      (charge as { [key: string]: unknown }).bankSlipUrl as string | undefined ??
+      (charge as { [key: string]: unknown }).boletoUrl as string | undefined ??
+      (charge as { [key: string]: unknown }).invoiceUrl as string | undefined,
+    boletoBarcode:
+      (charge as { [key: string]: unknown }).identificationField as string | undefined ??
+      (charge as { [key: string]: unknown }).digitableLine as string | undefined ??
+      (charge as { [key: string]: unknown }).barCode as string | undefined,
+    cardAuthorizationCode:
+      (charge as { [key: string]: unknown }).authorizationCode as string | undefined ??
+      (charge as { [key: string]: unknown }).nsu as string | undefined,
+    raw: charge,
+  };
+
+  return normalized;
+}
+
+function normalizeChargeStatuses(payload: unknown): AsaasChargeStatus[] {
+  if (!payload) return [];
+  const collection = extractData<unknown[]>(payload, 'statuses') ?? extractData<unknown[]>(payload, 'items');
+  const entries = Array.isArray(collection) ? collection : Array.isArray(payload) ? payload : [];
+  return entries
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') return null;
+      const statusValue =
+        (entry as { [key: string]: unknown }).status ??
+        (entry as { [key: string]: unknown }).currentStatus ??
+        (entry as { [key: string]: unknown }).code;
+      if (typeof statusValue !== 'string') return null;
+      return {
+        status: statusValue,
+        description: (entry as { [key: string]: unknown }).description as string | undefined,
+        updatedAt: (entry as { [key: string]: unknown }).updatedAt as string | undefined,
+        metadata: entry as Record<string, unknown>,
+      } satisfies AsaasChargeStatus;
+    })
+    .filter((status): status is AsaasChargeStatus => Boolean(status));
+}
+
+function getChargeEndpoint(flowId: number | string): string {
+  return joinUrl(FLOWS_ENDPOINT, `${flowId}/asaas/charges`);
+}
+
+export async function createAsaasCharge(
+  flowId: number,
+  payload: CreateAsaasChargePayload,
+): Promise<AsaasCharge> {
+  const endpoint = getChargeEndpoint(flowId);
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  const data = await ensureOkResponse(response).json();
+  const charge = normalizeCharge(data);
+  if (!charge) {
+    throw new Error('Resposta inesperada ao criar cobrança');
+  }
+  return charge;
+}
+
+export async function fetchChargeDetails(flowId: number): Promise<AsaasCharge | null> {
+  const endpoint = getChargeEndpoint(flowId);
+  const response = await fetch(endpoint, { method: 'GET' });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  const data = await ensureOkResponse(response).json();
+  return normalizeCharge(data);
+}
+
+export async function listChargeStatus(flowId: number): Promise<AsaasChargeStatus[]> {
+  const endpoint = joinUrl(getChargeEndpoint(flowId), 'status');
+  const response = await fetch(endpoint, { method: 'GET' });
+  if (response.status === 404) {
+    return [];
+  }
+  const payload = await ensureOkResponse(response).json();
+  return normalizeChargeStatuses(payload);
+}
+
+export async function tokenizeCard(payload: CardTokenPayload): Promise<CardTokenResponse> {
+  const endpoint = getApiUrl('asaas/tokenize-card');
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  const data = await ensureOkResponse(response).json();
+  const token =
+    (data as { [key: string]: unknown }).token ??
+    (data as { [key: string]: unknown }).cardToken ??
+    (data as { [key: string]: unknown }).id;
+  if (!token || typeof token !== 'string') {
+    throw new Error('Token do cartão não encontrado na resposta');
+  }
+
+  return {
+    token,
+    brand: (data as { [key: string]: unknown }).brand as string | undefined,
+    last4Digits: (data as { [key: string]: unknown }).last4Digits as string | undefined,
+    raw: data,
+  } satisfies CardTokenResponse;
+}
+
+export interface CustomerSyncStatus {
+  status: string;
+  lastSyncedAt?: string;
+  needsSync?: boolean;
+  message?: string;
+  raw?: unknown;
+}
+
+function normalizeCustomerStatus(payload: unknown): CustomerSyncStatus | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const statusValue =
+    (payload as { [key: string]: unknown }).status ??
+    (payload as { [key: string]: unknown }).syncStatus ??
+    (payload as { [key: string]: unknown }).code;
+
+  if (typeof statusValue !== 'string') {
+    return null;
+  }
+
+  return {
+    status: statusValue,
+    lastSyncedAt: (payload as { [key: string]: unknown }).lastSyncedAt as string | undefined,
+    needsSync: Boolean((payload as { [key: string]: unknown }).needsSync ?? false),
+    message: (payload as { [key: string]: unknown }).message as string | undefined,
+    raw: payload,
+  } satisfies CustomerSyncStatus;
+}
+
+export async function fetchCustomerSyncStatus(customerId: string): Promise<CustomerSyncStatus | null> {
+  const endpoint = getApiUrl(`asaas/customers/status?customerId=${encodeURIComponent(customerId)}`);
+  const response = await fetch(endpoint, { method: 'GET' });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  const data = await ensureOkResponse(response).json();
+  const directStatus = normalizeCustomerStatus(data);
+  if (directStatus) {
+    return directStatus;
+  }
+
+  const statusFromData = extractData<unknown>(data, 'status');
+  return normalizeCustomerStatus(statusFromData);
+}
+
+export async function syncCustomerNow(customerId: string): Promise<CustomerSyncStatus | null> {
+  const endpoint = getApiUrl('asaas/customers/sync');
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ customerId }),
+  });
+  const data = await ensureOkResponse(response).json();
+  const status = normalizeCustomerStatus(data);
+  if (status) {
+    return status;
+  }
+  const nested = extractData<unknown>(data, 'status');
+  return normalizeCustomerStatus(nested);
 }

--- a/frontend/src/pages/FinancialFlows.tsx
+++ b/frontend/src/pages/FinancialFlows.tsx
@@ -10,9 +10,18 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/hooks/use-toast';
 import { getApiUrl } from '@/lib/api';
-import { Info } from 'lucide-react';
+import { Info, AlertCircle } from 'lucide-react';
 import { AsaasChargeDialog } from '@/components/financial/AsaasChargeDialog';
 import type { CustomerOption } from '@/components/financial/AsaasChargeDialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
 
 function normalizeCustomerOption(entry: unknown): CustomerOption | null {
   if (!entry || typeof entry !== 'object') {
@@ -74,7 +83,13 @@ async function fetchCustomersForFlows(): Promise<CustomerOption[]> {
 const FinancialFlows = () => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
-  const { data: flows = [] } = useQuery({ queryKey: ['flows'], queryFn: fetchFlows });
+  const {
+    data: flows = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({ queryKey: ['flows'], queryFn: fetchFlows });
   const {
     data: customers = [],
     isLoading: customersLoading,
@@ -127,6 +142,10 @@ const FinancialFlows = () => {
   };
 
   const [activePeriod, setActivePeriod] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'all' | DerivedStatus>('all');
+  const [typeFilter, setTypeFilter] = useState<'all' | Flow['tipo']>('all');
+  const [onlyOpenCharges, setOnlyOpenCharges] = useState(false);
 
   const currencyFormatter = useMemo(
     () => new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }),
@@ -153,21 +172,19 @@ const FinancialFlows = () => {
     vencido: 'destructive',
   };
 
-  const deriveMonthLabel = (date: Date) => {
+  const deriveMonthLabel = useCallback((date: Date) => {
     const label = format(date, "MMMM 'de' yyyy", { locale: ptBR });
     return label.charAt(0).toUpperCase() + label.slice(1);
-  };
+  }, []);
 
   const formatDayDate = (date: Date | null, fallback?: string) => {
     if (!date || !isValid(date)) return fallback ?? '-';
     return format(date, 'dd/MM/yyyy');
   };
 
-  const periods = useMemo<PeriodGroup[]>(() => {
+  const detailedFlows = useMemo<FlowWithDetails[]>(() => {
     const today = startOfDay(new Date());
-    const accumulator = new Map<string, { key: string; label: string; sortValue: number; flows: FlowWithDetails[] }>();
-
-    flows.forEach((flow) => {
+    return flows.map((flow) => {
       const parsedDueDate = flow.vencimento ? parseISO(flow.vencimento) : null;
       const dueDate = parsedDueDate && isValid(parsedDueDate) ? parsedDueDate : null;
       const parsedPaymentDate = flow.pagamento ? parseISO(flow.pagamento) : null;
@@ -180,20 +197,43 @@ const FinancialFlows = () => {
             ? 'vencido'
             : 'pendente';
 
-      const key = dueDate ? format(dueDate, 'yyyy-MM') : 'sem-data';
-      const sortValue = dueDate ? startOfMonth(dueDate).getTime() : Number.NEGATIVE_INFINITY;
-      const label = dueDate ? deriveMonthLabel(dueDate) : 'Sem vencimento';
+      return {
+        ...flow,
+        computedStatus,
+        dueDate,
+        pagamentoDate,
+      };
+    });
+  }, [flows]);
+
+  const filteredFlows = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    return detailedFlows.filter((flow) => {
+      const matchesSearch =
+        term.length === 0 || flow.descricao.toLowerCase().includes(term);
+      const matchesStatus =
+        statusFilter === 'all' || flow.computedStatus === statusFilter;
+      const matchesType = typeFilter === 'all' || flow.tipo === typeFilter;
+      const matchesOnlyOpen =
+        !onlyOpenCharges || (flow.computedStatus === 'pendente' || flow.computedStatus === 'vencido');
+
+      return matchesSearch && matchesStatus && matchesType && matchesOnlyOpen;
+    });
+  }, [detailedFlows, onlyOpenCharges, searchTerm, statusFilter, typeFilter]);
+
+  const periods = useMemo<PeriodGroup[]>(() => {
+    const accumulator = new Map<string, { key: string; label: string; sortValue: number; flows: FlowWithDetails[] }>();
+
+    filteredFlows.forEach((flow) => {
+      const key = flow.dueDate ? format(flow.dueDate, 'yyyy-MM') : 'sem-data';
+      const sortValue = flow.dueDate ? startOfMonth(flow.dueDate).getTime() : Number.NEGATIVE_INFINITY;
+      const label = flow.dueDate ? deriveMonthLabel(flow.dueDate) : 'Sem vencimento';
 
       if (!accumulator.has(key)) {
         accumulator.set(key, { key, label, sortValue, flows: [] });
       }
 
-      accumulator.get(key)!.flows.push({
-        ...flow,
-        computedStatus,
-        dueDate,
-        pagamentoDate,
-      });
+      accumulator.get(key)!.flows.push(flow);
     });
 
     return Array.from(accumulator.values())
@@ -228,7 +268,36 @@ const FinancialFlows = () => {
         };
       })
       .sort((a, b) => b.sortValue - a.sortValue);
-  }, [flows]);
+  }, [filteredFlows, deriveMonthLabel]);
+
+  const globalTotals = useMemo(() => {
+    const totals = filteredFlows.reduce<PeriodTotals>(
+      (acc, flow) => {
+        if (flow.tipo === 'receita') {
+          acc.receitas += flow.valor;
+        } else {
+          acc.despesas += flow.valor;
+        }
+        acc.status[flow.computedStatus].count += 1;
+        acc.status[flow.computedStatus].value += flow.valor;
+        return acc;
+      },
+      {
+        receitas: 0,
+        despesas: 0,
+        saldo: 0,
+        status: {
+          pendente: { count: 0, value: 0 },
+          pago: { count: 0, value: 0 },
+          vencido: { count: 0, value: 0 },
+        },
+      },
+    );
+    totals.saldo = totals.receitas - totals.despesas;
+    return totals;
+  }, [filteredFlows]);
+
+  const hasAnyFlow = detailedFlows.length > 0;
 
   const safePeriodKey =
     activePeriod && periods.some((period) => period.key === activePeriod)
@@ -272,9 +341,141 @@ const FinancialFlows = () => {
 
   const statusOrder: DerivedStatus[] = ['pendente', 'vencido', 'pago'];
 
+  if (isLoading) {
+    return (
+      <div className="p-6 space-y-6">
+        <div>
+          <Skeleton className="h-9 w-64" />
+          <Skeleton className="mt-2 h-5 w-80" />
+        </div>
+        <Card className="p-6 space-y-4">
+          <Skeleton className="h-6 w-48" />
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <Skeleton key={index} className="h-24 w-full" />
+            ))}
+          </div>
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-64 w-full" />
+        </Card>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="p-6 space-y-6">
+        <div className="flex items-center gap-3 rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-destructive">
+          <AlertCircle className="h-6 w-6" />
+          <div className="space-y-1">
+            <h1 className="text-xl font-semibold">Não foi possível carregar os lançamentos financeiros</h1>
+            <p className="text-sm text-destructive/80">
+              {(error as Error)?.message || 'Ocorreu um erro inesperado ao comunicar com o servidor.'}
+            </p>
+          </div>
+          <Button variant="outline" onClick={() => refetch()}>
+            Tentar novamente
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="p-6 space-y-6">
-      <h1 className="text-3xl font-bold">Lançamentos Financeiros</h1>
+      <div>
+        <h1 className="text-3xl font-bold">Lançamentos Financeiros</h1>
+        <p className="mt-2 text-muted-foreground">
+          Visualize todas as cobranças emitidas para os clientes, acompanhe a situação de pagamento e mantenha o controle do
+          fluxo de caixa da empresa.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card className="p-4">
+          <p className="text-sm text-muted-foreground">Saldo filtrado</p>
+          <p className="text-2xl font-bold">{formatCurrency(globalTotals.saldo)}</p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-sm text-muted-foreground">Receitas</p>
+          <p className="text-2xl font-bold">{formatCurrency(globalTotals.receitas)}</p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-sm text-muted-foreground">Despesas</p>
+          <p className="text-2xl font-bold">{formatCurrency(globalTotals.despesas)}</p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-sm text-muted-foreground">Cobranças em aberto</p>
+          <p className="text-2xl font-bold">
+            {formatCurrency(globalTotals.status.pendente.value + globalTotals.status.vencido.value)}
+          </p>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        {statusOrder.map((status) => (
+          <Card key={status} className="p-4 space-y-1">
+            <div className="flex items-center justify-between text-sm text-muted-foreground">
+              <span>{statusLabels[status]}</span>
+              <Badge variant="outline">{globalTotals.status[status].count}</Badge>
+            </div>
+            <p className="text-lg font-semibold">{formatCurrency(globalTotals.status[status].value)}</p>
+          </Card>
+        ))}
+      </div>
+
+      <Card className="p-4">
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-muted-foreground">Buscar cobranças</label>
+            <Input
+              placeholder="Busque por descrição ou palavra-chave"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-muted-foreground">Situação</label>
+            <Select value={statusFilter} onValueChange={(value) => setStatusFilter(value as 'all' | DerivedStatus)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Todas as situações" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Todas</SelectItem>
+                <SelectItem value="pendente">Pendentes</SelectItem>
+                <SelectItem value="vencido">Vencidos</SelectItem>
+                <SelectItem value="pago">Pagos</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-muted-foreground">Tipo de lançamento</label>
+            <Select value={typeFilter} onValueChange={(value) => setTypeFilter(value as 'all' | Flow['tipo'])}>
+              <SelectTrigger>
+                <SelectValue placeholder="Todos os tipos" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Todos</SelectItem>
+                <SelectItem value="receita">Receitas</SelectItem>
+                <SelectItem value="despesa">Despesas</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-muted-foreground">Apenas cobranças em aberto</label>
+            <div className="flex h-10 items-center gap-3 rounded-md border border-input px-3">
+              <Checkbox
+                id="only-open"
+                checked={onlyOpenCharges}
+                onCheckedChange={(checked) => setOnlyOpenCharges(Boolean(checked))}
+              />
+              <label htmlFor="only-open" className="text-sm text-muted-foreground">
+                Mostrar pendentes e vencidas
+              </label>
+            </div>
+          </div>
+        </div>
+      </Card>
 
       <form
         onSubmit={(e) => {
@@ -438,7 +639,9 @@ const FinancialFlows = () => {
         </Tabs>
       ) : (
         <Card className="p-6 text-center text-muted-foreground">
-          Nenhum lançamento financeiro cadastrado até o momento.
+          {hasAnyFlow
+            ? 'Nenhum lançamento atende aos filtros selecionados. Ajuste os filtros para visualizar outras cobranças.'
+            : 'Nenhum lançamento financeiro cadastrado até o momento.'}
         </Card>
       )}
 

--- a/frontend/src/test/setupTests.ts
+++ b/frontend/src/test/setupTests.ts
@@ -1,0 +1,9 @@
+import '@testing-library/jest-dom/vitest';
+
+// Mock clipboard for tests that rely on copy actions
+if (typeof navigator !== 'undefined' && !navigator.clipboard) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (navigator as any).clipboard = {
+    writeText: async () => {},
+  };
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,4 +15,10 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: [path.resolve(__dirname, "./src/test/setupTests.ts")],
+    css: true,
+  },
 }));


### PR DESCRIPTION
## Summary
- extend the flows client with helpers for tokenizing cards, creating charges, listing statuses and syncing customers
- refactor the financial flows page to surface the new Asaas dialog, customer data and stored charge summaries
- add the Asaas charge dialog, supporting card token capture, PIX/boleto outputs, sync controls and component tests via Vitest

## Testing
- `npm run lint`
- `npm test -- --runInBand` *(fails: `vitest` binary missing because npm install cannot fetch @testing-library/jest-dom in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf12285de083269c71821952f2885a