### PR TITLE
Fix financial flows query typing

### DIFF
--- a/backend/tests/financialController.test.ts
+++ b/backend/tests/financialController.test.ts
@@ -58,6 +58,8 @@ test('listFlows combines financial and opportunity flows', async () => {
   const financialRow = {
     id: 10,
     tipo: 'despesa',
+    conta_id: 7,
+    categoria_id: 3,
     descricao: 'Conta de luz',
     valor: 100.5,
     vencimento: new Date('2024-01-10T00:00:00.000Z'),
@@ -68,6 +70,8 @@ test('listFlows combines financial and opportunity flows', async () => {
   const oportunidadeRow = {
     id: -20,
     tipo: 'receita',
+    conta_id: null,
+    categoria_id: null,
     descricao: 'Oportunidade 5 - Cliente Teste - Parcela 1/2',
     valor: '250.00',
     vencimento: '2024-02-15',
@@ -101,6 +105,8 @@ test('listFlows combines financial and opportunity flows', async () => {
       {
         id: 10,
         tipo: 'despesa',
+        conta_id: 7,
+        categoria_id: 3,
         descricao: 'Conta de luz',
         valor: 100.5,
         vencimento: '2024-01-10',
@@ -110,6 +116,8 @@ test('listFlows combines financial and opportunity flows', async () => {
       {
         id: -20,
         tipo: 'receita',
+        conta_id: null,
+        categoria_id: null,
         descricao: 'Oportunidade 5 - Cliente Teste - Parcela 1/2',
         valor: 250,
         vencimento: '2024-02-15',


### PR DESCRIPTION
## Summary
- guard query parameters parsing in financialController to avoid invalid casts
- include account and category identifiers when combining opportunity flows with financial flows
- adjust financial controller tests to cover the new fields

## Testing
- npm --prefix backend run build
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68cf2f58c0f083268cbb025d87381902