### PR TITLE
feat: sync crm plans with available options

### DIFF
--- a/frontend/src/features/plans/PlanSelection.tsx
+++ b/frontend/src/features/plans/PlanSelection.tsx
@@ -9,101 +9,11 @@ import { useToast } from "@/components/ui/use-toast";
 import { getApiUrl } from "@/lib/api";
 import { useAuth } from "@/features/auth/AuthProvider";
 import { evaluateSubscriptionAccess } from "@/features/auth/subscriptionStatus";
+import { fetchPlanOptions, formatPlanPriceLabel, type PlanOption } from "./api";
 
-type RawRecord = Record<string, unknown>;
-
-type PlanOption = {
-  id: number;
-  name: string;
-  description: string | null;
-  monthlyPrice: number | null;
-  annualPrice: number | null;
-};
-
-const currencyFormatter = new Intl.NumberFormat("pt-BR", {
-  style: "currency",
-  currency: "BRL",
-});
 const graceDateFormatter = new Intl.DateTimeFormat("pt-BR", {
   dateStyle: "long",
 });
-
-const toNumber = (value: unknown): number | null => {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
-  }
-
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return null;
-    }
-
-    const sanitized = trimmed.replace(/[^\d,.-]/g, "").replace(/\.(?=.*\.)/g, "");
-    const normalized = sanitized.replace(",", ".");
-    const parsed = Number(normalized);
-    if (Number.isFinite(parsed)) {
-      return parsed;
-    }
-  }
-
-  return null;
-};
-
-const extractRows = (payload: unknown): RawRecord[] => {
-  if (Array.isArray(payload)) {
-    return payload.filter((item): item is RawRecord => item !== null && typeof item === "object");
-  }
-
-  if (payload && typeof payload === "object") {
-    const data = (payload as { data?: unknown }).data;
-    if (Array.isArray(data)) {
-      return data.filter((item): item is RawRecord => item !== null && typeof item === "object");
-    }
-
-    const rows = (payload as { rows?: unknown }).rows;
-    if (Array.isArray(rows)) {
-      return rows.filter((item): item is RawRecord => item !== null && typeof item === "object");
-    }
-  }
-
-  return [];
-};
-
-const parsePlans = (payload: unknown): PlanOption[] =>
-  extractRows(payload)
-    .map((record) => {
-      const id = toNumber(record.id);
-      if (id === null) {
-        return null;
-      }
-
-      const nameCandidate = typeof record.nome === "string" ? record.nome.trim() : undefined;
-      const descriptionCandidate = typeof record.descricao === "string" ? record.descricao.trim() : undefined;
-      const monthly = toNumber(record.valor_mensal ?? record.valorMensal ?? record.preco_mensal);
-      const annual = toNumber(record.valor_anual ?? record.valorAnual ?? record.preco_anual);
-
-      return {
-        id,
-        name: nameCandidate && nameCandidate.length > 0 ? nameCandidate : `Plano ${id}`,
-        description: descriptionCandidate && descriptionCandidate.length > 0 ? descriptionCandidate : null,
-        monthlyPrice: monthly,
-        annualPrice: annual,
-      } satisfies PlanOption;
-    })
-    .filter((plan): plan is PlanOption => plan !== null);
-
-const resolvePriceLabel = (plan: PlanOption): string => {
-  if (plan.monthlyPrice !== null) {
-    return `${currencyFormatter.format(plan.monthlyPrice)} / mês`;
-  }
-
-  if (plan.annualPrice !== null) {
-    return `${currencyFormatter.format(plan.annualPrice)} / ano`;
-  }
-
-  return "Consulte condições";
-};
 
 export const PlanSelection = () => {
   const { user, refreshUser } = useAuth();
@@ -129,20 +39,12 @@ export const PlanSelection = () => {
       setError(null);
 
       try {
-        const response = await fetch(getApiUrl("planos"), {
-          headers: { Accept: "application/json" },
-        });
-
-        if (!response.ok) {
-          throw new Error(`Falha ao carregar planos (HTTP ${response.status})`);
-        }
-
-        const payload = await response.json();
+        const options = await fetchPlanOptions();
         if (cancelled) {
           return;
         }
 
-        setPlans(parsePlans(payload));
+        setPlans(options);
       } catch (loadError) {
         if (cancelled) {
           return;
@@ -299,7 +201,7 @@ export const PlanSelection = () => {
                   <CardDescription>{plan.description ?? "Inclui recursos essenciais para o seu time."}</CardDescription>
                 </CardHeader>
                 <CardContent>
-                  <p className="text-lg font-semibold text-primary">{resolvePriceLabel(plan)}</p>
+                  <p className="text-lg font-semibold text-primary">{formatPlanPriceLabel(plan)}</p>
                   <p className="mt-2 text-sm text-muted-foreground">
                     Inicie agora e conheça todos os módulos disponíveis para o seu escritório.
                   </p>

--- a/frontend/src/features/plans/api.ts
+++ b/frontend/src/features/plans/api.ts
@@ -1,0 +1,119 @@
+import { getApiUrl } from "@/lib/api";
+
+export type PlanOption = {
+  id: number;
+  name: string;
+  description: string | null;
+  monthlyPrice: number | null;
+  annualPrice: number | null;
+};
+
+type RawRecord = Record<string, unknown>;
+
+const currencyFormatter = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+});
+
+const toNumber = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const sanitized = trimmed.replace(/[^\d,.-]/g, "").replace(/\.(?=.*\.)/g, "");
+    const normalized = sanitized.replace(",", ".");
+    const parsed = Number(normalized);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+const extractRows = (payload: unknown): RawRecord[] => {
+  if (Array.isArray(payload)) {
+    return payload.filter((item): item is RawRecord => item !== null && typeof item === "object");
+  }
+
+  if (payload && typeof payload === "object") {
+    const data = (payload as { data?: unknown }).data;
+    if (Array.isArray(data)) {
+      return data.filter((item): item is RawRecord => item !== null && typeof item === "object");
+    }
+
+    const rows = (payload as { rows?: unknown }).rows;
+    if (Array.isArray(rows)) {
+      return rows.filter((item): item is RawRecord => item !== null && typeof item === "object");
+    }
+  }
+
+  return [];
+};
+
+export const parsePlanOptions = (payload: unknown): PlanOption[] =>
+  extractRows(payload)
+    .map((record) => {
+      const id = toNumber(record.id);
+      if (id === null) {
+        return null;
+      }
+
+      const nameCandidate = typeof record.nome === "string" ? record.nome.trim() : undefined;
+      const descriptionCandidate = typeof record.descricao === "string" ? record.descricao.trim() : undefined;
+      const monthly = toNumber(record.valor_mensal ?? record.valorMensal ?? record.preco_mensal);
+      const annual = toNumber(record.valor_anual ?? record.valorAnual ?? record.preco_anual);
+
+      return {
+        id,
+        name: nameCandidate && nameCandidate.length > 0 ? nameCandidate : `Plano ${id}`,
+        description: descriptionCandidate && descriptionCandidate.length > 0 ? descriptionCandidate : null,
+        monthlyPrice: monthly,
+        annualPrice: annual,
+      } satisfies PlanOption;
+    })
+    .filter((plan): plan is PlanOption => plan !== null);
+
+export const formatPlanPriceLabel = (plan: PlanOption): string => {
+  if (plan.monthlyPrice !== null) {
+    return `${currencyFormatter.format(plan.monthlyPrice)} / mês`;
+  }
+
+  if (plan.annualPrice !== null) {
+    return `${currencyFormatter.format(plan.annualPrice)} / ano`;
+  }
+
+  return "Consulte condições";
+};
+
+export async function fetchPlanOptions(signal?: AbortSignal): Promise<PlanOption[]> {
+  const response = await fetch(getApiUrl("planos"), {
+    headers: { Accept: "application/json" },
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Falha ao carregar planos (HTTP ${response.status})`);
+  }
+
+  const payload = await response.json();
+  return parsePlanOptions(payload);
+}
+
+export const getComparableMonthlyPrice = (plan: PlanOption): number | null => {
+  if (typeof plan.monthlyPrice === "number" && Number.isFinite(plan.monthlyPrice)) {
+    return plan.monthlyPrice;
+  }
+
+  if (typeof plan.annualPrice === "number" && Number.isFinite(plan.annualPrice)) {
+    return plan.annualPrice / 12;
+  }
+
+  return null;
+};


### PR DESCRIPTION
## Summary
- extract plan fetching and formatting helpers into a shared feature module
- update the Meu Plano selector to consume the shared helpers
- load and display the available plans dynamically on the CRM Advocacia landing page with loading and error states

## Testing
- `npm test` *(fails: vitest not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d469b2337c8326bf5ad4d28cf8b942