### PR TITLE
Normalize financial flow IDs to text

### DIFF
--- a/backend/tests/financialController.test.ts
+++ b/backend/tests/financialController.test.ts
@@ -209,8 +209,8 @@ test('listFlows applies cliente filter when provided', async () => {
   );
   assert.equal(calls[0]?.values, undefined);
   assert.match(calls[1]?.text ?? '', /WHERE combined_flows\.cliente_id = \$1/);
-  assert.deepEqual(calls[1]?.values, [42, 10, 0]);
-  assert.deepEqual(calls[2]?.values, [42]);
+  assert.deepEqual(calls[1]?.values, ['42', 10, 0]);
+  assert.deepEqual(calls[2]?.values, ['42']);
 });
 
 test('listFlows returns only financial flows when opportunity tables are absent', async () => {


### PR DESCRIPTION
## Summary
- cast financial and opportunity flow IDs to text before combining the flows CTE
- normalize returned IDs from the list flows query to handle text values
- update financial controller tests to reflect string-valued filters

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf3f07d7e88326b2a2c5ca54e6fb02