### PR TITLE
Implement plan-based sync gating and expose plan context

### DIFF
--- a/backend/src/services/templateService.ts
+++ b/backend/src/services/templateService.ts
@@ -41,7 +41,7 @@ export function replaceVariables(
     MUSTACHE_VARIABLE_REGEX,
     (_match, key: string) => {
       const resolved = resolveVariableValue(values, key);
-      return resolved !== undefined ? resolved : `<${key}>`;
+      return resolved !== undefined ? resolved : `{{${key}}}`;
     },
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -66,6 +66,7 @@ import { AuthProvider } from "@/features/auth/AuthProvider";
 import { ProtectedRoute } from "@/features/auth/ProtectedRoute";
 import { RequireModule } from "@/features/auth/RequireModule";
 import { RequireAdminUser } from "@/features/auth/RequireAdminUser";
+import { PlanProvider } from "@/features/plans/PlanProvider";
 
 const CRMLayout = lazy(() =>
   import("@/components/layout/CRMLayout").then((module) => ({ default: module.CRMLayout })),
@@ -110,7 +111,9 @@ const App = () => (
               <Route
                 element={(
                   <ProtectedRoute>
-                    <CRMLayout />
+                    <PlanProvider>
+                      <CRMLayout />
+                    </PlanProvider>
                   </ProtectedRoute>
                 )}
               >

--- a/frontend/src/features/plans/PlanProvider.tsx
+++ b/frontend/src/features/plans/PlanProvider.tsx
@@ -1,0 +1,330 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { useAuth } from "@/features/auth/AuthProvider";
+import { getApiUrl } from "@/lib/api";
+
+export interface PlanInfo {
+  id: number | null;
+  nome: string | null;
+  sincronizacaoProcessosHabilitada: boolean;
+  sincronizacaoProcessosLimite: number | null;
+}
+
+interface PlanContextValue {
+  plan: PlanInfo | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => Promise<PlanInfo | null>;
+}
+
+const PlanContext = createContext<PlanContextValue | undefined>(undefined);
+
+type ApiRecord = Record<string, unknown>;
+
+const extractRows = (input: unknown): ApiRecord[] => {
+  if (Array.isArray(input)) {
+    return input.filter((item): item is ApiRecord =>
+      item !== null && typeof item === "object",
+    );
+  }
+
+  if (input && typeof input === "object") {
+    const data = (input as { data?: unknown }).data;
+    if (Array.isArray(data)) {
+      return data.filter((item): item is ApiRecord =>
+        item !== null && typeof item === "object",
+      );
+    }
+
+    const rows = (input as { rows?: unknown }).rows;
+    if (Array.isArray(rows)) {
+      return rows.filter((item): item is ApiRecord =>
+        item !== null && typeof item === "object",
+      );
+    }
+  }
+
+  return [];
+};
+
+const extractRecord = (input: unknown): ApiRecord | null => {
+  if (!input || typeof input !== "object") {
+    return null;
+  }
+
+  if (Array.isArray(input)) {
+    return input.find((item): item is ApiRecord => item !== null && typeof item === "object") ?? null;
+  }
+
+  const rows = (input as { rows?: unknown }).rows;
+  if (Array.isArray(rows)) {
+    return rows.find((item): item is ApiRecord => item !== null && typeof item === "object") ?? null;
+  }
+
+  return input as ApiRecord;
+};
+
+const toInteger = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const normalized = Math.trunc(value);
+    return Number.isNaN(normalized) ? null : normalized;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const parsed = Number.parseInt(trimmed, 10);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+const toNonNegativeInteger = (value: unknown): number | null => {
+  const parsed = toInteger(value);
+  if (parsed === null || parsed < 0) {
+    return null;
+  }
+  return parsed;
+};
+
+const parseBooleanFlag = (value: unknown): boolean | null => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      return null;
+    }
+
+    return value !== 0;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) {
+      return null;
+    }
+
+    if (
+      [
+        "1",
+        "true",
+        "t",
+        "yes",
+        "y",
+        "sim",
+        "on",
+        "habilitado",
+        "habilitada",
+        "ativo",
+        "ativa",
+      ].includes(normalized)
+    ) {
+      return true;
+    }
+
+    if (
+      [
+        "0",
+        "false",
+        "f",
+        "no",
+        "n",
+        "nao",
+        "não",
+        "off",
+        "desabilitado",
+        "desabilitada",
+        "inativo",
+        "inativa",
+      ].includes(normalized)
+    ) {
+      return false;
+    }
+  }
+
+  return null;
+};
+
+const normalizeText = (value: unknown): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+export function PlanProvider({ children }: { children: ReactNode }) {
+  const { user, isAuthenticated } = useAuth();
+  const [plan, setPlan] = useState<PlanInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadPlan = useCallback(
+    async (signal?: AbortSignal): Promise<PlanInfo | null> => {
+      if (!isAuthenticated || user?.empresa_id == null) {
+        setPlan(null);
+        setError(null);
+        setIsLoading(false);
+        return null;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const [planosRes, empresaRes] = await Promise.all([
+          fetch(getApiUrl("planos"), {
+            headers: { Accept: "application/json" },
+            signal,
+          }),
+          fetch(getApiUrl(`empresas/${user.empresa_id}`), {
+            headers: { Accept: "application/json" },
+            signal,
+          }),
+        ]);
+
+        if (!planosRes.ok) {
+          throw new Error(`Falha ao carregar planos (HTTP ${planosRes.status})`);
+        }
+
+        if (!empresaRes.ok) {
+          throw new Error(
+            `Falha ao carregar empresa atual (HTTP ${empresaRes.status})`,
+          );
+        }
+
+        const [planosJson, empresaJson] = await Promise.all([
+          planosRes.json(),
+          empresaRes.json(),
+        ]);
+
+        if (signal?.aborted) {
+          return null;
+        }
+
+        const planos = extractRows(planosJson).map((row) => {
+          const id = toInteger(row.id);
+          const nome = normalizeText(row.nome);
+          const syncEnabled = parseBooleanFlag(
+            row.sincronizacao_processos_habilitada ??
+              row.sincronizacaoProcessosHabilitada,
+          );
+          const syncLimit = toNonNegativeInteger(
+            row.sincronizacao_processos_limite ??
+              row.sincronizacaoProcessosLimite,
+          );
+
+          return {
+            id,
+            nome,
+            sincronizacaoProcessosHabilitada: syncEnabled ?? true,
+            sincronizacaoProcessosLimite: syncLimit,
+          } satisfies PlanInfo;
+        });
+
+        const empresaRecord = extractRecord(empresaJson);
+        const planIdCandidates: number[] = [];
+        const rawPlanId = empresaRecord?.plano_id ?? empresaRecord?.plano;
+        const parsedPlanId = toInteger(rawPlanId);
+        if (parsedPlanId !== null) {
+          planIdCandidates.push(parsedPlanId);
+        }
+
+        const planNameCandidate = normalizeText(empresaRecord?.plano);
+
+        let selectedPlan: PlanInfo | null = null;
+
+        for (const candidateId of planIdCandidates) {
+          const found = planos.find((item) => item.id === candidateId);
+          if (found) {
+            selectedPlan = found;
+            break;
+          }
+        }
+
+        if (!selectedPlan && planNameCandidate) {
+          const normalizedName = planNameCandidate.toLowerCase();
+          selectedPlan =
+            planos.find(
+              (item) => (item.nome ?? "").toLowerCase() === normalizedName,
+            ) ?? null;
+        }
+
+        if (!selectedPlan) {
+          selectedPlan = {
+            id: parsedPlanId,
+            nome: planNameCandidate,
+            sincronizacaoProcessosHabilitada: true,
+            sincronizacaoProcessosLimite: null,
+          };
+        }
+
+        setPlan(selectedPlan);
+        setIsLoading(false);
+        setError(null);
+        return selectedPlan;
+      } catch (loadError) {
+        if (signal?.aborted) {
+          return null;
+        }
+
+        console.error("Erro ao carregar plano atual", loadError);
+        const message =
+          loadError instanceof Error
+            ? loadError.message
+            : "Não foi possível carregar o plano atual.";
+        setError(message);
+        setPlan(null);
+        setIsLoading(false);
+        return null;
+      }
+    },
+    [isAuthenticated, user?.empresa_id],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    loadPlan(controller.signal).catch((error) => {
+      if (error && (error as { name?: string }).name !== "AbortError") {
+        console.warn("Falha ao carregar plano", error);
+      }
+    });
+
+    return () => {
+      controller.abort();
+    };
+  }, [loadPlan]);
+
+  const refetch = useCallback(() => loadPlan(), [loadPlan]);
+
+  const value = useMemo<PlanContextValue>(
+    () => ({ plan, isLoading, error, refetch }),
+    [plan, isLoading, error, refetch],
+  );
+
+  return <PlanContext.Provider value={value}>{children}</PlanContext.Provider>;
+}
+
+export const usePlan = () => {
+  const context = useContext(PlanContext);
+  if (!context) {
+    throw new Error("usePlan deve ser utilizado dentro de um PlanProvider");
+  }
+  return context;
+};

