### PR TITLE
feat: generate onboarding passwords server-side

### DIFF
--- a/backend/src/controllers/usuarioController.ts
+++ b/backend/src/controllers/usuarioController.ts
@@ -1,6 +1,23 @@
 import { Request, Response } from 'express';
 import pool from '../services/db';
-import { createPasswordResetRequest } from '../services/passwordResetService';
+import {
+  createPasswordResetRequest,
+  generateTemporaryPassword,
+} from '../services/passwordResetService';
+import { hashPassword } from '../utils/passwordUtils';
+import { newUserWelcomeEmailService } from '../services/newUserWelcomeEmailService';
+
+let welcomeEmailService = newUserWelcomeEmailService;
+
+export const __setWelcomeEmailServiceForTests = (
+  service: typeof newUserWelcomeEmailService
+) => {
+  welcomeEmailService = service;
+};
+
+export const __resetWelcomeEmailServiceForTests = () => {
+  welcomeEmailService = newUserWelcomeEmailService;
+};
 
 const parseOptionalId = (value: unknown): number | null | 'invalid' => {
   if (value === undefined || value === null) {
@@ -216,7 +233,6 @@ export const createUsuario = async (req: Request, res: Response) => {
     setor,
     oab,
     status,
-    senha,
     telefone,
     ultimo_login,
     observacoes,
@@ -287,24 +303,64 @@ export const createUsuario = async (req: Request, res: Response) => {
       }
     }
 
+    const normalizedEmail = typeof email === 'string' ? email.trim() : '';
+
+    if (normalizedEmail.length === 0) {
+      return res.status(400).json({ error: 'E-mail é obrigatório para criação de usuário.' });
+    }
+
+    const temporaryPassword = generateTemporaryPassword();
+    const hashedPassword = hashPassword(temporaryPassword);
+
     const result = await pool.query(
       'INSERT INTO public.usuarios (nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, NOW()) RETURNING id, nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao',
       [
         nome_completo,
         cpf,
-        email,
+        normalizedEmail,
         perfil,
         empresaId,
         setorId,
         oab,
         parsedStatus,
-        senha,
+        hashedPassword,
         telefone,
         ultimo_login,
         observacoes,
       ]
     );
-    res.status(201).json(result.rows[0]);
+
+    const createdUser = result.rows[0];
+    const userNameForEmail =
+      typeof nome_completo === 'string' && nome_completo.trim().length > 0
+        ? nome_completo
+        : 'Usuário';
+
+    try {
+      await welcomeEmailService.sendWelcomeEmail({
+        to: normalizedEmail,
+        userName: userNameForEmail,
+        temporaryPassword,
+      });
+    } catch (emailError) {
+      console.error('Erro ao enviar senha provisória para novo usuário', emailError);
+
+      const createdUserId = parseOptionalId((createdUser as { id?: unknown })?.id);
+
+      if (createdUserId !== 'invalid' && createdUserId !== null) {
+        try {
+          await pool.query('DELETE FROM public.usuarios WHERE id = $1', [createdUserId]);
+        } catch (cleanupError) {
+          console.error('Falha ao remover usuário após erro no envio de e-mail', cleanupError);
+        }
+      }
+
+      return res
+        .status(500)
+        .json({ error: 'Não foi possível enviar a senha provisória para o novo usuário.' });
+    }
+
+    res.status(201).json(createdUser);
   } catch (error) {
     console.error(error);
     res.status(500).json({ error: 'Internal server error' });

--- a/backend/src/routes/usuarioRoutes.ts
+++ b/backend/src/routes/usuarioRoutes.ts
@@ -119,6 +119,7 @@ router.get(['/usuarios/:id', '/users/:id'], getUsuarioById);
  *   post:
  *     summary: Cria um novo usuário
  *     tags: [Usuarios]
+ *     description: A senha inicial é gerada automaticamente e enviada por e-mail ao usuário.
  *     requestBody:
  *       required: true
  *       content:
@@ -142,8 +143,6 @@ router.get(['/usuarios/:id', '/users/:id'], getUsuarioById);
  *                 type: string
  *               status:
  *                 type: boolean
- *               senha:
- *                 type: string
  *               telefone:
  *                 type: string
  *               ultimo_login:

--- a/backend/src/services/newUserWelcomeEmailService.ts
+++ b/backend/src/services/newUserWelcomeEmailService.ts
@@ -1,0 +1,41 @@
+import { sendEmail } from './emailService';
+import { buildNewUserWelcomeEmail } from './newUserWelcomeEmailTemplate';
+
+export interface SendWelcomeEmailParams {
+  to: string;
+  userName: string;
+  temporaryPassword: string;
+}
+
+type SendWelcomeEmailFn = (params: SendWelcomeEmailParams) => Promise<void>;
+
+const defaultSendWelcomeEmail: SendWelcomeEmailFn = async ({
+  to,
+  userName,
+  temporaryPassword,
+}: SendWelcomeEmailParams) => {
+  const emailContent = buildNewUserWelcomeEmail({ userName, temporaryPassword });
+
+  await sendEmail({
+    to,
+    subject: emailContent.subject,
+    html: emailContent.html,
+    text: emailContent.text,
+  });
+};
+
+let sendWelcomeEmailImplementation: SendWelcomeEmailFn = defaultSendWelcomeEmail;
+
+export const newUserWelcomeEmailService = {
+  async sendWelcomeEmail(params: SendWelcomeEmailParams): Promise<void> {
+    await sendWelcomeEmailImplementation(params);
+  },
+};
+
+export const __setSendWelcomeEmailImplementationForTests = (fn: SendWelcomeEmailFn) => {
+  sendWelcomeEmailImplementation = fn;
+};
+
+export const __resetSendWelcomeEmailImplementationForTests = () => {
+  sendWelcomeEmailImplementation = defaultSendWelcomeEmail;
+};

--- a/backend/src/services/newUserWelcomeEmailTemplate.ts
+++ b/backend/src/services/newUserWelcomeEmailTemplate.ts
@@ -1,0 +1,71 @@
+import { escapeHtml } from '../utils/html';
+
+const DEFAULT_FRONTEND_BASE_URL =
+  process.env.FRONTEND_BASE_URL || 'https://quantumjud.quantumtecnologia.com.br';
+const SYSTEM_NAME = process.env.SYSTEM_NAME || 'Jus Connect';
+
+export interface NewUserWelcomeEmailContent {
+  subject: string;
+  text: string;
+  html: string;
+}
+
+interface BuildNewUserWelcomeEmailParams {
+  userName: string;
+  temporaryPassword: string;
+}
+
+function buildFrontendBaseUrl(): string {
+  const trimmed = DEFAULT_FRONTEND_BASE_URL.trim();
+
+  if (trimmed.length === 0) {
+    return 'https://quantumjud.quantumtecnologia.com.br';
+  }
+
+  return trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
+}
+
+function normalizeUserName(rawName: string): string {
+  const trimmed = rawName.trim();
+  return trimmed.length > 0 ? trimmed : 'Usuário';
+}
+
+export function buildNewUserWelcomeEmail({
+  userName,
+  temporaryPassword,
+}: BuildNewUserWelcomeEmailParams): NewUserWelcomeEmailContent {
+  const normalizedUserName = normalizeUserName(userName);
+  const frontendBaseUrl = buildFrontendBaseUrl();
+
+  const subject = `${SYSTEM_NAME} - Acesso ao sistema`;
+  const textLines = [
+    `Olá ${normalizedUserName},`,
+    '',
+    `Sua conta no ${SYSTEM_NAME} foi criada com sucesso.`,
+    'Utilize a senha provisória abaixo para realizar o primeiro acesso:',
+    temporaryPassword,
+    '',
+    `Acesse: ${frontendBaseUrl}`,
+    '',
+    'Recomendamos alterar a senha após concluir o primeiro login.',
+  ];
+
+  const text = `${textLines.join('\n')}\n`;
+
+  const htmlLines = [
+    `<p>Olá ${escapeHtml(normalizedUserName)},</p>`,
+    `<p>Sua conta no ${escapeHtml(SYSTEM_NAME)} foi criada com sucesso.</p>`,
+    '<p>Utilize a senha provisória abaixo para realizar o primeiro acesso:</p>',
+    `<p style="font-size: 18px; font-weight: bold;">${escapeHtml(temporaryPassword)}</p>`,
+    `<p>Acesse: <a href="${escapeHtml(frontendBaseUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(frontendBaseUrl)}</a></p>`,
+    '<p>Recomendamos alterar a senha após concluir o primeiro login.</p>',
+  ];
+
+  const html = htmlLines.join('\n');
+
+  return {
+    subject,
+    text,
+    html,
+  };
+}

--- a/backend/src/services/passwordResetService.ts
+++ b/backend/src/services/passwordResetService.ts
@@ -15,7 +15,7 @@ interface TargetUser {
   email: string;
 }
 
-function generateTemporaryPassword(length = 12): string {
+export function generateTemporaryPassword(length = 12): string {
   const charset = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789@#$%';
   const bytes = crypto.randomBytes(length);
   let password = '';


### PR DESCRIPTION
## Summary
- generate temporary passwords when creating a user and send welcome emails with rollback on failure
- add reusable welcome email template/service and expose helpers for tests
- extend password reset utilities and tests to cover the new behavior and document the API change

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3362183208326aeb034e3def7061a