### PR TITLE
Protect opportunity documents by empresa

### DIFF
--- a/backend/src/controllers/oportunidadeDocumentoController.ts
+++ b/backend/src/controllers/oportunidadeDocumentoController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import pool from '../services/db';
 import { queryEmpresas } from '../services/empresaQueries';
 import { replaceVariables } from '../services/templateService';
+import { fetchAuthenticatedUserEmpresa } from '../utils/authUser';
 
 type Primitive = string | number | boolean | null | undefined;
 
@@ -148,6 +149,48 @@ type OpportunityDocumentRow = {
   variables: unknown;
   created_at: string;
 };
+
+type AuthenticatedContext =
+  | { ok: true; empresaId: number; userId: number }
+  | { ok: false };
+
+async function resolveAuthenticatedContext(
+  req: Request,
+  res: Response,
+): Promise<AuthenticatedContext> {
+  if (!req.auth) {
+    res.status(401).json({ error: 'Token inválido.' });
+    return { ok: false };
+  }
+
+  const empresaLookup = await fetchAuthenticatedUserEmpresa(req.auth.userId);
+
+  if (!empresaLookup.success) {
+    res.status(empresaLookup.status).json({ error: empresaLookup.message });
+    return { ok: false };
+  }
+
+  const { empresaId } = empresaLookup;
+
+  if (empresaId === null) {
+    res.status(403).json({ error: 'Usuário autenticado não possui empresa vinculada.' });
+    return { ok: false };
+  }
+
+  return { ok: true, empresaId, userId: req.auth.userId };
+}
+
+async function ensureOpportunityAccess(
+  oportunidadeId: number,
+  empresaId: number,
+): Promise<boolean> {
+  const result = await pool.query(
+    'SELECT 1 FROM public.oportunidades WHERE id = $1 AND idempresa = $2 LIMIT 1',
+    [oportunidadeId, empresaId],
+  );
+
+  return (result.rowCount ?? 0) > 0;
+}
 
 function ensureEditorJsonContent(value: unknown): EditorJsonNode[] | null {
   if (!value) return null;
@@ -742,7 +785,10 @@ function buildVariables({
   return variables;
 }
 
-async function fetchOpportunityData(id: number): Promise<OpportunityData | null> {
+async function fetchOpportunityData(
+  id: number,
+  empresaId: number,
+): Promise<OpportunityData | null> {
   const opportunityResult = await pool.query<OpportunityRow>(
     `SELECT id, tipo_processo_id, area_atuacao_id, responsavel_id, idempresa, numero_processo_cnj, numero_protocolo,
             vara_ou_orgao, comarca, fase_id, etapa_id, prazo_proximo, status_id, solicitante_id,
@@ -750,8 +796,8 @@ async function fetchOpportunityData(id: number): Promise<OpportunityData | null>
             contingenciamento, detalhes, documentos_anexados, criado_por, sequencial_empresa,
             audiencia_data, audiencia_horario, audiencia_local, data_criacao, ultima_atualizacao
 
-       FROM public.oportunidades WHERE id = $1`,
-    [id],
+       FROM public.oportunidades WHERE id = $1 AND idempresa = $2`,
+    [id, empresaId],
   );
   if (opportunityResult.rowCount === 0) {
     return null;
@@ -850,19 +896,26 @@ export const createOpportunityDocumentFromTemplate = async (req: Request, res: R
   }
 
   try {
+    const authContext = await resolveAuthenticatedContext(req, res);
+    if (!authContext.ok) {
+      return;
+    }
+
+    const { empresaId, userId } = authContext;
+
+    const opportunityData = await fetchOpportunityData(opportunityId, empresaId);
+    if (!opportunityData) {
+      return res.status(404).json({ error: 'Oportunidade não encontrada' });
+    }
+
     const templateResult = await pool.query<TemplateRow>(
-      'SELECT id, title, content FROM templates WHERE id = $1',
-      [numericTemplateId],
+      'SELECT id, title, content FROM templates WHERE id = $1 AND idempresa IS NOT DISTINCT FROM $2 AND idusuario = $3',
+      [numericTemplateId, empresaId, userId],
     );
     if (templateResult.rowCount === 0) {
       return res.status(404).json({ error: 'Template não encontrado' });
     }
     const template = templateResult.rows[0];
-
-    const opportunityData = await fetchOpportunityData(opportunityId);
-    if (!opportunityData) {
-      return res.status(404).json({ error: 'Oportunidade não encontrada' });
-    }
 
     const { contentHtml, contentEditorJson, metadata } = parseTemplateContent(template.content);
     const variables = buildVariables(opportunityData);
@@ -916,6 +969,18 @@ export const listOpportunityDocuments = async (req: Request, res: Response) => {
   }
 
   try {
+    const authContext = await resolveAuthenticatedContext(req, res);
+    if (!authContext.ok) {
+      return;
+    }
+
+    const { empresaId } = authContext;
+
+    const hasAccess = await ensureOpportunityAccess(opportunityId, empresaId);
+    if (!hasAccess) {
+      return res.status(404).json({ error: 'Oportunidade não encontrada' });
+    }
+
     const result = await pool.query<OpportunityDocumentRow>(
       `SELECT id, oportunidade_id, template_id, title, content, variables, created_at
        FROM public.oportunidade_documentos
@@ -944,6 +1009,18 @@ export const getOpportunityDocument = async (req: Request, res: Response) => {
   }
 
   try {
+    const authContext = await resolveAuthenticatedContext(req, res);
+    if (!authContext.ok) {
+      return;
+    }
+
+    const { empresaId } = authContext;
+
+    const hasAccess = await ensureOpportunityAccess(opportunityId, empresaId);
+    if (!hasAccess) {
+      return res.status(404).json({ error: 'Oportunidade não encontrada' });
+    }
+
     const result = await pool.query<OpportunityDocumentRow>(
       `SELECT id, oportunidade_id, template_id, title, content, variables, created_at
        FROM public.oportunidade_documentos
@@ -973,6 +1050,18 @@ export const deleteOpportunityDocument = async (req: Request, res: Response) => 
   }
 
   try {
+    const authContext = await resolveAuthenticatedContext(req, res);
+    if (!authContext.ok) {
+      return;
+    }
+
+    const { empresaId } = authContext;
+
+    const hasAccess = await ensureOpportunityAccess(opportunityId, empresaId);
+    if (!hasAccess) {
+      return res.status(404).json({ error: 'Oportunidade não encontrada' });
+    }
+
     const result = await pool.query(
       'DELETE FROM public.oportunidade_documentos WHERE oportunidade_id = $1 AND id = $2 RETURNING id',
       [opportunityId, docId],

--- a/backend/tests/oportunidadeDocumentoController.test.ts
+++ b/backend/tests/oportunidadeDocumentoController.test.ts
@@ -9,9 +9,10 @@ type QueryCall = { text: string; values?: unknown[] };
 type QueryResponse = { rows: any[]; rowCount: number };
 
 let createOpportunityDocumentFromTemplate: typeof import('../src/controllers/oportunidadeDocumentoController')['createOpportunityDocumentFromTemplate'];
+let listOpportunityDocuments: typeof import('../src/controllers/oportunidadeDocumentoController')['listOpportunityDocuments'];
 
 test.before(async () => {
-  ({ createOpportunityDocumentFromTemplate } = await import(
+  ({ createOpportunityDocumentFromTemplate, listOpportunityDocuments } = await import(
     '../src/controllers/oportunidadeDocumentoController'
   ));
 });
@@ -70,7 +71,7 @@ test('createOpportunityDocumentFromTemplate uses the opportunity empresa when fi
   const insertedPayload: { content?: string; variables?: string } = {};
 
   const { calls, restore } = setupQueryMock([
-    { rows: [{ id: 7, title: 'Modelo', content: templateContent }], rowCount: 1 },
+    { rows: [{ empresa: 55 }], rowCount: 1 },
     {
       rows: [
         {
@@ -128,7 +129,6 @@ test('createOpportunityDocumentFromTemplate uses the opportunity empresa when fi
     {
       rows: [
         { column_name: 'id' },
-
         { column_name: 'cep' },
         { column_name: 'rua' },
         { column_name: 'numero' },
@@ -166,6 +166,7 @@ test('createOpportunityDocumentFromTemplate uses the opportunity empresa when fi
     { rows: [], rowCount: 0 },
     { rows: [], rowCount: 0 },
     { rows: [], rowCount: 0 },
+    { rows: [{ id: 7, title: 'Modelo', content: templateContent }], rowCount: 1 },
     (text: string, values?: unknown[]) => {
       assert.match(text, /INSERT INTO public\.oportunidade_documentos/);
       insertedPayload.content = values?.[3] as string;
@@ -190,6 +191,7 @@ test('createOpportunityDocumentFromTemplate uses the opportunity empresa when fi
   const req = {
     params: { id: '123' },
     body: { templateId: 7 },
+    auth: { userId: 99 },
   } as unknown as Request;
 
   const res = createMockResponse();
@@ -237,4 +239,106 @@ test('createOpportunityDocumentFromTemplate uses the opportunity empresa when fi
   assert.match(empresaQuery!.text, /WHERE id = \$1/);
   assert.deepEqual(empresaQuery!.values, [55]);
 
+  const opportunityQuery = calls.find((call) =>
+    call.text.includes('FROM public.oportunidades') && call.text.includes('idempresa = $2'),
+  );
+  assert.ok(opportunityQuery, 'expected opportunity lookup to include empresa filter');
+  assert.deepEqual(opportunityQuery!.values, [123, 55]);
+
+  const templateQuery = calls.find((call) => call.text.includes('FROM templates'));
+  assert.ok(templateQuery, 'expected template query to be executed');
+  assert.match(templateQuery!.text, /idusuario = \$3/);
+  assert.deepEqual(templateQuery!.values, [7, 55, 99]);
+});
+
+test('createOpportunityDocumentFromTemplate returns 401 when auth is missing', async () => {
+  const { restore } = setupQueryMock([]);
+
+  const req = {
+    params: { id: '5' },
+    body: { templateId: 2 },
+  } as unknown as Request;
+
+  const res = createMockResponse();
+
+  try {
+    await createOpportunityDocumentFromTemplate(req, res);
+  } finally {
+    restore();
+  }
+
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.body, { error: 'Token inválido.' });
+});
+
+test('createOpportunityDocumentFromTemplate returns 403 when user lacks empresa', async () => {
+  const { restore } = setupQueryMock([{ rows: [{ empresa: null }], rowCount: 1 }]);
+
+  const req = {
+    params: { id: '7' },
+    body: { templateId: 3 },
+    auth: { userId: 42 },
+  } as unknown as Request;
+
+  const res = createMockResponse();
+
+  try {
+    await createOpportunityDocumentFromTemplate(req, res);
+  } finally {
+    restore();
+  }
+
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.body, {
+    error: 'Usuário autenticado não possui empresa vinculada.',
+  });
+});
+
+test('createOpportunityDocumentFromTemplate returns 404 when opportunity does not belong to empresa', async () => {
+  const { calls, restore } = setupQueryMock([
+    { rows: [{ empresa: 99 }], rowCount: 1 },
+    { rows: [], rowCount: 0 },
+  ]);
+
+  const req = {
+    params: { id: '88' },
+    body: { templateId: 5 },
+    auth: { userId: 77 },
+  } as unknown as Request;
+
+  const res = createMockResponse();
+
+  try {
+    await createOpportunityDocumentFromTemplate(req, res);
+  } finally {
+    restore();
+  }
+
+  assert.equal(res.statusCode, 404);
+  assert.deepEqual(res.body, { error: 'Oportunidade não encontrada' });
+  assert.equal(calls.length, 2);
+});
+
+test('listOpportunityDocuments returns 404 when opportunity is inaccessible', async () => {
+  const { calls, restore } = setupQueryMock([
+    { rows: [{ empresa: 12 }], rowCount: 1 },
+    { rows: [], rowCount: 0 },
+  ]);
+
+  const req = {
+    params: { id: '900' },
+    auth: { userId: 321 },
+  } as unknown as Request;
+
+  const res = createMockResponse();
+
+  try {
+    await listOpportunityDocuments(req, res);
+  } finally {
+    restore();
+  }
+
+  assert.equal(res.statusCode, 404);
+  assert.deepEqual(res.body, { error: 'Oportunidade não encontrada' });
+  assert.equal(calls.length, 2);
 });


### PR DESCRIPTION
## Summary
- resolve the authenticated empresa for oportunidade documento endpoints and block access when missing
- ensure opportunity, template and document queries are constrained by the authenticated empresa and user
- extend oportunidadeDocumentoController tests with tenant boundary scenarios

## Testing
- `npm test` *(fails: financialController listFlows assertions on unrelated SQL formatting)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b590088883268b7487c2b1aca084