### PR TITLE
feat: add blog article page and admin management

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -66,6 +66,7 @@ import NotFound from "./pages/operator/NotFound";
 import SiteIndex from "./pages/site/Index";
 import SiteServices from "./pages/site/Services";
 import SiteBlog from "./pages/site/Blog";
+import SiteBlogArticle from "./pages/site/BlogArticle";
 import SiteHistory from "./pages/site/NossaHistoria";
 import SiteNotFound from "./pages/site/NotFound";
 import SiteServiceAssistenteIA from "./pages/site/services/AssistenteIA";
@@ -95,6 +96,7 @@ const AdminSubscriptions = lazy(() => import("./pages/administrator/Subscription
 const AdminNewSubscription = lazy(() => import("./pages/administrator/NewSubscription"));
 const AdminUsers = lazy(() => import("./pages/administrator/Users"));
 const AdminNewUser = lazy(() => import("./pages/administrator/NewUser"));
+const AdminBlogPosts = lazy(() => import("./pages/administrator/BlogPosts"));
 const AdminAnalytics = lazy(() => import("./pages/administrator/Analytics"));
 const AdminSupport = lazy(() => import("./pages/administrator/Support"));
 const AdminLogs = lazy(() => import("./pages/administrator/Logs"));
@@ -118,6 +120,7 @@ const App = () => (
             <Routes>
               <Route path={routes.home} element={<SiteIndex />} />
               <Route path="/blog" element={<SiteBlog />} />
+              <Route path="/blog/:slug" element={<SiteBlogArticle />} />
               <Route path="/nossa-historia" element={<SiteHistory />} />
               <Route path="/servicos" element={<SiteServices />} />
               <Route path="/servicos/assistente-ia" element={<SiteServiceAssistenteIA />} />
@@ -325,6 +328,7 @@ const App = () => (
                 <Route path={adminRelativePath.newSubscription} element={<AdminNewSubscription />} />
                 <Route path={adminRelativePath.users} element={<AdminUsers />} />
                 <Route path={adminRelativePath.newUser} element={<AdminNewUser />} />
+                <Route path={adminRelativePath.blog} element={<AdminBlogPosts />} />
                 <Route path={adminRelativePath.analytics} element={<AdminAnalytics />} />
                 <Route path={adminRelativePath.support} element={<AdminSupport />} />
                 <Route path={adminRelativePath.logs} element={<AdminLogs />} />

--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -20,6 +20,7 @@ import {
   HeadphonesIcon,
   Loader2,
   Settings,
+  Newspaper,
 } from "lucide-react";
 import { HeaderActions } from "@/components/layout/HeaderActions";
 
@@ -50,6 +51,11 @@ const navigation = [
     name: "Usuários",
     href: routes.admin.users,
     icon: Users,
+  },
+  {
+    name: "Blog",
+    href: routes.admin.blog,
+    icon: Newspaper,
   },
   {
     name: "Relatórios",

--- a/frontend/src/config/routes.ts
+++ b/frontend/src/config/routes.ts
@@ -4,6 +4,8 @@ const route = (path: string) => path;
 
 export const routes = {
   home: route("/"),
+  blog: route("/blog"),
+  blogPost: (slug: string) => route(`/blog/${slug}`),
   dashboard: route("/app"),
   login: route("/login"),
   register: route("/register"),
@@ -22,6 +24,7 @@ export const routes = {
     newSubscription: route(buildAdminPath("subscriptions", "new")),
     users: route(buildAdminPath("users")),
     newUser: route(buildAdminPath("users", "new")),
+    blog: route(buildAdminPath("blog")),
     analytics: route(buildAdminPath("analytics")),
     support: route(buildAdminPath("support")),
     logs: route(buildAdminPath("logs")),
@@ -51,6 +54,7 @@ export const adminRelativePath = {
   newSubscription: "subscriptions/new",
   users: "users",
   newUser: "users/new",
+  blog: "blog",
   analytics: "analytics",
   support: "support",
   logs: "logs",

--- a/frontend/src/lib/adminApi.ts
+++ b/frontend/src/lib/adminApi.ts
@@ -57,6 +57,7 @@ export const blogPostSchema = z.object({
   id: z.string().min(1),
   title: z.string().min(1),
   description: z.string().min(1),
+  content: z.string().min(1).optional(),
   author: z.string().min(1),
   date: z.string().min(1),
   readTime: z.string().min(1),
@@ -73,6 +74,7 @@ export type BlogPost = z.infer<typeof blogPostSchema>;
 
 export const blogPostInputSchema = blogPostSchema.partial({
   id: true,
+  content: true,
   createdAt: true,
   updatedAt: true,
 }).required({

--- a/frontend/src/pages/administrator/BlogPosts.tsx
+++ b/frontend/src/pages/administrator/BlogPosts.tsx
@@ -1,0 +1,501 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { useQueryClient, useMutation } from "@tanstack/react-query";
+import { Plus, Pencil, Trash2, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { useToast } from "@/hooks/use-toast";
+import { adminApi, blogPostKeys, type BlogPost, type BlogPostInput } from "@/lib/adminApi";
+import { useBlogPosts } from "@/hooks/useBlogPosts";
+
+interface BlogPostFormState {
+  title: string;
+  description: string;
+  author: string;
+  date: string;
+  readTime: string;
+  category: string;
+  slug: string;
+  tags: string;
+  image: string;
+  content: string;
+}
+
+const emptyFormState: BlogPostFormState = {
+  title: "",
+  description: "",
+  author: "",
+  date: "",
+  readTime: "",
+  category: "",
+  slug: "",
+  tags: "",
+  image: "",
+  content: "",
+};
+
+const normalizeTags = (value: string): string[] =>
+  value
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+
+const buildInputPayload = (state: BlogPostFormState): BlogPostInput => ({
+  title: state.title.trim(),
+  description: state.description.trim(),
+  author: state.author.trim(),
+  date: state.date.trim(),
+  readTime: state.readTime.trim(),
+  category: state.category.trim(),
+  slug: state.slug.trim(),
+  image: state.image.trim() || undefined,
+  content: state.content.trim() || undefined,
+  tags: normalizeTags(state.tags),
+});
+
+const formatDisplayDate = (value: string): string => {
+  const parsed = new Date(value);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toLocaleDateString("pt-BR", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    });
+  }
+
+  return value;
+};
+
+const BlogPosts = () => {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const {
+    data: posts = [],
+    isLoading,
+    isError,
+  } = useBlogPosts();
+
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [editingPost, setEditingPost] = useState<BlogPost | null>(null);
+  const [formState, setFormState] = useState<BlogPostFormState>(emptyFormState);
+
+  const sortedPosts = useMemo(
+    () =>
+      [...posts].sort((a, b) => {
+        const dateA = new Date(a.date).getTime();
+        const dateB = new Date(b.date).getTime();
+        return Number.isFinite(dateB) && Number.isFinite(dateA) ? dateB - dateA : a.title.localeCompare(b.title);
+      }),
+    [posts],
+  );
+
+  const resetForm = useCallback(() => {
+    setFormState(emptyFormState);
+  }, []);
+
+  useEffect(() => {
+    if (!isDialogOpen) {
+      setEditingPost(null);
+      resetForm();
+      return;
+    }
+
+    if (editingPost) {
+      setFormState({
+        title: editingPost.title,
+        description: editingPost.description,
+        author: editingPost.author,
+        date: editingPost.date,
+        readTime: editingPost.readTime,
+        category: editingPost.category,
+        slug: editingPost.slug,
+        tags: editingPost.tags.join(", "),
+        image: editingPost.image ?? "",
+        content: editingPost.content ?? "",
+      });
+    } else {
+      resetForm();
+    }
+  }, [editingPost, isDialogOpen, resetForm]);
+
+  const createPostMutation = useMutation({
+    mutationFn: async (input: BlogPostInput) => adminApi.createPost(input),
+    onSuccess: (created) => {
+      toast({
+        title: "Artigo publicado",
+        description: `O artigo “${created.title}” foi criado com sucesso.`,
+      });
+      queryClient.invalidateQueries({ queryKey: blogPostKeys.list() });
+      setIsDialogOpen(false);
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Erro ao publicar",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const updatePostMutation = useMutation({
+    mutationFn: async ({ id, input }: { id: string; input: BlogPostInput }) => adminApi.updatePost(id, input),
+    onSuccess: (updated) => {
+      toast({
+        title: "Artigo atualizado",
+        description: `O artigo “${updated.title}” foi atualizado com sucesso.`,
+      });
+      queryClient.invalidateQueries({ queryKey: blogPostKeys.list() });
+      setIsDialogOpen(false);
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Erro ao atualizar",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const deletePostMutation = useMutation({
+    mutationFn: async (id: string) => adminApi.deletePost(id),
+    onSuccess: () => {
+      toast({
+        title: "Artigo removido",
+        description: "O artigo foi excluído do blog.",
+      });
+      queryClient.invalidateQueries({ queryKey: blogPostKeys.list() });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Erro ao remover",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const payload = buildInputPayload(formState);
+
+    if (editingPost) {
+      updatePostMutation.mutate({ id: editingPost.id, input: payload });
+      return;
+    }
+
+    createPostMutation.mutate(payload);
+  };
+
+  const isSubmitting = createPostMutation.isPending || updatePostMutation.isPending;
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-bold">Gestão de blog</h1>
+          <p className="text-muted-foreground">
+            Centralize a criação, edição e publicação dos artigos do site institucional.
+          </p>
+        </div>
+        <Button
+          type="button"
+          size="lg"
+          onClick={() => {
+            setEditingPost(null);
+            setIsDialogOpen(true);
+          }}
+        >
+          <Plus className="mr-2 h-4 w-4" aria-hidden /> Novo artigo
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader className="border-b border-border">
+          <CardTitle>Artigos publicados</CardTitle>
+          <CardDescription>Visualize o desempenho dos conteúdos e mantenha o blog sempre atualizado.</CardDescription>
+        </CardHeader>
+        <CardContent className="px-0">
+          {isLoading ? (
+            <div className="flex min-h-[240px] items-center justify-center gap-2 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
+              Carregando artigos...
+            </div>
+          ) : isError ? (
+            <Alert variant="destructive" className="m-6">
+              <AlertTitle>Não foi possível carregar o blog</AlertTitle>
+              <AlertDescription>
+                Tente novamente em alguns instantes. Se o problema persistir, verifique a conexão com a API administrativa.
+              </AlertDescription>
+            </Alert>
+          ) : sortedPosts.length === 0 ? (
+            <div className="flex min-h-[240px] flex-col items-center justify-center gap-3 text-center">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+                <Pencil className="h-5 w-5 text-muted-foreground" aria-hidden />
+              </div>
+              <div className="space-y-1">
+                <h2 className="text-lg font-semibold">Nenhum artigo cadastrado ainda</h2>
+                <p className="max-w-md text-sm text-muted-foreground">
+                  Inicie a publicação de conteúdos clicando no botão “Novo artigo” para aumentar o alcance do seu site.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="min-w-[240px]">Título</TableHead>
+                    <TableHead>Categoria</TableHead>
+                    <TableHead>Autor</TableHead>
+                    <TableHead>Publicado em</TableHead>
+                    <TableHead className="text-right">Ações</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {sortedPosts.map((post) => (
+                    <TableRow key={post.id}>
+                      <TableCell>
+                        <div className="space-y-1">
+                          <p className="font-medium text-foreground">{post.title}</p>
+                          <p className="text-sm text-muted-foreground">{post.description}</p>
+                          <div className="flex flex-wrap gap-2 pt-2">
+                            {post.tags.map((tag) => (
+                              <Badge key={`${post.id}-${tag}`} variant="outline" className="text-xs">
+                                #{tag}
+                              </Badge>
+                            ))}
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">{post.category}</TableCell>
+                      <TableCell className="whitespace-nowrap">{post.author}</TableCell>
+                      <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
+                        {formatDisplayDate(post.date)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex items-center justify-end gap-2">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => {
+                              setEditingPost(post);
+                              setIsDialogOpen(true);
+                            }}
+                          >
+                            <Pencil className="h-4 w-4" aria-hidden />
+                            <span className="sr-only">Editar artigo</span>
+                          </Button>
+                          <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                              <Button type="button" variant="ghost" size="icon">
+                                <Trash2 className="h-4 w-4 text-destructive" aria-hidden />
+                                <span className="sr-only">Excluir artigo</span>
+                              </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                              <AlertDialogHeader>
+                                <AlertDialogTitle>Excluir este artigo?</AlertDialogTitle>
+                                <AlertDialogDescription>
+                                  Esta ação não poderá ser desfeita. O artigo será removido imediatamente do blog público.
+                                </AlertDialogDescription>
+                              </AlertDialogHeader>
+                              <AlertDialogFooter>
+                                <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                                <AlertDialogAction
+                                  onClick={() => deletePostMutation.mutate(post.id)}
+                                  disabled={deletePostMutation.isPending}
+                                >
+                                  {deletePostMutation.isPending ? (
+                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+                                  ) : null}
+                                  Excluir
+                                </AlertDialogAction>
+                              </AlertDialogFooter>
+                            </AlertDialogContent>
+                          </AlertDialog>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>{editingPost ? "Editar artigo" : "Novo artigo"}</DialogTitle>
+            <DialogDescription>
+              Preencha os campos abaixo para publicar um novo conteúdo ou atualizar um artigo existente.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form className="space-y-6" onSubmit={handleSubmit}>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="title">Título</Label>
+                <Input
+                  id="title"
+                  value={formState.title}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, title: event.target.value }))}
+                  required
+                  placeholder="Ex.: Como a IA transforma o atendimento jurídico"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="category">Categoria</Label>
+                <Input
+                  id="category"
+                  value={formState.category}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, category: event.target.value }))}
+                  required
+                  placeholder="Ex.: Transformação Digital"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="author">Autor</Label>
+                <Input
+                  id="author"
+                  value={formState.author}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, author: event.target.value }))}
+                  required
+                  placeholder="Nome do especialista"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="date">Data de publicação</Label>
+                <Input
+                  id="date"
+                  value={formState.date}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, date: event.target.value }))}
+                  required
+                  placeholder="2025-01-31"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="readTime">Tempo de leitura</Label>
+                <Input
+                  id="readTime"
+                  value={formState.readTime}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, readTime: event.target.value }))}
+                  required
+                  placeholder="Ex.: 6 min"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="slug">Slug</Label>
+                <Input
+                  id="slug"
+                  value={formState.slug}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, slug: event.target.value }))}
+                  required
+                  placeholder="ex.: ia-transforma-atendimento-juridico"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="image">Imagem destacada (URL)</Label>
+                <Input
+                  id="image"
+                  value={formState.image}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, image: event.target.value }))}
+                  placeholder="https://exemplo.com/imagem.jpg"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="tags">Tags (separe com vírgula)</Label>
+                <Input
+                  id="tags"
+                  value={formState.tags}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, tags: event.target.value }))}
+                  placeholder="automação, crm, tecnologia"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">Descrição breve</Label>
+              <Textarea
+                id="description"
+                value={formState.description}
+                onChange={(event) => setFormState((prev) => ({ ...prev, description: event.target.value }))}
+                required
+                placeholder="Resumo do conteúdo exibido nas listagens."
+                rows={3}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="content">Conteúdo completo</Label>
+              <Textarea
+                id="content"
+                value={formState.content}
+                onChange={(event) => setFormState((prev) => ({ ...prev, content: event.target.value }))}
+                placeholder="Insira os parágrafos do artigo separados por linhas em branco."
+                rows={8}
+              />
+            </div>
+
+            <DialogFooter className="gap-2 sm:space-x-2">
+              <Button type="button" variant="outline" onClick={() => setIsDialogOpen(false)}>
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden /> : null}
+                {editingPost ? "Salvar alterações" : "Publicar artigo"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default BlogPosts;

--- a/frontend/src/pages/site/Blog.tsx
+++ b/frontend/src/pages/site/Blog.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { ArrowRight, Calendar, Clock, Filter, Search, Sparkles, Tag, User } from "lucide-react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
@@ -12,11 +12,11 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useBlogPosts, type BlogPost } from "@/hooks/useBlogPosts";
 import { cn } from "@/lib/utils";
