### PR TITLE
Update services hero gradient to match index palette

### DIFF
--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -80,7 +80,7 @@ export default {
       },
       backgroundImage: {
         "gradient-hero":
-          "linear-gradient(135deg, rgba(26, 28, 36, 0.95) 0%, rgba(75, 85, 99, 0.9) 55%, rgba(24, 24, 27, 0.95) 100%)",
+          "linear-gradient(135deg, hsl(var(--background)) 0%, hsl(var(--primary) / 0.08) 55%, hsl(var(--accent) / 0.15) 100%)",
         "gradient-quantum":
           "linear-gradient(135deg, rgba(107, 114, 128, 1) 0%, rgba(63, 63, 70, 1) 50%, rgba(24, 24, 27, 1) 100%)",
         "gradient-card":


### PR DESCRIPTION
## Summary
- replace the shared hero gradient with a lighter palette derived from the landing page

## Testing
- npm run lint *(fails: missing @eslint/js dependency because packages could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d438b3ba0c8326b5c4a7152c80513a