### PR TITLE
Handle missing cliente column when listing financial flows

### DIFF
--- a/backend/src/controllers/financialController.ts
+++ b/backend/src/controllers/financialController.ts
@@ -58,10 +58,18 @@ const POSTGRES_INSUFFICIENT_PRIVILEGE = '42501';
 
 const OPPORTUNITY_TABLES_CACHE_TTL_MS = 5 * 60 * 1000;
 const FINANCIAL_FLOW_EMPRESA_COLUMN_CACHE_TTL_MS = 5 * 60 * 1000;
+const FINANCIAL_FLOW_CLIENTE_COLUMN_CACHE_TTL_MS = 5 * 60 * 1000;
 
 type FinancialFlowEmpresaColumn = string;
+type FinancialFlowClienteColumn = string;
 
 const FINANCIAL_FLOW_EMPRESA_CANDIDATES = ['idempresa', 'empresa_id', 'empresa'] as const;
+const FINANCIAL_FLOW_CLIENTE_CANDIDATES = [
+  'cliente_id',
+  'clienteid',
+  'idcliente',
+  'cliente',
+] as const;
 
 const quoteIdentifier = (value: string): string => `"${value.replace(/"/g, '""')}"`;
 
@@ -71,9 +79,34 @@ let opportunityTablesCheckPromise: Promise<boolean> | null = null;
 
 let financialFlowEmpresaColumn: FinancialFlowEmpresaColumn | null = null;
 let financialFlowEmpresaColumnCheckedAt: number | null = null;
-let financialFlowEmpresaColumnPromise:
-  | Promise<FinancialFlowEmpresaColumn | null>
+
+let financialFlowClienteColumn: FinancialFlowClienteColumn | null = null;
+let financialFlowClienteColumnCheckedAt: number | null = null;
+
+type FinancialFlowColumnsLookup = Map<string, string>;
+
+let financialFlowColumnsLookup: FinancialFlowColumnsLookup | null = null;
+let financialFlowColumnsCheckedAt: number | null = null;
+let financialFlowColumnsPromise:
+  | Promise<FinancialFlowColumnsLookup | null>
   | null = null;
