### PR TITLE
Implement forced password change flow

### DIFF
--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -1,5 +1,11 @@
 import { Router } from 'express';
-import { getCurrentUser, login, refreshToken, register } from '../controllers/authController';
+import {
+  changePassword,
+  getCurrentUser,
+  login,
+  refreshToken,
+  register,
+} from '../controllers/authController';
 import { authenticateRequest } from '../middlewares/authMiddleware';
 
 const router = Router();
@@ -118,6 +124,53 @@ router.post('/auth/register', register);
  *         description: Credenciais inválidas
  */
 router.post('/auth/login', login);
+
+/**
+ * @swagger
+ * /api/auth/change-password:
+ *   post:
+ *     summary: Atualiza a senha utilizando a senha provisória fornecida
+ *     tags: [Autenticação]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - temporaryPassword
+ *               - newPassword
+ *               - confirmPassword
+ *             properties:
+ *               temporaryPassword:
+ *                 type: string
+ *                 format: password
+ *               newPassword:
+ *                 type: string
+ *                 format: password
+ *               confirmPassword:
+ *                 type: string
+ *                 format: password
+ *     responses:
+ *       200:
+ *         description: Senha atualizada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *       400:
+ *         description: Dados inválidos ou senha provisória incorreta
+ *       401:
+ *         description: Token ausente ou inválido
+ *       404:
+ *         description: Usuário não encontrado
+ */
+router.post('/auth/change-password', authenticateRequest, changePassword);
 
 /**
  * @swagger

--- a/backend/src/services/passwordResetService.ts
+++ b/backend/src/services/passwordResetService.ts
@@ -69,7 +69,7 @@ export async function createPasswordResetRequest(user: TargetUser): Promise<void
       typeof previousPasswordRow.senha === 'string' ? previousPasswordRow.senha : null;
 
     await client.query(
-      'UPDATE public.usuarios SET senha = $1 WHERE id = $2',
+      'UPDATE public.usuarios SET senha = $1, must_change_password = TRUE WHERE id = $2',
       [hashedPassword, user.id]
     );
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -164,6 +164,7 @@ const App = () => (
               </Route>
               <Route path="/financeiro/lancamentos" element={withModule("financeiro", <FinancialFlows />)} />
               <Route path="/relatorios" element={withModule("relatorios", <Relatorios />)} />
+              <Route path="/alterar-senha" element={<AlterarSenha />} />
               <Route path="/meu-perfil" element={<MeuPerfil />} />
               <Route path="/meu-plano" element={withModule("meu-plano", <MeuPlano />)} />
               <Route path="/suporte" element={withModule("suporte", <Suporte />)} />

--- a/frontend/src/features/auth/AuthProvider.tsx
+++ b/frontend/src/features/auth/AuthProvider.tsx
@@ -193,11 +193,21 @@ const sanitizeAuthUser = (user: AuthUser | undefined | null): AuthUser | null =>
     ? candidate.modulos.filter((module): module is string => typeof module === "string")
     : [];
   const subscription = sanitizeAuthSubscription(candidate.subscription ?? null);
+  const record = candidate as Record<string, unknown>;
+  const mustChangePassword =
+    parseBooleanFlag(
+      record.mustChangePassword ??
+        record.must_change_password ??
+        record.must_change ??
+        record.must_change_pass ??
+        record.must_change_password_flag,
+    ) ?? false;
 
   return {
     ...candidate,
     modulos: modules,
     subscription: subscription ?? null,
+    mustChangePassword,
   } satisfies AuthUser;
 };
 

--- a/frontend/src/features/auth/ProtectedRoute.test.tsx
+++ b/frontend/src/features/auth/ProtectedRoute.test.tsx
@@ -35,6 +35,7 @@ describe("ProtectedRoute", () => {
       isAuthenticated: true,
       isLoading: false,
       user: {
+        mustChangePassword: false,
         subscription: { status: "inactive" },
       },
     } as unknown as ReturnType<typeof useAuth>);
@@ -60,6 +61,37 @@ describe("ProtectedRoute", () => {
     expect(container.textContent).toContain("Seleção de plano");
   });
 
+  it("redirects users that must update their password", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      user: {
+        mustChangePassword: true,
+        subscription: { status: "active" },
+      },
+    } as unknown as ReturnType<typeof useAuth>);
+
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={["/clientes"]}>
+          <Routes>
+            <Route
+              path="/clientes"
+              element={
+                <ProtectedRoute>
+                  <div>Área restrita</div>
+                </ProtectedRoute>
+              }
+            />
+            <Route path="/alterar-senha" element={<div>Alterar Senha</div>} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    expect(container.textContent).toContain("Alterar Senha");
+  });
+
   it("allows access when the subscription is within the grace period", () => {
     const now = new Date("2024-06-15T12:00:00.000Z");
     vi.setSystemTime(now);
@@ -68,6 +100,7 @@ describe("ProtectedRoute", () => {
       isAuthenticated: true,
       isLoading: false,
       user: {
+        mustChangePassword: false,
         subscription: {
           status: "grace_period",
           planId: 1,
@@ -108,6 +141,7 @@ describe("ProtectedRoute", () => {
       isAuthenticated: true,
       isLoading: false,
       user: {
+        mustChangePassword: false,
         subscription: {
           status: "past_due",
           planId: 1,

--- a/frontend/src/features/auth/ProtectedRoute.tsx
+++ b/frontend/src/features/auth/ProtectedRoute.tsx
@@ -30,6 +30,14 @@ export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
     return <Navigate to={routes.login} replace state={{ from: location }} />;
   }
 
+  const mustChangePassword = user?.mustChangePassword ?? false;
+  const isOnForcedPasswordRoute =
+    location.pathname === "/alterar-senha" || /\/configuracoes\/usuarios\/.+\/senha$/.test(location.pathname);
+
+  if (mustChangePassword && !isOnForcedPasswordRoute) {
+    return <Navigate to="/alterar-senha" replace state={{ from: location }} />;
+  }
+
   const { hasAccess } = evaluateSubscriptionAccess(user?.subscription ?? null);
   const requiresPlanSelection = !hasAccess;
   const isOnPlanRoute = location.pathname.startsWith(PLAN_SELECTION_PATH);

--- a/frontend/src/features/auth/types.ts
+++ b/frontend/src/features/auth/types.ts
@@ -27,6 +27,7 @@ export interface AuthUser {
   setor_id: number | null;
   setor_nome: string | null;
   subscription: AuthSubscription | null;
+  mustChangePassword: boolean;
 }
 
 export interface LoginCredentials {


### PR DESCRIPTION
## Summary
- extend authentication responses to expose the must_change_password flag, add a transactional change-password controller, and mark reset requests to require password updates
- document and expose the new /api/auth/change-password endpoint while covering the flow with backend tests
- surface the flag in the frontend auth types, redirect logic, and login screen, and turn the AlterarSenha page into a working form that calls the new API

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test` *(fails: vitest could not be installed due to 403 from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d33712bd8c832699fd1aa4d33c4be8