### PR TITLE
feat: sync blog posts with categories and media

### DIFF
--- a/backend/sql/blog_posts.sql
+++ b/backend/sql/blog_posts.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS blog_posts (
+CREATE TABLE IF NOT EXISTS public.blog_posts (
     id UUID PRIMARY KEY,
     title TEXT NOT NULL,
     description TEXT NOT NULL,
@@ -6,13 +6,14 @@ CREATE TABLE IF NOT EXISTS blog_posts (
     author TEXT NOT NULL,
     published_at TIMESTAMPTZ NOT NULL,
     read_time TEXT NOT NULL,
-    category TEXT NOT NULL,
+    category INTEGER NOT NULL,
     image TEXT,
     slug TEXT NOT NULL UNIQUE,
     tags TEXT[] NOT NULL DEFAULT '{}',
     featured BOOLEAN NOT NULL DEFAULT FALSE,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT blog_posts_categories_fk FOREIGN KEY (category) REFERENCES public.categorias(id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_blog_posts_published_at ON blog_posts (published_at DESC, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_blog_posts_published_at ON public.blog_posts (published_at DESC, created_at DESC);

--- a/backend/src/routes/blogPostRoutes.ts
+++ b/backend/src/routes/blogPostRoutes.ts
@@ -38,8 +38,12 @@ export const publicBlogPostRoutes = Router();
  *           description: Data de publicação do artigo
  *         readTime:
  *           type: string
+ *         categoryId:
+ *           type: integer
+ *           description: Identificador da categoria relacionada
  *         category:
  *           type: string
+ *           description: Nome da categoria relacionada
  *         image:
  *           type: string
  *           nullable: true
@@ -65,7 +69,7 @@ export const publicBlogPostRoutes = Router();
  *         - author
  *         - date
  *         - readTime
- *         - category
+ *         - categoryId
  *         - slug
  *         - tags
  *       properties:
@@ -80,8 +84,8 @@ export const publicBlogPostRoutes = Router();
  *           format: date-time
  *         readTime:
  *           type: string
- *         category:
- *           type: string
+ *         categoryId:
+ *           type: integer
  *         slug:
  *           type: string
  *           description: Identificador único utilizado na URL do artigo
@@ -97,7 +101,7 @@ export const publicBlogPostRoutes = Router();
  *             type: string
  *         featured:
  *           type: boolean
- */
+*/
 
 /**
  * @swagger

--- a/frontend/src/hooks/useBlogPosts.ts
+++ b/frontend/src/hooks/useBlogPosts.ts
@@ -1,8 +1,14 @@
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 
-import { adminApi, blogPostKeys, type BlogPost } from "@/lib/adminApi";
+import {
+  adminApi,
+  blogPostKeys,
+  blogCategoryKeys,
+  type BlogPost,
+  type BlogCategory,
+} from "@/lib/adminApi";
 
-export type { BlogPost };
+export type { BlogPost, BlogCategory };
 
 const FIVE_MINUTES_IN_MS = 1000 * 60 * 5;
 const EMPTY_BLOG_POST_ID_QUERY_KEY = [...blogPostKeys.all, "id", ""] as const;
@@ -40,3 +46,10 @@ export const useBlogPostBySlug = (
     staleTime: FIVE_MINUTES_IN_MS,
   });
 };
+
+export const useBlogCategories = (): UseQueryResult<BlogCategory[], Error> =>
+  useQuery<BlogCategory[], Error>({
+    queryKey: blogCategoryKeys.list(),
+    queryFn: () => adminApi.listBlogCategories(),
+    staleTime: FIVE_MINUTES_IN_MS,
+  });


### PR DESCRIPTION
## Summary
- point the blog posts schema to the existing `public.categorias` table instead of creating a duplicate `categories` definition
- load category names for blog post listings by joining `public.categorias`
- have the admin API consume `/categorias`, filtering for active entries and normalizing them for the blog form

## Testing
- npm test --prefix backend
- npm test --prefix frontend *(fails: vitest binary missing because npm install --prefix frontend is blocked with 403 Forbidden for registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68d442a9192c8326bad7a3f143efea23