### PR TITLE
Fix operator dashboard navigation route

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -42,6 +42,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { routes } from "@/config/routes";
 import { getApiBaseUrl } from "@/lib/api";
 import { useAuth } from "@/features/auth/AuthProvider";
 import { useSidebarCounters, type SidebarCounterKey, type SidebarCountersMap } from "@/hooks/useSidebarCounters";
@@ -111,7 +112,7 @@ export function Sidebar() {
 
   const navigation = useMemo<NavItem[]>(
     () => [
-      { name: "Dashboard", href: "/", icon: LayoutDashboard, moduleId: "dashboard" },
+      { name: "Dashboard", href: routes.dashboard, icon: LayoutDashboard, moduleId: "dashboard" },
       {
         name: "Conversas",
         href: "/conversas",


### PR DESCRIPTION
## Summary
- import the centralized routes config into the operator sidebar
- update the dashboard navigation item to use the /app route instead of the public home

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' required by eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d4692411748326b38a93487149ee62