### PR TITLE
Improve blog preview text contrast

### DIFF
--- a/frontend/src/pages/site/Blog.tsx
+++ b/frontend/src/pages/site/Blog.tsx
@@ -408,7 +408,7 @@ const BlogPage = () => {
                       <CardTitle className="text-xl leading-snug group-hover:text-quantum-bright transition-colors">
                         {post.title}
                       </CardTitle>
-                      <CardDescription className="text-sm text-muted-foreground">
+                      <CardDescription className="text-sm text-foreground/80">
                         {post.description}
                       </CardDescription>
                     </CardHeader>

--- a/frontend/src/pages/site/components/Blog.tsx
+++ b/frontend/src/pages/site/components/Blog.tsx
@@ -72,7 +72,9 @@ const Blog = () => {
                     {post.category}
                   </Badge>
                   <CardTitle className="text-xl text-foreground">{post.title}</CardTitle>
-                  <CardDescription>{post.description}</CardDescription>
+                  <CardDescription className="text-foreground/80">
+                    {post.description}
+                  </CardDescription>
                 </CardHeader>
                 <CardContent className="mt-auto space-y-3 text-sm text-muted-foreground">
                   <div className="flex items-center justify-between text-xs text-muted-foreground/90">


### PR DESCRIPTION
## Summary
- enhance the homepage blog preview cards with a higher-contrast description color
- adjust the blog listing preview text to use the standard foreground color for better readability

## Testing
- npm run lint *(fails: missing @eslint/js dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4685a99a4832682403a8951136225