### PR TITLE
feat: format new plan price inputs

### DIFF
--- a/frontend/src/pages/administrator/NewPlan.tsx
+++ b/frontend/src/pages/administrator/NewPlan.tsx
@@ -35,10 +35,12 @@ import {
   initialPlanFormState,
   extractCollection,
   parseInteger,
-  parseDecimal,
   sanitizeLimitInput,
   orderModules,
   parseModuleInfo,
+  extractCurrencyDigits,
+  formatCurrencyInputValue,
+  parseCurrencyDigits,
 } from "./plans-utils";
 
 interface ModuleMultiSelectProps {
@@ -77,14 +79,14 @@ function ModuleMultiSelect({ modules, selected, onChange, disabled }: ModuleMult
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className="justify-between"
+          className="w-full justify-between"
           disabled={disabled || modules.length === 0}
         >
           <span className="truncate text-left">{triggerLabel}</span>
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[min(320px,90vw)] p-0">
+      <PopoverContent className="w-[min(420px,90vw)] p-0">
         <Command>
           <CommandInput placeholder="Buscar módulo..." />
           <CommandList>
@@ -206,6 +208,22 @@ export default function NewPlan() {
     }));
   };
 
+  const handleMonthlyPriceChange = (value: string) => {
+    const digits = extractCurrencyDigits(value);
+    setFormState((prev) => ({
+      ...prev,
+      monthlyPrice: formatCurrencyInputValue(digits),
+    }));
+  };
+
+  const handleAnnualPriceChange = (value: string) => {
+    const digits = extractCurrencyDigits(value);
+    setFormState((prev) => ({
+      ...prev,
+      annualPrice: formatCurrencyInputValue(digits),
+    }));
+  };
+
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
@@ -214,16 +232,16 @@ export default function NewPlan() {
     }
 
     const name = formState.name.trim();
-    const monthlyPriceInput = formState.monthlyPrice.trim();
-    const annualPriceInput = formState.annualPrice.trim();
-    if (!name || !monthlyPriceInput || !annualPriceInput) {
+    const monthlyPriceDigits = extractCurrencyDigits(formState.monthlyPrice);
+    const annualPriceDigits = extractCurrencyDigits(formState.annualPrice);
+    if (!name || !monthlyPriceDigits || !annualPriceDigits) {
       setSubmitError("Informe o nome, o valor mensal e o valor anual do plano.");
       setSubmitSuccess(null);
       return;
     }
 
-    const monthlyPriceValue = parseDecimal(monthlyPriceInput);
-    const annualPriceValue = parseDecimal(annualPriceInput);
+    const monthlyPriceValue = parseCurrencyDigits(monthlyPriceDigits);
+    const annualPriceValue = parseCurrencyDigits(annualPriceDigits);
     if (monthlyPriceValue == null || annualPriceValue == null) {
       setSubmitError("Informe valores numéricos válidos para os preços mensal e anual.");
       setSubmitSuccess(null);
@@ -335,9 +353,8 @@ export default function NewPlan() {
                   id="plan-monthly-price"
                   placeholder="Ex.: 199,90"
                   value={formState.monthlyPrice}
-                  onChange={(event) =>
-                    setFormState((prev) => ({ ...prev, monthlyPrice: event.target.value }))
-                  }
+                  inputMode="decimal"
+                  onChange={(event) => handleMonthlyPriceChange(event.target.value)}
                   disabled={submitting}
                 />
                 <p className="text-xs text-muted-foreground">
@@ -350,9 +367,8 @@ export default function NewPlan() {
                   id="plan-annual-price"
                   placeholder="Ex.: 1999,90"
                   value={formState.annualPrice}
-                  onChange={(event) =>
-                    setFormState((prev) => ({ ...prev, annualPrice: event.target.value }))
-                  }
+                  inputMode="decimal"
+                  onChange={(event) => handleAnnualPriceChange(event.target.value)}
                   disabled={submitting}
                 />
                 <p className="text-xs text-muted-foreground">

--- a/frontend/src/pages/administrator/plans-utils.ts
+++ b/frontend/src/pages/administrator/plans-utils.ts
@@ -238,6 +238,41 @@ export const sanitizeLimitInput = (value: string): string => {
   return value.replace(/[^0-9]/g, "");
 };
 
+const DIGIT_ONLY_REGEX = /\D+/g;
+
+const BRAZILIAN_CURRENCY_FORMATTER = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+});
+
+export const extractCurrencyDigits = (value: string): string => value.replace(DIGIT_ONLY_REGEX, "");
+
+export const formatCurrencyInputValue = (digits: string): string => {
+  if (!digits) {
+    return "";
+  }
+
+  const parsed = Number.parseInt(digits, 10);
+  if (Number.isNaN(parsed)) {
+    return "";
+  }
+
+  return BRAZILIAN_CURRENCY_FORMATTER.format(parsed / 100);
+};
+
+export const parseCurrencyDigits = (digits: string): number | null => {
+  if (!digits) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(digits, 10);
+  if (Number.isNaN(parsed)) {
+    return null;
+  }
+
+  return parsed / 100;
+};
+
 export const orderModules = (modules: string[], available: ModuleInfo[]): string[] => {
   if (modules.length <= 1 || available.length === 0) return [...modules];
   const index = new Map<string, number>();


### PR DESCRIPTION
## Summary
- format the monthly and annual price inputs in the new plan form as Brazilian currency while typing
- sanitize currency digits before submission to prevent extra decimal places when saving
- widen the module selection trigger and dropdown to make the available modules easier to browse

## Testing
- npm run lint *(fails: missing npm registry access for required packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d355b5a5e88326a13ffbc6235f2613