### PR TITLE
Respect base path configuration

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { Loader2 } from "lucide-react";
 import { adminRelativePath, routes } from "@/config/routes";
+import { appConfig } from "@/config/app-config";
 import Landing from "./pages/operator/Landing";
 import Clientes from "./pages/operator/Clientes";
 import NovoCliente from "./pages/operator/NovoCliente";
@@ -117,7 +118,7 @@ const App = () => (
       <Toaster />
       <Sonner />
       <AuthProvider>
-        <BrowserRouter>
+        <BrowserRouter basename={appConfig.basePath}>
           <Suspense fallback={<LandingFallback />}>
             <Routes>
               <Route path={routes.home} element={<SiteIndex />} />

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,24 +1,44 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-  },
-  plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+const normalizeBasePath = (value: string | undefined) => {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return "/";
+  }
+
+  const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+
+  if (withLeadingSlash.length === 1) {
+    return withLeadingSlash;
+  }
+
+  return withLeadingSlash.replace(/\/+$/, "");
+};
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+
+  return {
+    base: normalizeBasePath(env.VITE_APP_BASE_PATH),
+    server: {
+      host: "::",
+      port: 8080,
     },
-  },
-  test: {
-    environment: "jsdom",
-    setupFiles: "./src/setupTests.ts",
-    globals: true,
-    css: true,
-  },
-}));
+    plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+    test: {
+      environment: "jsdom",
+      setupFiles: "./src/setupTests.ts",
+      globals: true,
+      css: true,
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- read the configured base path when instantiating `BrowserRouter` so routed pages render correctly after build
- normalize the `VITE_APP_BASE_PATH` value inside `vite.config.ts` and feed it to Vite's `base` option to generate correct asset URLs

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68d46186f9748326a6dccad1ca4dd8a0