### PR TITLE
Improve mobile responsiveness across CRM

### DIFF
--- a/frontend/src/components/layout/CRMLayout.tsx
+++ b/frontend/src/components/layout/CRMLayout.tsx
@@ -28,15 +28,15 @@ export function CRMLayout() {
   useAutoLogout(handleAutoLogout);
   const isConversationsRoute = location.pathname.startsWith("/conversas");
   const rootClassName = cn(
-    "flex w-full",
+    "flex w-full flex-col md:flex-row",
     isConversationsRoute ? "h-dvh overflow-hidden" : "min-h-screen bg-background",
   );
   const containerClassName = cn(
-    "flex-1 flex min-h-0 flex-col",
+    "flex min-h-0 w-full flex-1 flex-col md:min-w-0",
     isConversationsRoute && "h-full",
   );
   const mainClassName = cn(
-    "flex-1 flex flex-col min-h-0",
+    "flex flex-1 flex-col min-h-0 w-full min-w-0",
     isConversationsRoute ? "h-full overflow-hidden" : "overflow-auto",
   );
 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -5,11 +5,11 @@ import { SidebarTrigger } from "@/components/ui/sidebar";
 
 export function Header() {
   return (
-    <header className="h-16 bg-card border-b border-border px-6 flex items-center justify-between gap-4">
+    <header className="flex flex-wrap items-center gap-3 border-b border-border bg-card px-4 py-3 sm:px-6 sm:py-4">
       {/* Search */}
-      <div className="flex flex-1 items-center gap-3">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
         <SidebarTrigger className="text-muted-foreground" />
-        <div className="flex-1 max-w-md">
+        <div className="max-w-md flex-1">
           <div className="relative">
             {/*<Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />*/}
             {/*<Input*/}

--- a/frontend/src/components/layout/HeaderActions.tsx
+++ b/frontend/src/components/layout/HeaderActions.tsx
@@ -66,23 +66,23 @@ export function HeaderActions() {
   }, [logout, navigate]);
 
   return (
-    <div className="flex items-center gap-3">
+    <div className="flex min-w-0 flex-1 flex-wrap items-center justify-end gap-2 sm:gap-3">
       <ModeToggle />
       <IntimacaoMenu />
 
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" className="flex items-center gap-2">
+          <Button variant="ghost" className="flex min-w-0 items-center gap-2 px-2 py-1.5 sm:px-3">
             <Avatar className="h-8 w-8">
               <AvatarFallback className="bg-primary text-primary-foreground">
                 {getInitials(user?.nome_completo)}
               </AvatarFallback>
             </Avatar>
-            <div className="text-left">
-              <p className="text-sm font-medium truncate max-w-[160px]">
+            <div className="hidden min-w-0 text-left sm:block">
+              <p className="max-w-[160px] truncate text-sm font-medium">
                 {user?.nome_completo ?? "Usuário"}
               </p>
-              <p className="text-xs text-muted-foreground truncate max-w-[160px]">
+              <p className="max-w-[160px] truncate text-xs text-muted-foreground">
                 {user?.email ?? "Conta"}
               </p>
             </div>

--- a/frontend/src/features/auth/TrialBanner.tsx
+++ b/frontend/src/features/auth/TrialBanner.tsx
@@ -152,7 +152,7 @@ export function TrialBanner({ className }: TrialBannerProps) {
     <Alert
       variant="destructive"
       className={cn(
-        "relative flex w-full shrink-0 flex-col gap-4 border-b border-t-0 border-destructive/40 bg-destructive/10 px-6 py-4 text-destructive dark:text-destructive-foreground sm:flex-row sm:items-center",
+        "relative flex w-full shrink-0 flex-col gap-4 border-b border-t-0 border-destructive/40 bg-destructive/10 px-4 py-4 text-destructive dark:text-destructive-foreground sm:flex-row sm:items-center sm:px-6",
 
         className,
       )}

--- a/frontend/src/pages/Agenda.tsx
+++ b/frontend/src/pages/Agenda.tsx
@@ -638,7 +638,7 @@ export default function Agenda() {
   };
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>

--- a/frontend/src/pages/Clientes.tsx
+++ b/frontend/src/pages/Clientes.tsx
@@ -151,7 +151,7 @@ export default function Clientes() {
   };
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>

--- a/frontend/src/pages/ContratoPreview.tsx
+++ b/frontend/src/pages/ContratoPreview.tsx
@@ -22,14 +22,14 @@ export default function ContratoPreview() {
 
   if (!client || !processo) {
     return (
-      <div className="p-6">
+      <div className="p-4 sm:p-6">
         <p>Contrato não encontrado</p>
       </div>
     );
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="flex items-center justify-between print:hidden">
         <Button variant="outline" onClick={() => navigate(-1)}>
           Voltar

--- a/frontend/src/pages/EditarCliente.tsx
+++ b/frontend/src/pages/EditarCliente.tsx
@@ -197,14 +197,14 @@ export default function EditarCliente() {
 
   if (loading) {
     return (
-      <div className="p-6">
+      <div className="p-4 sm:p-6">
         <p className="text-muted-foreground">Carregando…</p>
       </div>
     );
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold text-foreground">Editar Cliente</h1>

--- a/frontend/src/pages/EditarFornecedor.tsx
+++ b/frontend/src/pages/EditarFornecedor.tsx
@@ -194,14 +194,14 @@ export default function EditarFornecedor() {
 
   if (loading) {
     return (
-      <div className="p-6">
+      <div className="p-4 sm:p-6">
         <p className="text-muted-foreground">Carregando…</p>
       </div>
     );
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold text-foreground">Editar Fornecedor</h1>

--- a/frontend/src/pages/EditarOportunidade.tsx
+++ b/frontend/src/pages/EditarOportunidade.tsx
@@ -534,7 +534,7 @@ export default function EditarOportunidade() {
   };
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold text-foreground">Editar Proposta</h1>

--- a/frontend/src/pages/FinancialFlows.tsx
+++ b/frontend/src/pages/FinancialFlows.tsx
@@ -769,12 +769,12 @@ const FinancialFlows = () => {
 
   if (isLoading) {
     return (
-      <div className="p-6 space-y-6">
+      <div className="p-4 sm:p-6 space-y-6">
         <div>
           <Skeleton className="h-9 w-64" />
           <Skeleton className="mt-2 h-5 w-80" />
         </div>
-        <Card className="p-6 space-y-4">
+        <Card className="p-4 sm:p-6 space-y-4">
           <Skeleton className="h-6 w-48" />
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
             {Array.from({ length: 4 }).map((_, index) => (
@@ -790,8 +790,8 @@ const FinancialFlows = () => {
 
   if (isError) {
     return (
-      <div className="p-6 space-y-6">
-        <div className="flex items-center gap-3 rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-destructive">
+      <div className="p-4 sm:p-6 space-y-6">
+        <div className="flex items-center gap-3 rounded-lg border border-destructive/50 bg-destructive/10 p-4 sm:p-6 text-destructive">
           <AlertCircle className="h-6 w-6" />
           <div className="space-y-1">
             <h1 className="text-xl font-semibold">Não foi possível carregar os lançamentos financeiros</h1>
@@ -808,7 +808,7 @@ const FinancialFlows = () => {
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div>
         <h1 className="text-3xl font-bold">Lançamentos Financeiros</h1>
         <p className="mt-2 text-muted-foreground">
@@ -861,7 +861,7 @@ const FinancialFlows = () => {
           }
         }}
       >
-        <Card className="space-y-6 p-6">
+        <Card className="space-y-6 p-4 sm:p-6">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <h2 className="text-lg font-semibold">Resumo mensal do ano selecionado</h2>
@@ -1389,7 +1389,7 @@ const FinancialFlows = () => {
           </Tabs>
         </div>
       ) : (
-        <Card className="p-6 text-center text-muted-foreground">
+        <Card className="p-4 sm:p-6 text-center text-muted-foreground">
           {hasAnyFlow
             ? 'Nenhum lançamento atende aos filtros selecionados. Ajuste os filtros para visualizar outras cobranças.'
             : 'Nenhum lançamento financeiro cadastrado até o momento.'}

--- a/frontend/src/pages/Fornecedores.tsx
+++ b/frontend/src/pages/Fornecedores.tsx
@@ -163,7 +163,7 @@ export default function Fornecedores() {
   };
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold text-foreground">Fornecedores</h1>

--- a/frontend/src/pages/Intimacoes.tsx
+++ b/frontend/src/pages/Intimacoes.tsx
@@ -223,7 +223,7 @@ export default function Intimacoes() {
   const hasTypeData = typeData.some((item) => item.value > 0);
 
   return (
-    <div className="p-6 space-y-8">
+    <div className="p-4 sm:p-6 space-y-8">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div className="space-y-1">
           <h1 className="text-3xl font-bold">Intimações</h1>

--- a/frontend/src/pages/MeuPerfil.tsx
+++ b/frontend/src/pages/MeuPerfil.tsx
@@ -441,7 +441,7 @@ export default function MeuPerfil() {
   }, [profile?.name]);
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="space-y-1">
         <h1 className="text-3xl font-bold text-foreground">Meu Perfil</h1>
         <p className="text-muted-foreground">

--- a/frontend/src/pages/MeuPlano.tsx
+++ b/frontend/src/pages/MeuPlano.tsx
@@ -761,7 +761,7 @@ function MeuPlanoContent() {
   const hasMensalPricingAvailable = hasMensalPricing(planoExibido);
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="space-y-2">
         <h1 className="text-3xl font-bold">Meu Plano</h1>
         <p className="text-muted-foreground">
@@ -807,7 +807,7 @@ function MeuPlanoContent() {
               <div className="absolute -right-24 -top-24 h-64 w-64 rounded-full bg-primary/20 blur-3xl" />
               <div className="absolute -bottom-24 -left-10 h-56 w-56 rounded-full bg-primary/10 blur-3xl" />
             </div>
-            <CardContent className="relative z-10 space-y-8 p-6 md:p-10">
+            <CardContent className="relative z-10 space-y-8 p-4 sm:p-6 md:p-10">
               <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
                 <div className="space-y-4">
                   <div className="flex flex-wrap gap-2">

--- a/frontend/src/pages/NovaOportunidade.tsx
+++ b/frontend/src/pages/NovaOportunidade.tsx
@@ -608,7 +608,7 @@ export default function NovaOportunidade() {
   };
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold text-foreground">Nova Oportunidade</h1>

--- a/frontend/src/pages/NovoCliente.tsx
+++ b/frontend/src/pages/NovoCliente.tsx
@@ -137,7 +137,7 @@ export default function NovoCliente() {
   };
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold text-foreground">Novo Cliente</h1>

--- a/frontend/src/pages/NovoFornecedor.tsx
+++ b/frontend/src/pages/NovoFornecedor.tsx
@@ -214,7 +214,7 @@ export default function NovoFornecedor() {
   };
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold text-foreground">Novo Fornecedor</h1>

--- a/frontend/src/pages/NovoProcesso.tsx
+++ b/frontend/src/pages/NovoProcesso.tsx
@@ -103,14 +103,14 @@ export default function NovoProcesso() {
 
   if (!client) {
     return (
-      <div className="p-6">
+      <div className="p-4 sm:p-6">
         <p>Cliente não encontrado</p>
       </div>
     );
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div>
         <h1 className="text-3xl font-bold text-foreground">Nova Oportunidade</h1>
         <p className="text-muted-foreground">Cliente: {client.name}</p>

--- a/frontend/src/pages/Pipeline.tsx
+++ b/frontend/src/pages/Pipeline.tsx
@@ -549,7 +549,7 @@ export default function Pipeline() {
   };
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>

--- a/frontend/src/pages/PipelineMenu.tsx
+++ b/frontend/src/pages/PipelineMenu.tsx
@@ -42,7 +42,7 @@ export default function PipelineMenu() {
   }, [apiUrl]);
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold text-foreground">Pipelines</h1>
@@ -70,7 +70,7 @@ export default function PipelineMenu() {
         ))}
         {menus.length === 0 && (
           <Card>
-            <CardContent className="p-6 text-center text-muted-foreground">
+            <CardContent className="p-4 sm:p-6 text-center text-muted-foreground">
               Nenhum pipeline encontrado
             </CardContent>
           </Card>

--- a/frontend/src/pages/Processos.tsx
+++ b/frontend/src/pages/Processos.tsx
@@ -1494,7 +1494,7 @@ export default function Processos() {
   }, [processos, searchTerm, statusFilter, tipoFilter]);
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="space-y-1">
           <h1 className="text-3xl font-bold text-foreground">Processos</h1>

--- a/frontend/src/pages/Suporte.tsx
+++ b/frontend/src/pages/Suporte.tsx
@@ -598,7 +598,7 @@ export default function Suporte() {
     selectedRequest != null && canCancelRequest(selectedRequest);
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div>
         <h1 className="text-3xl font-bold text-foreground">Suporte</h1>
         <p className="text-muted-foreground">

--- a/frontend/src/pages/Tarefas.tsx
+++ b/frontend/src/pages/Tarefas.tsx
@@ -591,7 +591,7 @@ export default function Tarefas() {
   const taskDates = useMemo(() => tasks.map((t) => startOfDay(t.date)), [tasks]);
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold text-foreground">Tarefas</h1>

--- a/frontend/src/pages/VisualizarCliente.tsx
+++ b/frontend/src/pages/VisualizarCliente.tsx
@@ -1073,7 +1073,7 @@ export default function VisualizarCliente() {
 
   if (loading) {
     return (
-      <div className="p-6">
+      <div className="p-4 sm:p-6">
         <p className="text-muted-foreground">Carregando…</p>
       </div>
     );
@@ -1081,7 +1081,7 @@ export default function VisualizarCliente() {
 
   if (!client) {
     return (
-      <div className="p-6">
+      <div className="p-4 sm:p-6">
         <p>Cliente não encontrado</p>
       </div>
     );
@@ -1089,7 +1089,7 @@ export default function VisualizarCliente() {
 
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="flex items-center justify-between">
         <Button variant="outline" onClick={() => navigate(-1)}>
           Voltar
@@ -1560,7 +1560,7 @@ export default function VisualizarCliente() {
                       </Table>
                     </div>
                   ) : (
-                    <div className="p-6 text-center text-sm text-muted-foreground">
+                    <div className="p-4 sm:p-6 text-center text-sm text-muted-foreground">
                       Nenhuma movimentação financeira cadastrada para este cliente.
                     </div>
                   )}

--- a/frontend/src/pages/VisualizarFornecedor.tsx
+++ b/frontend/src/pages/VisualizarFornecedor.tsx
@@ -105,7 +105,7 @@ export default function VisualizarFornecedor() {
 
   if (loading) {
     return (
-      <div className="p-6">
+      <div className="p-4 sm:p-6">
         <p className="text-muted-foreground">Carregando…</p>
       </div>
     );
@@ -113,7 +113,7 @@ export default function VisualizarFornecedor() {
 
   if (!supplier) {
     return (
-      <div className="p-6">
+      <div className="p-4 sm:p-6">
         <Card>
           <CardHeader>
             <CardTitle>Fornecedor não encontrado</CardTitle>
@@ -133,7 +133,7 @@ export default function VisualizarFornecedor() {
     : "bg-muted text-muted-foreground";
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div className="space-y-1">
           <h1 className="text-3xl font-bold text-foreground">{supplier.nome}</h1>

--- a/frontend/src/pages/VisualizarOportunidade.tsx
+++ b/frontend/src/pages/VisualizarOportunidade.tsx
@@ -2773,7 +2773,7 @@ export default function VisualizarOportunidade() {
 
   if (!opportunity) {
     return (
-      <div className="p-6 space-y-4">
+      <div className="p-4 sm:p-6 space-y-4">
         <div className="flex items-center justify-between">
           <h1 className="text-3xl font-bold">Oportunidade</h1>
           <Button variant="outline" onClick={() => navigate(-1)}>
@@ -2857,7 +2857,7 @@ export default function VisualizarOportunidade() {
   const headerTitle = opportunity.title ?? `Proposta #${proposalNumber}`;
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       {/* Header / ações (REMOVIDO Duplicar) */}
       <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
         <div className="space-y-2">

--- a/frontend/src/pages/VisualizarProcesso.tsx
+++ b/frontend/src/pages/VisualizarProcesso.tsx
@@ -1071,7 +1071,7 @@ export default function VisualizarProcesso() {
 
   if (loading && !processo) {
     return (
-      <div className="space-y-6 p-6">
+      <div className="space-y-6 p-4 sm:p-6">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <Skeleton className="h-10 w-32" />
           <div className="space-y-2 lg:w-1/2">
@@ -1090,7 +1090,7 @@ export default function VisualizarProcesso() {
 
   if (!processo) {
     return (
-      <div className="space-y-6 p-6">
+      <div className="space-y-6 p-4 sm:p-6">
         <Button variant="outline" onClick={() => navigate(-1)} className="w-fit">
           <ArrowLeft className="mr-2 h-4 w-4" />
           Voltar
@@ -1108,7 +1108,7 @@ export default function VisualizarProcesso() {
   }
 
   return (
-    <div className="space-y-6 p-6">
+    <div className="space-y-6 p-4 sm:p-6">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <Button variant="outline" onClick={() => navigate(-1)} className="w-fit">
           <ArrowLeft className="mr-2 h-4 w-4" />
@@ -1274,7 +1274,7 @@ export default function VisualizarProcesso() {
                 </CardHeader>
                 <CardContent>
                   {ultimasMovimentacoes.length === 0 ? (
-                    <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-6 text-sm text-muted-foreground">
+                    <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-4 sm:p-6 text-sm text-muted-foreground">
                       Nenhuma movimentação foi registrada até o momento.
                     </div>
                   ) : (
@@ -1401,7 +1401,7 @@ export default function VisualizarProcesso() {
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
-                  <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-6 text-sm text-muted-foreground">
+                  <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-4 sm:p-6 text-sm text-muted-foreground">
                     Nenhum recurso ou desdobramento cadastrado para este processo.
                   </div>
                 </CardContent>
@@ -1415,7 +1415,7 @@ export default function VisualizarProcesso() {
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
-                  <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-6 text-sm text-muted-foreground">
+                  <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-4 sm:p-6 text-sm text-muted-foreground">
                     Nenhum processo apensado foi registrado.
                   </div>
                 </CardContent>
@@ -1580,7 +1580,7 @@ export default function VisualizarProcesso() {
                   <AlertDescription>{documentosError}</AlertDescription>
                 </Alert>
               ) : documentosPublicos.length === 0 ? (
-                <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-6 text-sm text-muted-foreground">
+                <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-4 sm:p-6 text-sm text-muted-foreground">
                   Nenhum documento público foi disponibilizado para este processo até o momento.
                 </div>
               ) : (
@@ -1702,7 +1702,7 @@ export default function VisualizarProcesso() {
             </CardHeader>
             <CardContent className="space-y-6">
               {processo.movimentacoes.length === 0 ? (
-                <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-6 text-sm text-muted-foreground">
+                <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-4 sm:p-6 text-sm text-muted-foreground">
                   Nenhuma movimentação foi sincronizada até o momento. Utilize a ação de sincronização na listagem de processos para importar os dados do tribunal.
                 </div>
               ) : (

--- a/frontend/src/pages/configuracoes/Empresas.tsx
+++ b/frontend/src/pages/configuracoes/Empresas.tsx
@@ -115,7 +115,7 @@ export default function Empresas() {
   };
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold text-foreground">Empresas</h1>

--- a/frontend/src/pages/configuracoes/Integracoes.tsx
+++ b/frontend/src/pages/configuracoes/Integracoes.tsx
@@ -791,7 +791,7 @@ export default function Integracoes() {
   };
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="space-y-1">
         <h1 className="text-3xl font-bold text-foreground">Integrações</h1>
         <p className="text-muted-foreground">

--- a/frontend/src/pages/configuracoes/NovaEmpresa.tsx
+++ b/frontend/src/pages/configuracoes/NovaEmpresa.tsx
@@ -76,7 +76,7 @@ export default function NovaEmpresa() {
   };
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold text-foreground">Nova Empresa</h1>

--- a/frontend/src/pages/configuracoes/parametros/Etiquetas.tsx
+++ b/frontend/src/pages/configuracoes/parametros/Etiquetas.tsx
@@ -238,7 +238,7 @@ export default function Etiquetas() {
   };
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div>
         <h1 className="text-3xl font-bold text-foreground">Etiquetas</h1>
         <p className="text-muted-foreground">Gerencie as etiquetas</p>

--- a/frontend/src/pages/configuracoes/parametros/FluxoTrabalho.tsx
+++ b/frontend/src/pages/configuracoes/parametros/FluxoTrabalho.tsx
@@ -182,7 +182,7 @@ export default function FluxoTrabalho() {
   };
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div>
         <h1 className="text-3xl font-bold text-foreground">Fluxo de Trabalho</h1>
         <p className="text-muted-foreground">Gerencie os fluxos de trabalho</p>

--- a/frontend/src/pages/configuracoes/parametros/ParameterPage.tsx
+++ b/frontend/src/pages/configuracoes/parametros/ParameterPage.tsx
@@ -179,7 +179,7 @@ export default function ParameterPage({
     };
 
     return (
-        <div className="p-6 space-y-6">
+        <div className="p-4 sm:p-6 space-y-6">
             <div>
                 <h1 className="text-3xl font-bold text-foreground">{title}</h1>
                 <p className="text-muted-foreground">{description}</p>

--- a/frontend/src/pages/configuracoes/parametros/Perfis.tsx
+++ b/frontend/src/pages/configuracoes/parametros/Perfis.tsx
@@ -384,7 +384,7 @@ export default function Perfis() {
   };
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div>
         <h1 className="text-3xl font-bold text-foreground">Perfis</h1>
         <p className="text-muted-foreground">Gerencie os perfis do sistema e seus módulos de acesso.</p>

--- a/frontend/src/pages/configuracoes/parametros/Setores.tsx
+++ b/frontend/src/pages/configuracoes/parametros/Setores.tsx
@@ -337,7 +337,7 @@ export default function Setores() {
   };
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="flex items-center justify-between gap-4 flex-wrap">
         <div>
           <h1 className="text-3xl font-bold text-foreground">Setores</h1>

--- a/frontend/src/pages/configuracoes/usuarios/EditarPerfil.tsx
+++ b/frontend/src/pages/configuracoes/usuarios/EditarPerfil.tsx
@@ -401,7 +401,7 @@ export default function EditarPerfil() {
 
   if (isLoading) {
     return (
-      <div className="p-6 space-y-6">
+      <div className="p-4 sm:p-6 space-y-6">
         <div className="flex items-center gap-4">
           <Button variant="ghost" size="sm" onClick={handleBack}>
             <ArrowLeft className="h-4 w-4 mr-2" />
@@ -422,7 +422,7 @@ export default function EditarPerfil() {
 
   if (error) {
     return (
-      <div className="p-6 space-y-6">
+      <div className="p-4 sm:p-6 space-y-6">
         <div className="flex items-center gap-4">
           <Button variant="ghost" size="sm" onClick={handleBack}>
             <ArrowLeft className="h-4 w-4 mr-2" />
@@ -444,7 +444,7 @@ export default function EditarPerfil() {
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">

--- a/frontend/src/pages/configuracoes/usuarios/NovoUsuario.tsx
+++ b/frontend/src/pages/configuracoes/usuarios/NovoUsuario.tsx
@@ -153,7 +153,7 @@ export default function NovoUsuario() {
   };
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold text-foreground">Novo Usuário</h1>

--- a/frontend/src/pages/configuracoes/usuarios/Usuarios.tsx
+++ b/frontend/src/pages/configuracoes/usuarios/Usuarios.tsx
@@ -305,7 +305,7 @@ export default function Usuarios() {
   };
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-4 sm:p-6 space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>


### PR DESCRIPTION
## Summary
- adjust the CRM layout so the sidebar, header and outlet flex correctly on narrow viewports
- allow header actions to wrap and hide secondary text on small screens to avoid overflow
- replace rigid page padding with responsive spacing across client, finance and configuration screens and soften the trial banner padding

## Testing
- npm install *(fails: 403 Forbidden when downloading vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68d340002f648326b556bdb5742d9626