### PR TITLE
Restrict financial data by company and tag opportunity installments

### DIFF
--- a/backend/src/controllers/oportunidadeController.ts
+++ b/backend/src/controllers/oportunidadeController.ts
@@ -247,6 +247,7 @@ const resetOpportunityInstallments = async (
   client: PoolClient,
   oportunidadeId: number,
   installments: InstallmentEntry[],
+  empresaId: number | null,
 ) => {
   await client.query('DELETE FROM public.oportunidade_parcelas WHERE oportunidade_id = $1', [
     oportunidadeId,
@@ -256,14 +257,16 @@ const resetOpportunityInstallments = async (
     return;
   }
 
+  const empresaValue = empresaId ?? null;
+
   for (let index = 0; index < installments.length; index += 1) {
     const installment = installments[index];
     const dueDateParam =
       installment.dataPrevista !== null ? formatDateOnly(installment.dataPrevista) : null;
     await client.query(
-      `INSERT INTO public.oportunidade_parcelas (oportunidade_id, numero_parcela, valor, data_prevista)
-       VALUES ($1, $2, $3, $4)`,
-      [oportunidadeId, index + 1, installment.valor, dueDateParam],
+      `INSERT INTO public.oportunidade_parcelas (oportunidade_id, numero_parcela, valor, data_prevista, idempresa)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [oportunidadeId, index + 1, installment.valor, dueDateParam, empresaValue],
     );
   }
 };
@@ -275,11 +278,12 @@ const createOrReplaceOpportunityInstallments = async (
   formaPagamento: unknown,
   qtdeParcelas: unknown,
   prazoProximo: unknown,
+  empresaId: number | null,
 ) => {
   const normalizedPayment = normalizePaymentLabel(formaPagamento);
   const honorarios = normalizeDecimal(valorHonorarios);
   if (!honorarios || honorarios <= 0 || !shouldCreateInstallments(normalizedPayment)) {
-    await resetOpportunityInstallments(client, oportunidadeId, []);
+    await resetOpportunityInstallments(client, oportunidadeId, [], empresaId);
     return;
   }
 
@@ -300,7 +304,7 @@ const createOrReplaceOpportunityInstallments = async (
     valor,
     dataPrevista: dueDates[index] ?? null,
   }));
-  await resetOpportunityInstallments(client, oportunidadeId, installments);
+  await resetOpportunityInstallments(client, oportunidadeId, installments, empresaId);
 };
 
 const ensureOpportunityInstallments = async (
@@ -310,6 +314,7 @@ const ensureOpportunityInstallments = async (
   formaPagamento: unknown,
   qtdeParcelas: unknown,
   prazoProximo: unknown,
+  empresaId: number | null,
 ) => {
   const existing = await client.query(
     'SELECT id FROM public.oportunidade_parcelas WHERE oportunidade_id = $1 LIMIT 1',
@@ -325,6 +330,7 @@ const ensureOpportunityInstallments = async (
     formaPagamento,
     qtdeParcelas,
     prazoProximo,
+    empresaId,
   );
 };
 
@@ -620,6 +626,7 @@ export const createOportunidade = async (req: Request, res: Response) => {
       forma_pagamento,
       qtde_parcelas,
       prazo_proximo,
+      empresaId,
     );
     await client.query('COMMIT');
     res.status(201).json(oportunidade);
@@ -699,7 +706,7 @@ export const updateOportunidade = async (req: Request, res: Response) => {
        RETURNING id, tipo_processo_id, area_atuacao_id, responsavel_id, numero_processo_cnj, numero_protocolo,
                  vara_ou_orgao, comarca, fase_id, etapa_id, prazo_proximo, status_id, solicitante_id,
                  valor_causa, valor_honorarios, percentual_honorarios, forma_pagamento, qtde_parcelas, contingenciamento,
-                 detalhes, documentos_anexados, criado_por, sequencial_empresa, data_criacao, ultima_atualizacao`,
+                 detalhes, documentos_anexados, criado_por, sequencial_empresa, data_criacao, ultima_atualizacao, idempresa`,
       [
         tipo_processo_id,
         area_atuacao_id,
@@ -765,6 +772,7 @@ export const updateOportunidade = async (req: Request, res: Response) => {
       forma_pagamento,
       qtde_parcelas,
       prazo_proximo,
+      typeof oportunidade.idempresa === 'number' ? oportunidade.idempresa : null,
     );
 
     await client.query('COMMIT');
@@ -1041,7 +1049,7 @@ export const createOportunidadeFaturamento = async (
     await client.query('BEGIN');
 
     const opportunityResult = await client.query(
-      `SELECT id, forma_pagamento, qtde_parcelas, valor_honorarios, prazo_proximo
+      `SELECT id, forma_pagamento, qtde_parcelas, valor_honorarios, prazo_proximo, idempresa
          FROM public.oportunidades
         WHERE id = $1`,
       [id],
@@ -1061,6 +1069,7 @@ export const createOportunidadeFaturamento = async (
       opportunity.forma_pagamento,
       opportunity.qtde_parcelas,
       opportunity.prazo_proximo,
+      typeof opportunity.idempresa === 'number' ? opportunity.idempresa : null,
     );
 
     const installmentsResult = await client.query(

--- a/backend/tests/financialController.test.ts
+++ b/backend/tests/financialController.test.ts
@@ -11,6 +11,12 @@ type QueryResponse = { rows: any[]; rowCount: number };
 let listFlows: typeof import('../src/controllers/financialController')['listFlows'];
 let __internal: typeof import('../src/controllers/financialController')['__internal'];
 
+const DEFAULT_EMPRESA_ID = 123;
+const empresaLookupResponse: QueryResponse = {
+  rows: [{ empresa: DEFAULT_EMPRESA_ID }],
+  rowCount: 1,
+};
+
 test.before(async () => {
   ({ listFlows, __internal } = await import('../src/controllers/financialController'));
 });
@@ -98,6 +104,7 @@ test('listFlows combines financial and opportunity flows', async () => {
   };
 
   const { calls, restore } = setupQueryMock([
+    empresaLookupResponse,
     { rows: [tablesRow], rowCount: 1 },
     { rows: [financialRow, oportunidadeRow], rowCount: 2 },
     { rows: [{ total: 2 }], rowCount: 1 },
@@ -108,6 +115,7 @@ test('listFlows combines financial and opportunity flows', async () => {
       page: '2',
       limit: '1',
     },
+    auth: { userId: 10 },
   } as unknown as Request;
 
   const res = createMockResponse();
@@ -149,26 +157,31 @@ test('listFlows combines financial and opportunity flows', async () => {
     limit: 1,
   });
 
-  assert.equal(calls.length, 3);
+  assert.equal(calls.length, 4);
+  assert.match(calls[0]?.text ?? '', /FROM public\.usuarios WHERE id = \$1/);
+  assert.deepEqual(calls[0]?.values, [10]);
   assert.match(
-    calls[0]?.text ?? '',
+    calls[1]?.text ?? '',
     /to_regclass\('public\.oportunidade_parcelas'\)/,
   );
   assert.match(
-    calls[0]?.text ?? '',
+    calls[1]?.text ?? '',
     /has_table_privilege\(parcelas, 'SELECT'\)/,
   );
 
-  assert.equal(calls[0]?.values, undefined);
-  assert.match(calls[1]?.text ?? '', /WITH oportunidade_parcelas_enriched AS/);
-  assert.match(calls[1]?.text ?? '', /ff\.id::TEXT AS id/);
-  assert.match(calls[1]?.text ?? '', /ff\.conta_id::TEXT AS conta_id/);
-  assert.match(calls[1]?.text ?? '', /ff\.categoria_id::TEXT AS categoria_id/);
-  assert.match(calls[1]?.text ?? '', /\(-p\.id\)::TEXT AS id/);
-  assert.match(calls[1]?.text ?? '', /NULL::TEXT AS conta_id/);
-  assert.match(calls[1]?.text ?? '', /NULL::TEXT AS categoria_id/);
-  assert.deepEqual(calls[1]?.values, [1, 1]);
-  assert.deepEqual(calls[2]?.values, []);
+  assert.equal(calls[1]?.values, undefined);
+  assert.match(calls[2]?.text ?? '', /WITH oportunidade_parcelas_enriched AS/);
+  assert.match(calls[2]?.text ?? '', /ff\.id::TEXT AS id/);
+  assert.match(calls[2]?.text ?? '', /ff\.conta_id::TEXT AS conta_id/);
+  assert.match(calls[2]?.text ?? '', /ff\.categoria_id::TEXT AS categoria_id/);
+  assert.match(calls[2]?.text ?? '', /ff\.idempresa AS empresa_id/);
+  assert.match(calls[2]?.text ?? '', /\(-p\.id\)::TEXT AS id/);
+  assert.match(calls[2]?.text ?? '', /NULL::TEXT AS conta_id/);
+  assert.match(calls[2]?.text ?? '', /NULL::TEXT AS categoria_id/);
+  assert.match(calls[2]?.text ?? '', /p\.idempresa AS empresa_id/);
+  assert.match(calls[2]?.text ?? '', /WHERE combined_flows\.empresa_id = \$1/);
+  assert.deepEqual(calls[2]?.values, [DEFAULT_EMPRESA_ID, 1, 1]);
+  assert.deepEqual(calls[3]?.values, [DEFAULT_EMPRESA_ID]);
 });
 
 test('listFlows preserves textual identifiers returned by the database', async () => {
@@ -194,12 +207,13 @@ test('listFlows preserves textual identifiers returned by the database', async (
   };
 
   const { calls, restore } = setupQueryMock([
+    empresaLookupResponse,
     { rows: [tablesRow], rowCount: 1 },
     { rows: [financialRow], rowCount: 1 },
     { rows: [{ total: 1 }], rowCount: 1 },
   ]);
 
-  const req = { query: {} } as unknown as Request;
+  const req = { query: {}, auth: { userId: 5 } } as unknown as Request;
   const res = createMockResponse();
 
   try {
@@ -228,10 +242,14 @@ test('listFlows preserves textual identifiers returned by the database', async (
     limit: 10,
   });
 
-  assert.equal(calls.length, 3);
-  assert.match(calls[1]?.text ?? '', /WITH combined_flows AS \(/);
-  assert.deepEqual(calls[1]?.values, [10, 0]);
-  assert.deepEqual(calls[2]?.values, []);
+  assert.equal(calls.length, 4);
+  assert.match(calls[0]?.text ?? '', /FROM public\.usuarios WHERE id = \$1/);
+  assert.deepEqual(calls[0]?.values, [5]);
+  assert.match(calls[1]?.text ?? '', /to_regclass\('public\.oportunidade_parcelas'\)/);
+  assert.deepEqual(calls[1]?.values, undefined);
+  assert.match(calls[2]?.text ?? '', /WITH combined_flows AS \(/);
+  assert.deepEqual(calls[2]?.values, [DEFAULT_EMPRESA_ID, 10, 0]);
+  assert.deepEqual(calls[3]?.values, [DEFAULT_EMPRESA_ID]);
 });
 
 test('listFlows applies cliente filter when provided', async () => {
@@ -244,6 +262,7 @@ test('listFlows applies cliente filter when provided', async () => {
   };
 
   const { calls, restore } = setupQueryMock([
+    empresaLookupResponse,
     { rows: [tablesRow], rowCount: 1 },
     { rows: [], rowCount: 0 },
     { rows: [{ total: 0 }], rowCount: 1 },
@@ -253,6 +272,7 @@ test('listFlows applies cliente filter when provided', async () => {
     query: {
       clienteId: '42',
     },
+    auth: { userId: 8 },
   } as unknown as Request;
 
   const res = createMockResponse();
@@ -271,15 +291,20 @@ test('listFlows applies cliente filter when provided', async () => {
     limit: 10,
   });
 
-  assert.equal(calls.length, 3);
+  assert.equal(calls.length, 4);
+  assert.match(calls[0]?.text ?? '', /FROM public\.usuarios WHERE id = \$1/);
+  assert.deepEqual(calls[0]?.values, [8]);
   assert.match(
-    calls[0]?.text ?? '',
+    calls[1]?.text ?? '',
     /to_regclass\('public\.oportunidade_parcelas'\)/,
   );
-  assert.equal(calls[0]?.values, undefined);
-  assert.match(calls[1]?.text ?? '', /WHERE combined_flows\.cliente_id = \$1/);
-  assert.deepEqual(calls[1]?.values, ['42', 10, 0]);
-  assert.deepEqual(calls[2]?.values, ['42']);
+  assert.equal(calls[1]?.values, undefined);
+  assert.match(
+    calls[2]?.text ?? '',
+    /WHERE combined_flows\.empresa_id = \$1 AND combined_flows\.cliente_id = \$2/,
+  );
+  assert.deepEqual(calls[2]?.values, [DEFAULT_EMPRESA_ID, '42', 10, 0]);
+  assert.deepEqual(calls[3]?.values, [DEFAULT_EMPRESA_ID, '42']);
 });
 
 test('listFlows returns only financial flows when opportunity tables are absent', async () => {
@@ -304,12 +329,13 @@ test('listFlows returns only financial flows when opportunity tables are absent'
   };
 
   const { calls, restore } = setupQueryMock([
+    empresaLookupResponse,
     { rows: [tablesRow], rowCount: 1 },
     { rows: [financialRow], rowCount: 1 },
     { rows: [{ total: 1 }], rowCount: 1 },
   ]);
 
-  const req = { query: {} } as unknown as Request;
+  const req = { query: {}, auth: { userId: 4 } } as unknown as Request;
   const res = createMockResponse();
 
   try {
@@ -338,11 +364,15 @@ test('listFlows returns only financial flows when opportunity tables are absent'
     limit: 10,
   });
 
-  assert.equal(calls.length, 3);
-  assert.match(calls[1]?.text ?? '', /WITH combined_flows AS \(/);
-  assert.doesNotMatch(calls[1]?.text ?? '', /UNION ALL/);
-  assert.deepEqual(calls[1]?.values, [10, 0]);
-  assert.deepEqual(calls[2]?.values, []);
+  assert.equal(calls.length, 4);
+  assert.match(calls[0]?.text ?? '', /FROM public\.usuarios WHERE id = \$1/);
+  assert.deepEqual(calls[0]?.values, [4]);
+  assert.match(calls[1]?.text ?? '', /to_regclass\('public\.oportunidade_parcelas'\)/);
+  assert.deepEqual(calls[1]?.values, undefined);
+  assert.match(calls[2]?.text ?? '', /WITH combined_flows AS \(/);
+  assert.doesNotMatch(calls[2]?.text ?? '', /UNION ALL/);
+  assert.deepEqual(calls[2]?.values, [DEFAULT_EMPRESA_ID, 10, 0]);
+  assert.deepEqual(calls[3]?.values, [DEFAULT_EMPRESA_ID]);
 });
 
 test('listFlows retries without opportunity tables when union query fails', async () => {
@@ -372,13 +402,14 @@ test('listFlows retries without opportunity tables when union query fails', asyn
   );
 
   const { calls, restore } = setupQueryMock([
+    empresaLookupResponse,
     { rows: [tablesRow], rowCount: 1 },
     missingTableError,
     { rows: [financialRow], rowCount: 1 },
     { rows: [{ total: 1 }], rowCount: 1 },
   ]);
 
-  const req = { query: {} } as unknown as Request;
+  const req = { query: {}, auth: { userId: 6 } } as unknown as Request;
   const res = createMockResponse();
 
   try {
@@ -407,12 +438,17 @@ test('listFlows retries without opportunity tables when union query fails', asyn
     limit: 10,
   });
 
-  assert.equal(calls.length, 4);
-  assert.match(calls[1]?.text ?? '', /WITH oportunidade_parcelas_enriched AS/);
-  assert.match(calls[2]?.text ?? '', /WITH combined_flows AS \(/);
-  assert.doesNotMatch(calls[2]?.text ?? '', /UNION ALL/);
-  assert.deepEqual(calls[2]?.values, [10, 0]);
-  assert.deepEqual(calls[3]?.values, []);
+  assert.equal(calls.length, 5);
+  assert.match(calls[0]?.text ?? '', /FROM public\.usuarios WHERE id = \$1/);
+  assert.deepEqual(calls[0]?.values, [6]);
+  assert.match(calls[1]?.text ?? '', /to_regclass\('public\.oportunidade_parcelas'\)/);
+  assert.deepEqual(calls[1]?.values, undefined);
+  assert.match(calls[2]?.text ?? '', /WITH oportunidade_parcelas_enriched AS/);
+  assert.deepEqual(calls[2]?.values, [DEFAULT_EMPRESA_ID, 10, 0]);
+  assert.match(calls[3]?.text ?? '', /WITH combined_flows AS \(/);
+  assert.doesNotMatch(calls[3]?.text ?? '', /UNION ALL/);
+  assert.deepEqual(calls[3]?.values, [DEFAULT_EMPRESA_ID, 10, 0]);
+  assert.deepEqual(calls[4]?.values, [DEFAULT_EMPRESA_ID]);
 });
 
 test('listFlows retries without opportunity tables when privileges are missing', async () => {
@@ -441,13 +477,14 @@ test('listFlows retries without opportunity tables when privileges are missing',
   );
 
   const { calls, restore } = setupQueryMock([
+    empresaLookupResponse,
     { rows: [tablesRow], rowCount: 1 },
     insufficientPrivilegeError,
     { rows: [financialRow], rowCount: 1 },
     { rows: [{ total: 1 }], rowCount: 1 },
   ]);
 
-  const req = { query: {} } as unknown as Request;
+  const req = { query: {}, auth: { userId: 7 } } as unknown as Request;
   const res = createMockResponse();
 
   try {
@@ -476,11 +513,16 @@ test('listFlows retries without opportunity tables when privileges are missing',
     limit: 10,
   });
 
-  assert.equal(calls.length, 4);
-  assert.match(calls[1]?.text ?? '', /WITH oportunidade_parcelas_enriched AS/);
-  assert.match(calls[2]?.text ?? '', /WITH combined_flows AS \(/);
-  assert.doesNotMatch(calls[2]?.text ?? '', /UNION ALL/);
-  assert.deepEqual(calls[2]?.values, [10, 0]);
-  assert.deepEqual(calls[3]?.values, []);
+  assert.equal(calls.length, 5);
+  assert.match(calls[0]?.text ?? '', /FROM public\.usuarios WHERE id = \$1/);
+  assert.deepEqual(calls[0]?.values, [7]);
+  assert.match(calls[1]?.text ?? '', /to_regclass\('public\.oportunidade_parcelas'\)/);
+  assert.deepEqual(calls[1]?.values, undefined);
+  assert.match(calls[2]?.text ?? '', /WITH oportunidade_parcelas_enriched AS/);
+  assert.deepEqual(calls[2]?.values, [DEFAULT_EMPRESA_ID, 10, 0]);
+  assert.match(calls[3]?.text ?? '', /WITH combined_flows AS \(/);
+  assert.doesNotMatch(calls[3]?.text ?? '', /UNION ALL/);
+  assert.deepEqual(calls[3]?.values, [DEFAULT_EMPRESA_ID, 10, 0]);
+  assert.deepEqual(calls[4]?.values, [DEFAULT_EMPRESA_ID]);
 
 });

--- a/backend/tests/oportunidadeController.test.ts
+++ b/backend/tests/oportunidadeController.test.ts
@@ -29,6 +29,7 @@ test('createOrReplaceOpportunityInstallments replaces installments when editing'
     'Pagamento Parcelado',
     3,
     '2024-05-10',
+    123,
   );
 
   await createOrReplaceOpportunityInstallments(
@@ -38,6 +39,7 @@ test('createOrReplaceOpportunityInstallments replaces installments when editing'
     'À vista',
     1,
     '2024-08-01',
+    123,
   );
 
   const deleteCalls = client.calls.filter((call) =>
@@ -51,16 +53,16 @@ test('createOrReplaceOpportunityInstallments replaces installments when editing'
   assert.equal(insertCalls.length, 4);
 
   const firstInsert = insertCalls[0];
-  assert.deepEqual(firstInsert?.values, [10, 1, 400, '2024-05-10']);
+  assert.deepEqual(firstInsert?.values, [10, 1, 400, '2024-05-10', 123]);
 
   const secondInsert = insertCalls[1];
-  assert.deepEqual(secondInsert?.values, [10, 2, 400, '2024-06-10']);
+  assert.deepEqual(secondInsert?.values, [10, 2, 400, '2024-06-10', 123]);
 
   const thirdInsert = insertCalls[2];
-  assert.deepEqual(thirdInsert?.values, [10, 3, 400, '2024-07-10']);
+  assert.deepEqual(thirdInsert?.values, [10, 3, 400, '2024-07-10', 123]);
 
   const lastInsert = insertCalls[insertCalls.length - 1];
-  assert.deepEqual(lastInsert?.values, [10, 1, 600, '2024-08-01']);
+  assert.deepEqual(lastInsert?.values, [10, 1, 600, '2024-08-01', 123]);
 
   const deleteIndexes = deleteCalls.map((call) => client.calls.indexOf(call));
   assert.equal(deleteIndexes[0], 0);
@@ -84,6 +86,7 @@ test('createOrReplaceOpportunityInstallments keeps day when month is shorter', a
     'Pagamento Parcelado',
     2,
     '2024-01-31',
+    null,
   );
 
   const insertCalls = client.calls.filter((call) =>
@@ -92,8 +95,8 @@ test('createOrReplaceOpportunityInstallments keeps day when month is shorter', a
   assert.equal(insertCalls.length, 2);
 
   const firstInsert = insertCalls[0];
-  assert.deepEqual(firstInsert?.values, [99, 1, 1000, '2024-01-31']);
+  assert.deepEqual(firstInsert?.values, [99, 1, 1000, '2024-01-31', null]);
 
   const secondInsert = insertCalls[1];
-  assert.deepEqual(secondInsert?.values, [99, 2, 1000, '2024-02-29']);
+  assert.deepEqual(secondInsert?.values, [99, 2, 1000, '2024-02-29', null]);
 });


### PR DESCRIPTION
## Summary
- preenche o campo `idempresa` ao gerar ou garantir parcelas de oportunidade utilizando a empresa do usuário autenticado
- restringe o endpoint de listagem financeira para considerar somente lançamentos da empresa autenticada
- ajusta os testes unitários para cobrir os novos filtros e parâmetros de empresa

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d18fa33db483268e91b26066c3bdca