### PR TITLE
Refine document editor sidebar library

### DIFF
--- a/frontend/src/features/document-editor/api/client-custom-attributes.ts
+++ b/frontend/src/features/document-editor/api/client-custom-attributes.ts
@@ -1,0 +1,127 @@
+import { getApiUrl } from '@/lib/api';
+
+export interface ClientCustomAttributeType {
+  id: string;
+  label: string;
+  value?: string;
+}
+
+const COLLECTION_KEYS = ['data', 'items', 'rows', 'tipos', 'values'];
+const LABEL_KEYS = [
+  'nome',
+  'nome_tipo',
+  'nome_atributo',
+  'descricao',
+  'descricao_tipo',
+  'descricao_atributo',
+  'descricao_tipo_atributo',
+  'descricao_tipodocumento',
+  'descricao_tipo_documento',
+  'titulo',
+  'label',
+  'tipo',
+  'name',
+];
+const VALUE_KEYS = [
+  'variavel',
+  'chave',
+  'key',
+  'slug',
+  'campo',
+  'tag',
+  'identificador',
+  'codigo',
+  'valor',
+];
+const ID_KEYS = [
+  'id',
+  'idtipo',
+  'id_tipo',
+  'idtipodocumento',
+  'id_tipo_documento',
+  'idtipoatributo',
+  'id_tipo_atributo',
+  'idatributo',
+  'id_atributo',
+  'idtipoatributocliente',
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function pickFirstString(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const candidate = record[key];
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    } else if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+      return String(candidate);
+    }
+  }
+
+  return undefined;
+}
+
+function extractCollection(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (isRecord(payload)) {
+    for (const key of COLLECTION_KEYS) {
+      const value = payload[key];
+      if (Array.isArray(value)) {
+        return value;
+      }
+    }
+  }
+
+  return [];
+}
+
+export async function fetchClientCustomAttributeTypes(): Promise<ClientCustomAttributeType[]> {
+  const response = await fetch(getApiUrl('get_api_clientes_atributos_tipos'), {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error('Não foi possível carregar os atributos personalizados.');
+  }
+
+  const payload = (await response.json()) as unknown;
+  const rawItems = extractCollection(payload);
+  const attributes: ClientCustomAttributeType[] = [];
+  const seen = new Set<string>();
+
+  rawItems.forEach((item, index) => {
+    if (!isRecord(item)) {
+      return;
+    }
+
+    const label = pickFirstString(item, LABEL_KEYS);
+    if (!label) {
+      return;
+    }
+
+    const id = pickFirstString(item, ID_KEYS) ?? `custom-${index}`;
+    const value = pickFirstString(item, VALUE_KEYS);
+    const signature = `${id}|${label}`;
+
+    if (seen.has(signature)) {
+      return;
+    }
+
+    seen.add(signature);
+    attributes.push({
+      id,
+      label,
+      value: value?.trim() || undefined,
+    });
+  });
+
+  return attributes.sort((a, b) => a.label.localeCompare(b.label, 'pt-BR'));
+}

--- a/frontend/src/features/document-editor/components/InsertMenu.tsx
+++ b/frontend/src/features/document-editor/components/InsertMenu.tsx
@@ -15,15 +15,17 @@ import { variableMenuTree } from '../data/variable-items';
 type InsertMenuProps = {
   onSelect: (item: VariableMenuItem) => void;
   disabled?: boolean;
+  items?: VariableMenuItem[];
 };
 
 function RenderMenuItems({ items, onSelect }: { items: VariableMenuItem[]; onSelect: (item: VariableMenuItem) => void }) {
   return (
     <>
-      {items.map(item => {
+      {items.map((item, index) => {
+        const key = item.id ?? item.value ?? `${item.label}-${index}`;
         if (item.children && item.children.length > 0) {
           return (
-            <DropdownMenuSub key={item.value}>
+            <DropdownMenuSub key={key}>
               <DropdownMenuSubTrigger className="flex items-center justify-between gap-2">
                 <span>{item.label}</span>
               </DropdownMenuSubTrigger>
@@ -34,12 +36,20 @@ function RenderMenuItems({ items, onSelect }: { items: VariableMenuItem[]; onSel
           );
         }
 
+        if (item.value) {
+          return (
+            <DropdownMenuItem key={key} onSelect={() => onSelect(item)}>
+              <div className="flex flex-col">
+                <span>{item.label}</span>
+                <span className="text-xs text-muted-foreground">{`{{${item.value}}}`}</span>
+              </div>
+            </DropdownMenuItem>
+          );
+        }
+
         return (
-          <DropdownMenuItem key={item.value} onSelect={() => onSelect(item)}>
-            <div className="flex flex-col">
-              <span>{item.label}</span>
-              <span className="text-xs text-muted-foreground">{`{{${item.value}}}`}</span>
-            </div>
+          <DropdownMenuItem key={key} disabled>
+            <span className="text-muted-foreground">{item.label}</span>
           </DropdownMenuItem>
         );
       })}
@@ -47,7 +57,9 @@ function RenderMenuItems({ items, onSelect }: { items: VariableMenuItem[]; onSel
   );
 }
 
-export function InsertMenu({ onSelect, disabled }: InsertMenuProps) {
+export function InsertMenu({ onSelect, disabled, items }: InsertMenuProps) {
+  const menuItems = items ?? variableMenuTree;
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild disabled={disabled}>
@@ -57,7 +69,7 @@ export function InsertMenu({ onSelect, disabled }: InsertMenuProps) {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="min-w-56" sideOffset={8}>
-        <RenderMenuItems items={variableMenuTree} onSelect={onSelect} />
+        <RenderMenuItems items={menuItems} onSelect={onSelect} />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/frontend/src/features/document-editor/data/variable-items.ts
+++ b/frontend/src/features/document-editor/data/variable-items.ts
@@ -1,106 +1,123 @@
 export interface VariableMenuItem {
+  id?: string;
   label: string;
-  value: string;
+  value?: string;
   description?: string;
   children?: VariableMenuItem[];
+  isSection?: boolean;
 }
 
 export const variableMenuTree: VariableMenuItem[] = [
   {
+    id: 'cliente',
     label: 'Cliente',
-    value: 'cliente',
+    isSection: true,
     children: [
-      { label: 'Primeiro nome', value: 'cliente.primeiro_nome' },
-      { label: 'Sobrenome', value: 'cliente.sobrenome' },
-      { label: 'Nome completo', value: 'cliente.nome_completo' },
+      { id: 'cliente.primeiro_nome', label: 'Primeiro nome', value: 'cliente.primeiro_nome' },
+      { id: 'cliente.sobrenome', label: 'Sobrenome', value: 'cliente.sobrenome' },
+      { id: 'cliente.nome_completo', label: 'Nome completo', value: 'cliente.nome_completo' },
       {
+        id: 'cliente.endereco',
         label: 'Endereço',
         value: 'cliente.endereco',
         children: [
-          { label: 'Rua', value: 'cliente.endereco.rua' },
-          { label: 'Número', value: 'cliente.endereco.numero' },
-          { label: 'Bairro', value: 'cliente.endereco.bairro' },
-          { label: 'Cidade', value: 'cliente.endereco.cidade' },
-          { label: 'Estado', value: 'cliente.endereco.estado' },
-          { label: 'CEP', value: 'cliente.endereco.cep' },
+          { id: 'cliente.endereco.rua', label: 'Rua', value: 'cliente.endereco.rua' },
+          { id: 'cliente.endereco.numero', label: 'Número', value: 'cliente.endereco.numero' },
+          { id: 'cliente.endereco.bairro', label: 'Bairro', value: 'cliente.endereco.bairro' },
+          { id: 'cliente.endereco.cidade', label: 'Cidade', value: 'cliente.endereco.cidade' },
+          { id: 'cliente.endereco.estado', label: 'Estado', value: 'cliente.endereco.estado' },
+          { id: 'cliente.endereco.cep', label: 'CEP', value: 'cliente.endereco.cep' },
         ],
       },
       {
+        id: 'cliente.contato',
         label: 'Contato',
         value: 'cliente.contato',
         children: [
-          { label: 'E-mail', value: 'cliente.contato.email' },
-          { label: 'Telefone', value: 'cliente.contato.telefone' },
+          { id: 'cliente.contato.email', label: 'E-mail', value: 'cliente.contato.email' },
+          { id: 'cliente.contato.telefone', label: 'Telefone', value: 'cliente.contato.telefone' },
         ],
       },
       {
+        id: 'cliente.documento',
         label: 'Documento',
         value: 'cliente.documento',
         children: [
-          { label: 'CPF', value: 'cliente.documento.cpf' },
-          { label: 'RG', value: 'cliente.documento.rg' },
+          { id: 'cliente.documento.cpf', label: 'CPF', value: 'cliente.documento.cpf' },
+          { id: 'cliente.documento.rg', label: 'RG', value: 'cliente.documento.rg' },
         ],
+      },
+      {
+        id: 'cliente.atributos_personalizados',
+        label: 'Atributos personalizados',
+        children: [],
       },
     ],
   },
   {
+    id: 'processo',
     label: 'Processo',
-    value: 'processo',
+    isSection: true,
     children: [
-      { label: 'Número', value: 'processo.numero' },
-      { label: 'Tipo de ação', value: 'processo.tipo_acao' },
-      { label: 'Vara', value: 'processo.vara' },
-      { label: 'Fase atual', value: 'processo.fase_atual' },
-      { label: 'Status', value: 'processo.status' },
+      { id: 'processo.numero', label: 'Número', value: 'processo.numero' },
+      { id: 'processo.tipo_acao', label: 'Tipo de ação', value: 'processo.tipo_acao' },
+      { id: 'processo.vara', label: 'Vara', value: 'processo.vara' },
+      { id: 'processo.fase_atual', label: 'Fase atual', value: 'processo.fase_atual' },
+      { id: 'processo.status', label: 'Status', value: 'processo.status' },
       {
+        id: 'processo.audiencia',
         label: 'Audiência',
         value: 'processo.audiencia',
         children: [
-          { label: 'Data', value: 'processo.audiencia.data' },
-          { label: 'Horário', value: 'processo.audiencia.horario' },
-          { label: 'Local', value: 'processo.audiencia.local' },
+          { id: 'processo.audiencia.data', label: 'Data', value: 'processo.audiencia.data' },
+          { id: 'processo.audiencia.horario', label: 'Horário', value: 'processo.audiencia.horario' },
+          { id: 'processo.audiencia.local', label: 'Local', value: 'processo.audiencia.local' },
         ],
       },
     ],
   },
   {
+    id: 'escritorio',
     label: 'Escritório',
-    value: 'escritorio',
+    isSection: true,
     children: [
-      { label: 'Nome', value: 'escritorio.nome' },
-      { label: 'Razão social', value: 'escritorio.razao_social' },
-      { label: 'CNPJ', value: 'escritorio.cnpj' },
+      { id: 'escritorio.nome', label: 'Nome', value: 'escritorio.nome' },
+      { id: 'escritorio.razao_social', label: 'Razão social', value: 'escritorio.razao_social' },
+      { id: 'escritorio.cnpj', label: 'CNPJ', value: 'escritorio.cnpj' },
       {
+        id: 'escritorio.endereco',
         label: 'Endereço',
         value: 'escritorio.endereco',
         children: [
-          { label: 'Rua', value: 'escritorio.endereco.rua' },
-          { label: 'Número', value: 'escritorio.endereco.numero' },
-          { label: 'Bairro', value: 'escritorio.endereco.bairro' },
-          { label: 'Cidade', value: 'escritorio.endereco.cidade' },
-          { label: 'Estado', value: 'escritorio.endereco.estado' },
+          { id: 'escritorio.endereco.rua', label: 'Rua', value: 'escritorio.endereco.rua' },
+          { id: 'escritorio.endereco.numero', label: 'Número', value: 'escritorio.endereco.numero' },
+          { id: 'escritorio.endereco.bairro', label: 'Bairro', value: 'escritorio.endereco.bairro' },
+          { id: 'escritorio.endereco.cidade', label: 'Cidade', value: 'escritorio.endereco.cidade' },
+          { id: 'escritorio.endereco.estado', label: 'Estado', value: 'escritorio.endereco.estado' },
         ],
       },
     ],
   },
   {
+    id: 'usuario',
     label: 'Usuário',
-    value: 'usuario',
+    isSection: true,
     children: [
-      { label: 'Nome completo', value: 'usuario.nome' },
-      { label: 'Cargo', value: 'usuario.cargo' },
-      { label: 'OAB', value: 'usuario.oab' },
-      { label: 'E-mail', value: 'usuario.email' },
-      { label: 'Telefone', value: 'usuario.telefone' },
+      { id: 'usuario.nome', label: 'Nome completo', value: 'usuario.nome' },
+      { id: 'usuario.cargo', label: 'Cargo', value: 'usuario.cargo' },
+      { id: 'usuario.oab', label: 'OAB', value: 'usuario.oab' },
+      { id: 'usuario.email', label: 'E-mail', value: 'usuario.email' },
+      { id: 'usuario.telefone', label: 'Telefone', value: 'usuario.telefone' },
     ],
   },
   {
+    id: 'sistema',
     label: 'Data atual',
-    value: 'sistema',
+    isSection: true,
     children: [
-      { label: 'Data (DD/MM/AAAA)', value: 'sistema.data_atual' },
-      { label: 'Data por extenso', value: 'sistema.data_extenso' },
-      { label: 'Hora atual', value: 'sistema.hora_atual' },
+      { id: 'sistema.data_atual', label: 'Data (DD/MM/AAAA)', value: 'sistema.data_atual' },
+      { id: 'sistema.data_extenso', label: 'Data por extenso', value: 'sistema.data_extenso' },
+      { id: 'sistema.hora_atual', label: 'Hora atual', value: 'sistema.hora_atual' },
     ],
   },
 ];

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -41,12 +41,15 @@ import type {
 } from '@/types/templates';
 import { defaultTemplateMetadata } from '@/types/templates';
 import type { VariableMenuItem } from '@/features/document-editor/data/variable-items';
+import { variableMenuTree } from '@/features/document-editor/data/variable-items';
 import { InsertMenu } from '@/features/document-editor/components/InsertMenu';
 import { EditorToolbar, type ToolbarAlignment, type ToolbarBlock, type ToolbarState } from '@/features/document-editor/components/EditorToolbar';
 import { SidebarNavigation } from '@/features/document-editor/components/SidebarNavigation';
 import { MetadataModal, type MetadataFormValues } from '@/features/document-editor/components/MetadataModal';
 import { SaveButton } from '@/features/document-editor/components/SaveButton';
 import { Menu, Sparkles } from 'lucide-react';
+import { fetchClientCustomAttributeTypes } from '@/features/document-editor/api/client-custom-attributes';
+import type { ClientCustomAttributeType } from '@/features/document-editor/api/client-custom-attributes';
 
 function escapeHtml(text: string): string {
   const div = document.createElement('div');
@@ -136,6 +139,13 @@ function formatVariableLabel(name: string, label?: string | null): string {
     .join(' • ');
 }
 
+function cloneVariableMenuItems(items: VariableMenuItem[]): VariableMenuItem[] {
+  return items.map(item => ({
+    ...item,
+    children: item.children ? cloneVariableMenuItems(item.children) : undefined,
+  }));
+}
+
 const fontSizeMap: Record<string, string> = {
   '1': '10px',
   '2': '12px',
@@ -168,6 +178,8 @@ const DOCUMENT_TYPE_OPTIONS = [
   { value: 'notificacao', label: 'Notificação' },
   { value: 'outro', label: 'Outro' },
 ];
+
+const EMPTY_CLIENT_CUSTOM_ATTRIBUTES: ClientCustomAttributeType[] = [];
 
 export default function EditorPage() {
   const { id } = useParams();
@@ -205,6 +217,11 @@ export default function EditorPage() {
   const integrationQuery = useQuery({
     queryKey: ['integration-api-keys'],
     queryFn: fetchIntegrationApiKeys,
+  });
+
+  const clientCustomAttributeTypesQuery = useQuery({
+    queryKey: ['client-custom-attribute-types'],
+    queryFn: fetchClientCustomAttributeTypes,
   });
 
   const activeAiIntegrations = useMemo(() => {
@@ -527,6 +544,10 @@ export default function EditorPage() {
   };
 
   const handleInsertVariable = (item: VariableMenuItem) => {
+    if (!item.value) {
+      return;
+    }
+
     const selection = document.getSelection();
     const editor = editorRef.current;
     if (!selection || !editor || selection.rangeCount === 0) return;
@@ -668,6 +689,79 @@ export default function EditorPage() {
     updateToolbarState();
   };
 
+  const clientCustomAttributes: ClientCustomAttributeType[] =
+    clientCustomAttributeTypesQuery.data ?? EMPTY_CLIENT_CUSTOM_ATTRIBUTES;
+  const isLoadingClientAttributes = clientCustomAttributeTypesQuery.isLoading || clientCustomAttributeTypesQuery.isFetching;
+  const hasClientAttributeError = Boolean(clientCustomAttributeTypesQuery.isError);
+
+  const variableMenuItems = useMemo(() => {
+    const cloned = cloneVariableMenuItems(variableMenuTree);
+    const clientSection = cloned.find(item => item.id === 'cliente');
+
+    if (clientSection) {
+      const attributeChildren: VariableMenuItem[] = (() => {
+        if (isLoadingClientAttributes) {
+          return [
+            {
+              id: 'cliente.atributos_personalizados.loading',
+              label: 'Carregando atributos...',
+            },
+          ];
+        }
+
+        if (hasClientAttributeError) {
+          return [
+            {
+              id: 'cliente.atributos_personalizados.error',
+              label: 'Não foi possível carregar os atributos personalizados.',
+            },
+          ];
+        }
+
+        if (clientCustomAttributes.length === 0) {
+          return [
+            {
+              id: 'cliente.atributos_personalizados.empty',
+              label: 'Nenhum atributo personalizado cadastrado.',
+            },
+          ];
+        }
+
+        return clientCustomAttributes.map(attribute => ({
+          id: `cliente.atributos_personalizados.${attribute.id}`,
+          label: attribute.label,
+          value: attribute.value ?? undefined,
+        }));
+      })();
+
+      const baseChildren = clientSection.children ?? [];
+      let foundPlaceholder = false;
+
+      const updatedChildren = baseChildren.map(child => {
+        if (child.id === 'cliente.atributos_personalizados') {
+          foundPlaceholder = true;
+          return {
+            ...child,
+            children: attributeChildren,
+          };
+        }
+        return child;
+      });
+
+      if (!foundPlaceholder) {
+        updatedChildren.push({
+          id: 'cliente.atributos_personalizados',
+          label: 'Atributos personalizados',
+          children: attributeChildren,
+        });
+      }
+
+      clientSection.children = updatedChildren;
+    }
+
+    return cloned;
+  }, [clientCustomAttributes, hasClientAttributeError, isLoadingClientAttributes]);
+
   const placeholderList = useMemo(() => extractPlaceholders(contentHtml), [contentHtml]);
 
   const metadataFormDefaults: MetadataFormValues = {
@@ -700,6 +794,7 @@ export default function EditorPage() {
         onSelectSection={focusSection}
         onInsertVariable={handleInsertVariable}
         className="hidden md:flex"
+        items={variableMenuItems}
       />
 
       <Sheet open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen}>
@@ -714,6 +809,7 @@ export default function EditorPage() {
             onSelectSection={focusSection}
             onInsertVariable={handleInsertVariable}
             className="border-r-0"
+            items={variableMenuItems}
           />
         </SheetContent>
       </Sheet>
@@ -762,7 +858,7 @@ export default function EditorPage() {
                   <Sparkles className="h-4 w-4" aria-hidden="true" />
                   {isLoadingAiIntegrations ? 'Carregando IA...' : 'Gerar texto com IA'}
                 </Button>
-                <InsertMenu onSelect={handleInsertVariable} />
+                <InsertMenu onSelect={handleInsertVariable} items={variableMenuItems} />
               </div>
             </div>
             <EditorToolbar


### PR DESCRIPTION
## Summary
- add an API helper that loads custom client attribute types for the document editor
- reorganize the sidebar library into collapsible sections fed by the dynamic variable tree
- update the insert menu and editor page to use the shared tree and guard against inserting items without tags

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1a5b1f71c8326985cf0d6f3cd01d5