### PR TITLE
Add Typebot initialization script to frontend index

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,5 +20,27 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script>
+      const typebotInitScript = document.createElement("script");
+      typebotInitScript.type = "module";
+      typebotInitScript.innerHTML = `import Typebot from 'https://cdn.jsdelivr.net/npm/@typebot.io/js@0/dist/web.js'
+
+Typebot.initBubble({
+  typebot: "quantumbot",
+  apiHost: "https://form.quantumtecnologia.com.br",
+  previewMessage: {
+    message: "Olá, sou o QuantumBot. Em que posso ajudá-lo?",
+    autoShowDelay: 10000,
+    avatarUrl:
+      "https://i.postimg.cc/CLKVTcfx/graident-ai-robot-vectorart-em-ingles-78370-4114.avif",
+  },
+  theme: {
+    button: { backgroundColor: "#303235" },
+    chatWindow: { backgroundColor: "#FFFFFF" },
+  },
+});
+`;
+      document.body.append(typebotInitScript);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add inline script that injects the Typebot bubble initializer into the frontend entry page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d463046c3083269eb03eaf550f944e