### PR TITLE
Improve production API URL resolution

### DIFF
--- a/frontend/src/lib/adminApi.ts
+++ b/frontend/src/lib/adminApi.ts
@@ -1,12 +1,17 @@
 import { z } from "zod";
 
-const baseUrl = (import.meta.env.VITE_ADMIN_API_BASE_URL as string | undefined) ?? "http://localhost:3001";
+import { getApiBaseUrl } from "./api";
+
+const adminBaseUrlFromEnv = (
+  import.meta.env.VITE_ADMIN_API_BASE_URL as string | undefined
+)?.trim();
 
 const ensureBaseUrl = () => {
-  if (!baseUrl) {
-    throw new Error("VITE_ADMIN_API_BASE_URL is not defined");
-  }
-  return baseUrl.replace(/\/$/, "");
+  const baseUrl = adminBaseUrlFromEnv?.length
+    ? adminBaseUrlFromEnv
+    : getApiBaseUrl();
+
+  return baseUrl.replace(/\/+$/, "");
 };
 
 type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";


### PR DESCRIPTION
## Summary
- re-resolve the API base URL when switching between server and browser contexts so production hosts are preferred over cached localhost values
- update the admin API client to derive its base URL at request time and normalize trailing slashes through the shared resolver

## Testing
- npm install *(fails with 403 when downloading dependencies from the npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d426cd90ec8326bda6bd34b9feb652