### PR TITLE
feat: allow selecting specific installment when billing opportunity

### DIFF
--- a/backend/dist/routes/oportunidadeRoutes.js
+++ b/backend/dist/routes/oportunidadeRoutes.js
@@ -294,6 +294,11 @@ router.get('/oportunidades/:id/faturamentos', oportunidadeController_1.listOport
  *                 type: number
  *               parcelas:
  *                 type: integer
+ *               parcelas_ids:
+ *                 type: array
+ *                 items:
+ *                   type: integer
+ *                 description: Lista opcional de IDs de parcelas pendentes para atualizar como quitadas.
  *               observacoes:
  *                 type: string
  *               data_faturamento:

--- a/backend/src/routes/oportunidadeRoutes.ts
+++ b/backend/src/routes/oportunidadeRoutes.ts
@@ -314,6 +314,11 @@ router.get('/oportunidades/:id/faturamentos', listOportunidadeFaturamentos);
  *                 type: number
  *               parcelas:
  *                 type: integer
+ *               parcelas_ids:
+ *                 type: array
+ *                 items:
+ *                   type: integer
+ *                 description: Lista opcional de IDs de parcelas pendentes para atualizar como quitadas.
  *               observacoes:
  *                 type: string
  *               data_faturamento:


### PR DESCRIPTION
## Summary
- update the billing modal so users can select a specific pending installment to invoice and automatically reflect its value
- send selected installment identifiers when confirming the billing flow and surface validation feedback in the UI
- extend the backend billing endpoint to accept explicit installment IDs, mark only those as paid, and document the new payload field

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf69167e508326b62d4dc0f048f7a5