### PR TITLE
Handle null rowCount when fetching empresa address

### DIFF
--- a/backend/src/controllers/oportunidadeDocumentoController.ts
+++ b/backend/src/controllers/oportunidadeDocumentoController.ts
@@ -404,7 +404,7 @@ async function fetchEmpresaEndereco(empresaId: number | null): Promise<EmpresaAd
         throw error;
       });
 
-    if (result && result.rowCount > 0) {
+    if (result && (result.rowCount ?? 0) > 0) {
       return result.rows[0];
     }
   }


### PR DESCRIPTION
## Summary
- guard against null rowCount values when fetching empresa address data

## Testing
- npm --prefix backend run build

------
https://chatgpt.com/codex/tasks/task_e_68cf7ca06848832684993e06e65385b0