+import { routes } from "@/config/routes";
 import { trackEvent } from "@/lib/analytics";
 
 const BlogPage = () => {
   const navigate = useNavigate();
-  const location = useLocation();
   const [activeCategory, setActiveCategory] = useState<string>("Todos");
   const [searchTerm, setSearchTerm] = useState<string>("");
   const { data: blogPosts = [], isLoading, isError } = useBlogPosts();
@@ -86,30 +86,8 @@ const BlogPage = () => {
       post_title: post.title,
       post_category: post.category,
     });
-    navigate({ pathname: location.pathname, hash: post.slug });
+    navigate(routes.blogPost(post.slug));
   };
-
-  useEffect(() => {
-    if (typeof window === "undefined" || !location.hash) {
-      return;
-    }
-
-    const slug = location.hash.replace("#", "");
-    const element = document.getElementById(slug);
-
-    if (!element) {
-      return;
-    }
-
-    window.requestAnimationFrame(() => {
-      element.scrollIntoView({ behavior: "smooth", block: "start" });
-      element.classList.add("ring-2", "ring-quantum-bright", "ring-offset-2", "ring-offset-background");
-
-      window.setTimeout(() => {
-        element.classList.remove("ring-2", "ring-quantum-bright", "ring-offset-2", "ring-offset-background");
-      }, 1600);
-    });
-  }, [location.hash]);
 
   return (
     <div className="min-h-screen flex flex-col bg-background text-foreground">
@@ -233,12 +211,16 @@ const BlogPage = () => {
                 className="group relative overflow-hidden rounded-3xl border-0 bg-gradient-to-br from-background via-background/95 to-quantum-deep/30 shadow-2xl"
               >
                 <div className="absolute inset-0 overflow-hidden">
-                  <img
-                    src={featuredPost.image}
-                    alt={featuredPost.title}
-                    className="h-full w-full object-cover opacity-60 transition-all duration-700 group-hover:scale-105"
-                    loading="lazy"
-                  />
+                  {featuredPost.image ? (
+                    <img
+                      src={featuredPost.image}
+                      alt={featuredPost.title}
+                      className="h-full w-full object-cover opacity-60 transition-all duration-700 group-hover:scale-105"
+                      loading="lazy"
+                    />
+                  ) : (
+                    <div className="h-full w-full bg-gradient-to-br from-quantum-deep/40 via-background/60 to-background" aria-hidden />
+                  )}
                   <div className="absolute inset-0 bg-gradient-to-t from-background via-background/40 to-transparent" />
                 </div>
                 <div className="relative z-10 p-8 md:p-12 flex flex-col gap-6 text-white">
@@ -394,12 +376,16 @@ const BlogPage = () => {
                     className="group relative overflow-hidden rounded-2xl border-border/60 bg-background/90 backdrop-blur"
                   >
                     <div className="relative h-48 overflow-hidden">
-                      <img
-                        src={post.image}
-                        alt={post.title}
-                        className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
-                        loading="lazy"
-                      />
+                      {post.image ? (
+                        <img
+                          src={post.image}
+                          alt={post.title}
+                          className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <div className="h-full w-full bg-gradient-to-br from-quantum-deep/20 via-background/60 to-background" aria-hidden />
+                      )}
                       <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background via-background/40 to-transparent p-4">
                         <Badge className="bg-quantum-deep/70 text-white">{post.category}</Badge>
                       </div>

--- a/frontend/src/pages/site/BlogArticle.tsx
+++ b/frontend/src/pages/site/BlogArticle.tsx
@@ -1,0 +1,268 @@
+import { useMemo } from "react";
+import { Link, useParams } from "react-router-dom";
+import { ArrowLeft, Calendar, Clock, Share2, Sparkles, Tag } from "lucide-react";
+
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import SimpleBackground from "@/components/ui/SimpleBackground";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { routes } from "@/config/routes";
+import { useToast } from "@/hooks/use-toast";
+import { useBlogPostBySlug, useBlogPosts } from "@/hooks/useBlogPosts";
+
+const BlogArticle = () => {
+  const { slug } = useParams<{ slug: string }>();
+  const {
+    data: post,
+    isLoading,
+    isError,
+  } = useBlogPostBySlug(slug);
+  const { data: allPosts = [], isLoading: isLoadingPosts } = useBlogPosts();
+  const { toast } = useToast();
+
+  const recommendedPosts = useMemo(() => {
+    if (!post) {
+      return [];
+    }
+
+    return allPosts.filter((item) => item.slug !== post.slug).slice(0, 3);
+  }, [allPosts, post]);
+
+  const contentParagraphs = useMemo(() => {
+    const rawContent = post?.content?.trim() ?? post?.description ?? "";
+    if (!rawContent) {
+      return [];
+    }
+
+    return rawContent
+      .split(/\n{2,}/)
+      .map((paragraph) => paragraph.trim())
+      .filter(Boolean);
+  }, [post]);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <Header />
+      <main className="flex-1">
+        <section className="relative overflow-hidden border-b border-border/50">
+          <SimpleBackground className="opacity-80" />
+          <div className="container relative z-10 space-y-8 px-4 py-16">
+            <Button asChild variant="ghost" className="w-fit px-0 text-base font-medium text-primary">
+              <Link to={routes.blog} className="inline-flex items-center gap-2">
+                <ArrowLeft className="h-4 w-4" aria-hidden />
+                Voltar para o blog
+              </Link>
+            </Button>
+
+            {isLoading ? (
+              <div className="space-y-6">
+                <Skeleton className="h-6 w-32" />
+                <Skeleton className="h-12 w-3/4" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-2/3" />
+              </div>
+            ) : isError ? (
+              <div className="space-y-3">
+                <Badge variant="destructive" className="w-fit">
+                  Erro ao carregar artigo
+                </Badge>
+                <p className="max-w-2xl text-base text-muted-foreground">
+                  Não foi possível carregar este conteúdo agora. Tente novamente em instantes.
+                </p>
+              </div>
+            ) : post ? (
+              <div className="space-y-6">
+                <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-1 text-sm font-medium text-primary">
+                  <Sparkles className="h-4 w-4" aria-hidden />
+                  {post.category}
+                </div>
+
+                <div className="space-y-4">
+                  <h1 className="text-4xl font-bold leading-tight md:text-5xl">{post.title}</h1>
+                  <p className="max-w-3xl text-lg text-muted-foreground">{post.description}</p>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+                  <span className="inline-flex items-center gap-2">
+                    <Calendar className="h-4 w-4" aria-hidden />
+                    {post.date}
+                  </span>
+                  <span className="inline-flex items-center gap-2">
+                    <Clock className="h-4 w-4" aria-hidden />
+                    {post.readTime}
+                  </span>
+                  <span className="inline-flex items-center gap-2">
+                    <Tag className="h-4 w-4" aria-hidden />
+                    {post.author}
+                  </span>
+                </div>
+
+                {post.image ? (
+                  <div className="overflow-hidden rounded-3xl border border-white/10 bg-background/60 shadow-lg shadow-primary/10">
+                    <img
+                      src={post.image}
+                      alt={post.title}
+                      className="h-[360px] w-full object-cover"
+                      loading="lazy"
+                    />
+                  </div>
+                ) : null}
+
+                {post.tags?.length ? (
+                  <div className="flex flex-wrap gap-2">
+                    {post.tags.map((tag) => (
+                      <Badge key={tag} variant="outline" className="border-primary/50 text-primary">
+                        #{tag}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <Badge variant="outline" className="w-fit border-muted-foreground/40 text-muted-foreground">
+                  Artigo não encontrado
+                </Badge>
+                <p className="max-w-2xl text-base text-muted-foreground">
+                  O conteúdo que você procura pode ter sido removido ou estar indisponível.
+                </p>
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="container grid gap-12 px-4 py-16 lg:grid-cols-[minmax(0,3fr),minmax(0,1.4fr)]">
+          <article className="space-y-6 text-lg leading-relaxed text-muted-foreground">
+            {isLoading ? (
+              <div className="space-y-4">
+                {Array.from({ length: 6 }).map((_, index) => (
+                  <Skeleton key={index} className="h-4 w-full" />
+                ))}
+              </div>
+            ) : post && contentParagraphs.length ? (
+              contentParagraphs.map((paragraph, index) => (
+                <p key={index} className="text-foreground/90">
+                  {paragraph}
+                </p>
+              ))
+            ) : (
+              <p className="text-base text-muted-foreground">
+                Conteúdo em breve. Atualize a página para verificar novas informações.
+              </p>
+            )}
+          </article>
+
+          <aside className="space-y-8">
+            <Card className="border-border/60 bg-background/80 backdrop-blur">
+              <CardHeader className="space-y-3">
+                <CardTitle className="text-lg">Compartilhe este artigo</CardTitle>
+                <CardDescription>Leve estes insights para a sua equipe.</CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-wrap gap-3">
+                <Button
+                  variant="outline"
+                  className="gap-2"
+                  onClick={() => {
+                    const currentUrl = typeof window !== "undefined" ? window.location.href : "";
+
+                    if (typeof navigator === "undefined" || !navigator.clipboard) {
+                      toast({
+                        title: "Copie o link manualmente",
+                        description: currentUrl || "Compartilhe este endereço com sua equipe.",
+                      });
+                      return;
+                    }
+
+                    navigator.clipboard
+                      .writeText(currentUrl)
+                      .then(() => {
+                        toast({
+                          title: "Link copiado",
+                          description: "Cole em uma conversa ou e-mail para compartilhar o conteúdo.",
+                        });
+                      })
+                      .catch(() => {
+                        toast({
+                          title: "Não foi possível copiar automaticamente",
+                          description: currentUrl,
+                        });
+                      });
+                  }}
+                >
+                  <Share2 className="h-4 w-4" aria-hidden />
+                  Copiar link
+                </Button>
+              </CardContent>
+            </Card>
+
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold">Outros artigos</h2>
+                <Button variant="link" className="px-0 text-sm" asChild>
+                  <Link to={routes.blog}>Ver todos</Link>
+                </Button>
+              </div>
+
+              {isLoadingPosts ? (
+                <div className="space-y-4">
+                  {Array.from({ length: 3 }).map((_, index) => (
+                    <Card key={index} className="border-border/60">
+                      <CardHeader>
+                        <Skeleton className="h-4 w-32" />
+                        <Skeleton className="h-5 w-3/4" />
+                      </CardHeader>
+                    </Card>
+                  ))}
+                </div>
+              ) : recommendedPosts.length ? (
+                <div className="space-y-4">
+                  {recommendedPosts.map((related) => (
+                    <Card key={related.id} className="border-border/60 bg-background/70">
+                      <CardHeader className="space-y-2">
+                        <Badge variant="secondary" className="w-fit">
+                          {related.category}
+                        </Badge>
+                        <CardTitle className="text-base leading-snug text-foreground">
+                          {related.title}
+                        </CardTitle>
+                        <CardDescription>{related.description}</CardDescription>
+                      </CardHeader>
+                      <CardContent className="flex items-center justify-between text-xs text-muted-foreground">
+                        <span className="inline-flex items-center gap-1">
+                          <Calendar className="h-3.5 w-3.5" aria-hidden /> {related.date}
+                        </span>
+                        <span className="inline-flex items-center gap-1">
+                          <Clock className="h-3.5 w-3.5" aria-hidden /> {related.readTime}
+                        </span>
+                      </CardContent>
+                      <CardContent className="pt-0">
+                        <Button variant="ghost" className="px-0 text-sm font-medium" asChild>
+                          <Link to={routes.blogPost(related.slug)}>Ler artigo</Link>
+                        </Button>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+              ) : (
+                <Card className="border-border/60 bg-background/70">
+                  <CardHeader>
+                    <CardTitle className="text-base">Sem recomendações no momento</CardTitle>
+                    <CardDescription>
+                      Explore o blog para descobrir mais conteúdos sobre tecnologia e transformação digital.
+                    </CardDescription>
+                  </CardHeader>
+                </Card>
+              )}
+            </div>
+          </aside>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default BlogArticle;

--- a/frontend/src/pages/site/components/Blog.tsx
+++ b/frontend/src/pages/site/components/Blog.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { ArrowRight, Calendar, Clock, Sparkles } from "lucide-react";
 import { Link } from "react-router-dom";
 
@@ -5,44 +6,19 @@ import SimpleBackground from "@/components/ui/SimpleBackground";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-
-interface BlogPreview {
-  title: string;
-  description: string;
-  category: string;
-  readTime: string;
-  date: string;
-  href: string;
-}
-
-const BLOG_POSTS: BlogPreview[] = [
-  {
-    title: "Como implementar automações jurídicas com governança",
-    description: "Roadmap para mapear processos, definir integrações críticas e medir impacto em indicadores.",
-    category: "Operações",
-    readTime: "6 min",
-    date: "Out 2024",
-    href: "/blog/automacoes-juridicas",
-  },
-  {
-    title: "Guia completo de CRM para escritórios",
-    description: "Principais pilares para estruturar pipeline, atendimento e fidelização no segmento jurídico.",
-    category: "CRM",
-    readTime: "8 min",
-    date: "Set 2024",
-    href: "/blog/crm-advocacia",
-  },
-  {
-    title: "IA generativa aplicada ao contencioso",
-    description: "Casos reais de uso de IA para síntese de processos, minutas e suporte a audiências.",
-    category: "Inteligência Artificial",
-    readTime: "5 min",
-    date: "Ago 2024",
-    href: "/blog/ia-contencioso",
-  },
-];
+import { Skeleton } from "@/components/ui/skeleton";
+import { routes } from "@/config/routes";
+import { useBlogPosts } from "@/hooks/useBlogPosts";
 
 const Blog = () => {
+  const {
+    data: posts = [],
+    isLoading,
+    isError,
+  } = useBlogPosts();
+
+  const highlightedPosts = useMemo(() => posts.slice(0, 3), [posts]);
+
   return (
     <section id="blog" className="relative overflow-hidden bg-background">
       <div className="absolute inset-0" aria-hidden>
@@ -62,33 +38,71 @@ const Blog = () => {
         </div>
 
         <div className="grid gap-6 md:grid-cols-3">
-          {BLOG_POSTS.map((post) => (
-            <Card key={post.href} className="flex h-full flex-col border-border/40 bg-background/80 backdrop-blur">
-              <CardHeader className="space-y-3">
-                <Badge variant="secondary" className="w-fit">
-                  {post.category}
-                </Badge>
-                <CardTitle className="text-xl text-foreground">{post.title}</CardTitle>
-                <CardDescription>{post.description}</CardDescription>
+          {isLoading ? (
+            Array.from({ length: 3 }).map((_, index) => (
+              <Card key={index} className="border-border/40 bg-background/60">
+                <CardHeader className="space-y-3">
+                  <Skeleton className="h-5 w-24" />
+                  <Skeleton className="h-6 w-3/4" />
+                  <Skeleton className="h-4 w-full" />
+                </CardHeader>
+                <CardContent>
+                  <Skeleton className="h-4 w-1/2" />
+                </CardContent>
+              </Card>
+            ))
+          ) : isError ? (
+            <Card className="md:col-span-3 border-border/40 bg-background/70">
+              <CardHeader>
+                <CardTitle className="text-lg">Não foi possível carregar os artigos</CardTitle>
+                <CardDescription>
+                  Atualize a página para tentar novamente ou acesse o blog completo para ver os conteúdos.
+                </CardDescription>
               </CardHeader>
-              <CardContent className="mt-auto space-y-3 text-sm text-muted-foreground">
-                <div className="flex items-center justify-between text-xs text-muted-foreground/90">
-                  <span className="inline-flex items-center gap-1">
-                    <Calendar className="h-3.5 w-3.5" aria-hidden /> {post.date}
-                  </span>
-                  <span className="inline-flex items-center gap-1">
-                    <Clock className="h-3.5 w-3.5" aria-hidden /> {post.readTime}
-                  </span>
-                </div>
-                <Button asChild variant="ghost" className="justify-start gap-2 px-0 text-sm font-semibold text-primary">
-                  <Link to={post.href}>
-                    Ler artigo
-                    <ArrowRight className="h-4 w-4" aria-hidden />
-                  </Link>
+              <CardContent>
+                <Button asChild variant="quantum">
+                  <Link to={routes.blog}>Ir para o blog</Link>
                 </Button>
               </CardContent>
             </Card>
-          ))}
+          ) : highlightedPosts.length ? (
+            highlightedPosts.map((post) => (
+              <Card key={post.id} className="flex h-full flex-col border-border/40 bg-background/80 backdrop-blur">
+                <CardHeader className="space-y-3">
+                  <Badge variant="secondary" className="w-fit">
+                    {post.category}
+                  </Badge>
+                  <CardTitle className="text-xl text-foreground">{post.title}</CardTitle>
+                  <CardDescription>{post.description}</CardDescription>
+                </CardHeader>
+                <CardContent className="mt-auto space-y-3 text-sm text-muted-foreground">
+                  <div className="flex items-center justify-between text-xs text-muted-foreground/90">
+                    <span className="inline-flex items-center gap-1">
+                      <Calendar className="h-3.5 w-3.5" aria-hidden /> {post.date}
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                      <Clock className="h-3.5 w-3.5" aria-hidden /> {post.readTime}
+                    </span>
+                  </div>
+                  <Button asChild variant="ghost" className="justify-start gap-2 px-0 text-sm font-semibold text-primary">
+                    <Link to={routes.blogPost(post.slug)}>
+                      Ler artigo
+                      <ArrowRight className="h-4 w-4" aria-hidden />
+                    </Link>
+                  </Button>
+                </CardContent>
+              </Card>
+            ))
+          ) : (
+            <Card className="md:col-span-3 border-border/40 bg-background/70">
+              <CardHeader>
+                <CardTitle className="text-lg">Nenhum artigo publicado ainda</CardTitle>
+                <CardDescription>
+                  Nossa equipe está preparando conteúdos especiais. Enquanto isso, acompanhe as novidades em nossas redes.
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          )}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add a dedicated blog article page with sharing helpers and related content suggestions
- update the public blog listings and home preview to navigate via slug-based routes
- introduce an admin blog management screen with CRUD dialog, navigation entry, and updated API schema

## Testing
- npm run lint *(fails: dependencies unavailable because the npm registry returned 403 responses during install)*

------
https://chatgpt.com/codex/tasks/task_e_68d42e73239c8326a5671e6b483933a3