+
+const updateFinancialFlowColumnsLookup = (
+  value: FinancialFlowColumnsLookup | null,
+) => {
+  financialFlowColumnsLookup = value;
+  financialFlowColumnsCheckedAt = Date.now();
+};
+
+const resetFinancialFlowColumnsLookup = () => {
+  financialFlowColumnsLookup = null;
+  financialFlowColumnsCheckedAt = null;
+  financialFlowColumnsPromise = null;
+  financialFlowEmpresaColumn = null;
+  financialFlowEmpresaColumnCheckedAt = null;
+  financialFlowClienteColumn = null;
+  financialFlowClienteColumnCheckedAt = null;
+};
 
 const updateOpportunityTablesAvailability = (value: boolean) => {
   opportunityTablesAvailability = value;
@@ -92,9 +125,82 @@ const updateFinancialFlowEmpresaColumn = (value: FinancialFlowEmpresaColumn | nu
 };
 
 const resetFinancialFlowEmpresaColumnCache = () => {
-  financialFlowEmpresaColumn = null;
-  financialFlowEmpresaColumnCheckedAt = null;
-  financialFlowEmpresaColumnPromise = null;
+  resetFinancialFlowColumnsLookup();
+};
+
+const updateFinancialFlowClienteColumn = (value: FinancialFlowClienteColumn | null) => {
+  financialFlowClienteColumn = value;
+  financialFlowClienteColumnCheckedAt = Date.now();
+};
+
+const resetFinancialFlowClienteColumnCache = () => {
+  resetFinancialFlowColumnsLookup();
+};
+
+const ensureFinancialFlowColumns = async () => {
+  if (
+    financialFlowColumnsLookup !== null &&
+    financialFlowColumnsCheckedAt !== null &&
+    Date.now() - financialFlowColumnsCheckedAt < FINANCIAL_FLOW_EMPRESA_COLUMN_CACHE_TTL_MS
+  ) {
+    return;
+  }
+
+  if (financialFlowColumnsPromise) {
+    await financialFlowColumnsPromise;
+    return;
+  }
+
+  financialFlowColumnsPromise = pool
+    .query<{ column_name: string }>(
+      `
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'financial_flows'
+      `,
+    )
+    .then((result) => {
+      const available = result.rows
+        .map((row) => row?.column_name)
+        .filter((name): name is string => typeof name === 'string');
+
+      const lookup: FinancialFlowColumnsLookup = new Map();
+      for (const name of available) {
+        lookup.set(name.toLowerCase(), name);
+      }
+
+      updateFinancialFlowColumnsLookup(lookup);
+
+      const empresaMatch = FINANCIAL_FLOW_EMPRESA_CANDIDATES.find((candidate) =>
+        lookup.has(candidate.toLowerCase()),
+      );
+      const resolvedEmpresa = empresaMatch
+        ? lookup.get(empresaMatch.toLowerCase()) ?? empresaMatch
+        : null;
+      updateFinancialFlowEmpresaColumn(resolvedEmpresa ?? null);
+
+      const clienteMatch = FINANCIAL_FLOW_CLIENTE_CANDIDATES.find((candidate) =>
+        lookup.has(candidate.toLowerCase()),
+      );
+      const resolvedCliente = clienteMatch
+        ? lookup.get(clienteMatch.toLowerCase()) ?? clienteMatch
+        : null;
+      updateFinancialFlowClienteColumn(resolvedCliente ?? null);
+
+      return lookup;
+    })
+    .catch(() => {
+      updateFinancialFlowColumnsLookup(null);
+      updateFinancialFlowEmpresaColumn(null);
+      updateFinancialFlowClienteColumn(null);
+      return null;
+    })
+    .finally(() => {
+      financialFlowColumnsPromise = null;
+    });
+
+  await financialFlowColumnsPromise;
 };
 
 const determineOpportunityTablesAvailability = async (): Promise<boolean> => {
@@ -188,60 +294,35 @@ const shouldFallbackToFinancialFlowsOnly = (error: unknown): boolean => {
 export const __internal = {
   resetOpportunityTablesAvailabilityCache,
   resetFinancialFlowEmpresaColumnCache,
+  resetFinancialFlowClienteColumnCache,
 };
 
 const asaasChargeService = new AsaasChargeService();
 
 const determineFinancialFlowEmpresaColumn = async (): Promise<FinancialFlowEmpresaColumn | null> => {
   if (
-    financialFlowEmpresaColumn !== null &&
     financialFlowEmpresaColumnCheckedAt !== null &&
     Date.now() - financialFlowEmpresaColumnCheckedAt < FINANCIAL_FLOW_EMPRESA_COLUMN_CACHE_TTL_MS
   ) {
     return financialFlowEmpresaColumn;
   }
 
-  if (financialFlowEmpresaColumnPromise) {
-    return financialFlowEmpresaColumnPromise;
+  await ensureFinancialFlowColumns();
+
+  return financialFlowEmpresaColumn;
+};
+
+const determineFinancialFlowClienteColumn = async (): Promise<FinancialFlowClienteColumn | null> => {
+  if (
+    financialFlowClienteColumnCheckedAt !== null &&
+    Date.now() - financialFlowClienteColumnCheckedAt < FINANCIAL_FLOW_CLIENTE_COLUMN_CACHE_TTL_MS
+  ) {
+    return financialFlowClienteColumn;
   }
 
-  financialFlowEmpresaColumnPromise = pool
-    .query<{ column_name: string }>(
-      `
-        SELECT column_name
-        FROM information_schema.columns
-        WHERE table_schema = 'public'
-          AND table_name = 'financial_flows'
-      `,
-    )
-    .then((result) => {
-      const available = result.rows
-        .map((row) => row?.column_name)
-        .filter((name): name is string => typeof name === 'string');
+  await ensureFinancialFlowColumns();
 
-      const lookup = new Map<string, string>();
-      for (const name of available) {
-        lookup.set(name.toLowerCase(), name);
-      }
-
-      const match = FINANCIAL_FLOW_EMPRESA_CANDIDATES.find((candidate) =>
-        lookup.has(candidate.toLowerCase()),
-      );
-
-      const resolved = match ? lookup.get(match.toLowerCase()) ?? match : null;
-
-      updateFinancialFlowEmpresaColumn(resolved ?? null);
-      return resolved ?? null;
-    })
-    .catch(() => {
-      updateFinancialFlowEmpresaColumn(null);
-      return null;
-    })
-    .finally(() => {
-      financialFlowEmpresaColumnPromise = null;
-    });
-
-  return financialFlowEmpresaColumnPromise;
+  return financialFlowClienteColumn;
 };
 
 export const listFlows = async (req: Request, res: Response) => {
@@ -293,10 +374,15 @@ export const listFlows = async (req: Request, res: Response) => {
     }
 
     const empresaColumn = await determineFinancialFlowEmpresaColumn();
+    const clienteColumn = await determineFinancialFlowClienteColumn();
     const hasEmpresaColumn = typeof empresaColumn === 'string' && empresaColumn.length > 0;
     const empresaColumnExpression = hasEmpresaColumn
       ? `ff.${quoteIdentifier(empresaColumn)}`
       : '$1::INTEGER';
+    const clienteColumnExpression =
+      typeof clienteColumn === 'string' && clienteColumn.length > 0
+        ? `ff.${quoteIdentifier(clienteColumn)}::TEXT`
+        : 'NULL::TEXT';
 
     const filters: (string | number)[] = [empresaId];
     const filterConditions: string[] = ['combined_flows.empresa_id = $1'];
@@ -319,7 +405,7 @@ export const listFlows = async (req: Request, res: Response) => {
           ff.status AS status,
           ff.conta_id::TEXT AS conta_id,
           ff.categoria_id::TEXT AS categoria_id,
-          ff.cliente_id::TEXT AS cliente_id,
+          ${clienteColumnExpression} AS cliente_id,
           ff.fornecedor_id::TEXT AS fornecedor_id,
           ${empresaColumnExpression} AS empresa_id
         FROM financial_flows ff

--- a/backend/tests/financialController.test.ts
+++ b/backend/tests/financialController.test.ts
@@ -354,20 +354,17 @@ test('listFlows tolerates legacy empresa column names', async () => {
   assert.match(calls[0]?.text ?? '', /FROM public\.usuarios WHERE id = \$1/);
   assert.deepEqual(calls[0]?.values, [3]);
   assert.match(calls[1]?.text ?? '', /information_schema\.columns/);
+  assert.equal(calls[1]?.values, undefined);
+  assert.match(calls[2]?.text ?? '', /WITH tables AS/);
+  assert.equal(calls[2]?.values, undefined);
+  assert.match(calls[3]?.text ?? '', /ff\.id::TEXT AS id/);
+  assert.match(calls[3]?.text ?? '', /ff\.conta_id::TEXT AS conta_id/);
+  assert.match(calls[3]?.text ?? '', /ff\.categoria_id::TEXT AS categoria_id/);
+  assert.match(calls[3]?.text ?? '', /NULL::TEXT AS cliente_id/);
+  assert.match(calls[3]?.text ?? '', /ff\.fornecedor_id::TEXT AS fornecedor_id/);
   assert.match(calls[3]?.text ?? '', /ff\."empresa" AS empresa_id/);
-  assert.equal(calls[0]?.values, undefined);
-  assert.match(calls[1]?.text ?? '', /WITH oportunidade_parcelas_enriched AS/);
-  assert.match(calls[1]?.text ?? '', /ff\.id::TEXT AS id/);
-  assert.match(calls[1]?.text ?? '', /ff\.conta_id::TEXT AS conta_id/);
-  assert.match(calls[1]?.text ?? '', /ff\.categoria_id::TEXT AS categoria_id/);
-  assert.match(calls[1]?.text ?? '', /ff\.cliente_id::TEXT AS cliente_id/);
-  assert.match(calls[1]?.text ?? '', /ff\.fornecedor_id::TEXT AS fornecedor_id/);
-  assert.match(calls[1]?.text ?? '', /\(-p\.id\)::TEXT AS id/);
-  assert.match(calls[1]?.text ?? '', /NULL::TEXT AS conta_id/);
-  assert.match(calls[1]?.text ?? '', /NULL::TEXT AS categoria_id/);
-  assert.match(calls[1]?.text ?? '', /NULL::TEXT AS fornecedor_id/);
-  assert.deepEqual(calls[1]?.values, [1, 1]);
-  assert.deepEqual(calls[2]?.values, []);
+  assert.deepEqual(calls[3]?.values, [DEFAULT_EMPRESA_ID, 10, 0]);
+  assert.deepEqual(calls[4]?.values, [DEFAULT_EMPRESA_ID]);
 
 });
 


### PR DESCRIPTION
## Summary
- detect available cliente column in financial_flows and fall back to NULL when missing
- share column metadata lookup between empresa and cliente detection with caching
- update financial controller tests to expect the new lookup behaviour

## Testing
- npm test *(fails: templateService tests already failing on main)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d551278c8326b9faa5d2e98f5816