### PR TITLE
Fix missing div closure in Processos accordion

### DIFF
--- a/frontend/src/pages/operator/Processos.tsx
+++ b/frontend/src/pages/operator/Processos.tsx
@@ -1525,6 +1525,7 @@ export default function Processos() {
                         {movimentacoesLabel}
                       </span>
                     </div>
+                    </div>
                   </div>
                 </AccordionTrigger>
                 <AccordionContent className="border-t border-border/40 px-6 pb-6 pt-6 sm:px-8">


### PR DESCRIPTION
## Summary
- add the missing closing wrapper in the Processos accordion trigger so the JSX compiles correctly

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68d45e732d908326afd504389da8648a