### PR TITLE
Normalize module ids before enforcing plan upgrades

### DIFF
--- a/frontend/src/features/auth/AuthProvider.tsx
+++ b/frontend/src/features/auth/AuthProvider.tsx
@@ -11,6 +11,7 @@ import {
 import { getApiBaseUrl } from "@/lib/api";
 import { DEFAULT_TIMEOUT_MS, LAST_ACTIVITY_KEY } from "@/hooks/useAutoLogout";
 import { ApiError, fetchCurrentUser, loginRequest, refreshTokenRequest } from "./api";
+import { sanitizeModuleList } from "./moduleUtils";
 import type {
   AuthSubscription,
   AuthUser,
@@ -189,9 +190,7 @@ const sanitizeAuthUser = (user: AuthUser | undefined | null): AuthUser | null =>
   }
 
   const candidate = user as AuthUser & { modulos?: unknown; subscription?: unknown };
-  const modules = Array.isArray(candidate.modulos)
-    ? candidate.modulos.filter((module): module is string => typeof module === "string")
-    : [];
+  const modules = sanitizeModuleList(candidate.modulos);
   const subscription = sanitizeAuthSubscription(candidate.subscription ?? null);
   const record = candidate as Record<string, unknown>;
   const mustChangePassword =

--- a/frontend/src/features/auth/RequireModule.tsx
+++ b/frontend/src/features/auth/RequireModule.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 
 import { PlanUpgradePrompt } from "./PlanUpgradePrompt";
 import { useAuth } from "./AuthProvider";
+import { createNormalizedModuleSet, normalizeModuleId } from "./moduleUtils";
 
 interface RequireModuleProps {
   module: string | string[];
@@ -15,9 +16,15 @@ export const RequireModule = ({ module, children }: RequireModuleProps) => {
     return null;
   }
 
-  const modules = user?.modulos ?? [];
+  const modules = createNormalizedModuleSet(user?.modulos ?? []);
   const requiredModules = Array.isArray(module) ? module : [module];
-  const hasAccess = requiredModules.some((moduleId) => modules.includes(moduleId));
+  const normalizedRequiredModules = requiredModules
+    .map((moduleId) => normalizeModuleId(moduleId))
+    .filter((moduleId): moduleId is string => Boolean(moduleId));
+
+  const hasAccess =
+    normalizedRequiredModules.length === 0 ||
+    normalizedRequiredModules.some((moduleId) => modules.has(moduleId));
 
   if (hasAccess) {
     return <>{children}</>;

--- a/frontend/src/features/auth/moduleUtils.ts
+++ b/frontend/src/features/auth/moduleUtils.ts
@@ -1,0 +1,60 @@
+const ACCENT_REGEX = /[\u0300-\u036f]/g;
+const NON_ALPHANUMERIC_REGEX = /[^\p{L}\p{N}]+/gu;
+const LEADING_HYPHENS_REGEX = /^-+|-+$/g;
+
+const normalize = (value: string): string =>
+  value
+    .normalize("NFD")
+    .replace(ACCENT_REGEX, "")
+    .replace(NON_ALPHANUMERIC_REGEX, "-")
+    .replace(LEADING_HYPHENS_REGEX, "")
+    .toLowerCase();
+
+export const normalizeModuleId = (value: unknown): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const normalized = normalize(trimmed);
+  return normalized || null;
+};
+
+export const sanitizeModuleList = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const unique = new Set<string>();
+
+  for (const entry of value) {
+    const moduleId = normalizeModuleId(entry);
+    if (!moduleId || unique.has(moduleId)) {
+      continue;
+    }
+
+    unique.add(moduleId);
+  }
+
+  return [...unique];
+};
+
+export const createNormalizedModuleSet = (modules: Iterable<string>): Set<string> => {
+  const normalized = new Set<string>();
+
+  for (const moduleId of modules) {
+    const normalizedId = normalizeModuleId(moduleId);
+    if (!normalizedId) {
+      continue;
+    }
+
+    normalized.add(normalizedId);
+  }
+
+  return normalized;
+};
+


### PR DESCRIPTION
## Summary
- sanitize module identifiers received from authentication to remove whitespace, accents and casing differences
- reuse the normalized identifiers when verifying module access so the plan upgrade prompt only shows for modules outside the subscription
- extract shared helpers for normalizing and deduplicating module identifiers

## Testing
- npm run lint *(fails: missing npm registry access to install @eslint/js and other dev dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d35c599f008326b9463c52ef415822