--- a/frontend/src/pages/ProcessosSyncAction.test.tsx
+++ b/frontend/src/pages/ProcessosSyncAction.test.tsx
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { act } from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { ProcessosSyncAction, type Processo } from "./Processos";
+
+const baseProcesso: Processo = {
+  id: 1,
+  numero: "12345678901234567890",
+  dataDistribuicao: "01/01/2024",
+  status: "Ativo",
+  tipo: "Teste",
+  cliente: { id: 10, nome: "Cliente", documento: "", papel: "" },
+  advogados: [],
+  classeJudicial: "Classe",
+  assunto: "Assunto",
+  jurisdicao: "Jurisdição",
+  orgaoJulgador: "Órgão",
+  proposta: null,
+  ultimaSincronizacao: null,
+  consultasApiCount: 0,
+  movimentacoesCount: 0,
+};
+
+type RenderResult = {
+  container: HTMLElement;
+  unmount: () => void;
+};
+
+const renderWithTooltip = (element: React.ReactElement): RenderResult => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(<TooltipProvider>{element}</TooltipProvider>);
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+};
+
+describe("ProcessosSyncAction", () => {
+  it("não renderiza o botão quando o plano bloqueia a sincronização", () => {
+    const { container, unmount } = renderWithTooltip(
+      <ProcessosSyncAction
+        allowsSync={false}
+        syncLimit={null}
+        processo={baseProcesso}
+        isSyncing={false}
+        onSync={() => {}}
+      />,
+    );
+
+    try {
+      const button = container.querySelector("button");
+      expect(button).toBeNull();
+      expect(container.textContent).toContain("Sincronização indisponível");
+    } finally {
+      unmount();
+    }
+  });
+
+  it("desabilita o botão quando o limite de sincronizações do plano é atingido", () => {
+    const processoComLimite: Processo = {
+      ...baseProcesso,
+      consultasApiCount: 3,
+    };
+
+    const { container, unmount } = renderWithTooltip(
+      <ProcessosSyncAction
+        allowsSync
+        syncLimit={3}
+        processo={processoComLimite}
+        isSyncing={false}
+        onSync={() => {}}
+      />,
+    );
+
+    try {
+      const button = container.querySelector("button");
+      expect(button).not.toBeNull();
+      expect(button?.disabled).toBe(true);
+    } finally {
+      unmount();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- expose plan details via a new PlanProvider context and use it in the CRM layout
- gate process sync actions on the frontend according to plan flags/limits and add targeted tests
- enforce plan restrictions in syncProcessoMovimentacoes, surface plan metadata through plan APIs, and adjust template placeholder fallbacks

## Testing
- npm test (backend)
- npm test (frontend) *(fails: vitest not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d94cd51c8326ba2ee412fe570548