### PR TITLE
feat: add endpoint to list customer attribute types

### DIFF
--- a/backend/src/routes/clienteAtributoRoutes.ts
+++ b/backend/src/routes/clienteAtributoRoutes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import {
+  listClienteAtributoTipos,
   listClienteAtributos,
   createClienteAtributo,
   updateClienteAtributo,
@@ -32,6 +33,29 @@ const router = Router();
  *           type: string
  *           format: date-time
  */
+
+/**
+ * @swagger
+ * /api/clientes/atributos/tipos:
+ *   get:
+ *     summary: Lista os tipos de atributos de clientes da empresa autenticada
+ *     tags: [ClienteAtributos]
+ *     responses:
+ *       200:
+ *         description: Lista de tipos de atributos disponíveis
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                   nome:
+ *                     type: string
+ */
+router.get('/clientes/atributos/tipos', listClienteAtributoTipos);
 
 /**
  * @swagger


### PR DESCRIPTION
## Summary
- add a controller action that lists customer attribute document types scoped to the authenticated company
- expose a `/api/clientes/atributos/tipos` route and document it in Swagger

## Testing
- npm test *(fails: known financialController listFlows expectations in the existing suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a1cc45988326ae3574da4d8fc314