### PR TITLE
Handle missing template variables safely

### DIFF
--- a/backend/src/services/templateService.ts
+++ b/backend/src/services/templateService.ts
@@ -2,8 +2,8 @@ export function replaceVariables(
   content: string,
   values: Record<string, string | number>
 ): string {
-  return content.replace(/{{\s*([\w\.]+)\s*}}/g, (_match, key) => {
+  return content.replace(/{{\s*([\w\.]+)\s*}}/g, (match, key) => {
     const value = values[key];
-    return value !== undefined ? String(value) : `<${key}>`;
+    return value !== undefined ? String(value) : match;
   });
 }

--- a/backend/tests/templateService.test.ts
+++ b/backend/tests/templateService.test.ts
@@ -8,9 +8,20 @@ test('replaceVariables replaces placeholders with provided values', () => {
   assert.strictEqual(result, 'Olá Maria');
 });
 
-test('replaceVariables falls back to the tag name within angle brackets when value is missing', () => {
+test('replaceVariables leaves unknown placeholders untouched', () => {
   const content = 'Documento: {{ documento.numero }} e {{documento.data}}';
   const result = replaceVariables(content, { 'documento.numero': 123 });
-  assert.strictEqual(result, 'Documento: 123 e <documento.data>');
+  assert.strictEqual(result, 'Documento: 123 e {{documento.data}}');
+});
+
+test('replaceVariables keeps HTML documents well-formed when values are missing', () => {
+  const content = '<div><span>{{ known }}</span><span>{{unknown}}</span></div>';
+  const result = replaceVariables(content, { known: 'valor' });
+
+  assert.strictEqual(
+    result,
+    '<div><span>valor</span><span>{{unknown}}</span></div>'
+  );
+  assert.ok(!result.includes('<unknown>'));
 });
 


### PR DESCRIPTION
## Summary
- ensure replaceVariables keeps unresolved placeholders instead of rendering angle-bracket tags
- expand template service tests to cover unknown keys and HTML templates

## Testing
- npm test *(fails: several pre-existing financialController and oportunidadeDocumentoController suites)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c27834e08326b35340a6b7099d31