### PR TITLE
Fix production API base URL resolution

### DIFF
--- a/frontend/src/lib/adminApi.ts
+++ b/frontend/src/lib/adminApi.ts
@@ -1,12 +1,16 @@
 import { z } from "zod";
 
-const baseUrl = (import.meta.env.VITE_ADMIN_API_BASE_URL as string | undefined) ?? "http://localhost:3001";
+import { getApiBaseUrl } from "./api";
+
+const baseUrl =
+  (import.meta.env.VITE_ADMIN_API_BASE_URL as string | undefined)?.trim() ||
+  getApiBaseUrl();
 
 const ensureBaseUrl = () => {
   if (!baseUrl) {
     throw new Error("VITE_ADMIN_API_BASE_URL is not defined");
   }
-  return baseUrl.replace(/\/$/, "");
+  return baseUrl.replace(/\/+$/, "");
 };
 
 type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -14,6 +14,35 @@ function normalizeBaseUrl(url: string): string {
   return url.replace(/\/+$/, '');
 }
 
+const LOCAL_HOSTNAME_PATTERNS = [
+  'localhost',
+  '127.0.0.1',
+  '::1',
+];
+
+function isLocalhostUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    const normalizedHostname = hostname.toLowerCase();
+
+    return (
+      LOCAL_HOSTNAME_PATTERNS.includes(normalizedHostname) ||
+      normalizedHostname.endsWith('.localhost')
+    );
+  } catch {
+    return /(^|@|\b)(localhost|127\.0\.0\.1|::1)([:/]|\b)/i.test(url);
+  }
+}
+
+function getWindowOrigin(): string | undefined {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  const origin = window.location?.origin;
+  return origin ? normalizeBaseUrl(origin) : undefined;
+}
+
 function stripApiSuffix(url: string): string {
   const normalized = normalizeBaseUrl(url);
   return normalized.toLowerCase().endsWith('/api')
@@ -22,8 +51,24 @@ function stripApiSuffix(url: string): string {
 }
 
 function resolveFallbackBaseUrl(): string {
-  if (rawEnvApiUrl && rawEnvApiUrl.length > 0) {
-    return stripApiSuffix(rawEnvApiUrl);
+  const normalizedEnvUrl =
+    rawEnvApiUrl && rawEnvApiUrl.length > 0
+      ? stripApiSuffix(rawEnvApiUrl)
+      : undefined;
+
+  const windowOrigin = getWindowOrigin();
+
+  if (normalizedEnvUrl) {
+    if (
+      !isDevEnvironment &&
+      windowOrigin &&
+      !isLocalhostUrl(windowOrigin) &&
+      isLocalhostUrl(normalizedEnvUrl)
+    ) {
+      return windowOrigin;
+    }
+
+    return normalizedEnvUrl;
   }
 
   if (isDevEnvironment) {
@@ -33,8 +78,8 @@ function resolveFallbackBaseUrl(): string {
     return 'http://localhost:3001';
   }
 
-  if (typeof window !== 'undefined' && window.location?.origin) {
-    return normalizeBaseUrl(window.location.origin);
+  if (windowOrigin) {
+    return windowOrigin;
   }
 
   return PRODUCTION_DEFAULT_API_URL;


### PR DESCRIPTION
## Summary
- update API base URL resolution to avoid using localhost endpoints in production builds
- reuse the shared API base resolver for the admin API so it follows the same production fallback behavior

## Testing
- Not run (npm install failed with a 403 when downloading dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68d426cd90ec8326bda6bd34b9feb652