### PR TITLE
Load Typebot bubble only on site pages

### DIFF
--- a/frontend/src/components/site/TypebotBubble.tsx
+++ b/frontend/src/components/site/TypebotBubble.tsx
@@ -1,0 +1,87 @@
+import { useEffect } from "react";
+
+const TYPEBOT_SCRIPT_ATTRIBUTE = "data-typebot-inline";
+const TYPEBOT_BUBBLE_SELECTOR = "typebot-bubble";
+const TYPEBOT_STYLE_SELECTOR = "style[data-typebot], link[rel=\"stylesheet\"][href*=\"typebot\"]";
+const TYPEBOT_CONTAINER_SELECTOR = "[id^=\"typebot\"]";
+
+let activeInstances = 0;
+
+const injectTypebotBubble = () => {
+  const scriptElement = document.createElement("script");
+  scriptElement.type = "module";
+  scriptElement.setAttribute(TYPEBOT_SCRIPT_ATTRIBUTE, "true");
+  scriptElement.textContent = `import Typebot from 'https://cdn.jsdelivr.net/npm/@typebot.io/js@0/dist/web.js';
+
+Typebot.initBubble({
+  typebot: "quantumbot",
+  apiHost: "https://form.quantumtecnologia.com.br",
+  previewMessage: {
+    message: "Olá, sou o QuantumBot. Em que posso ajudá-lo?",
+    autoShowDelay: 10000,
+    avatarUrl: "https://i.postimg.cc/CLKVTcfx/graident-ai-robot-vectorart-em-ingles-78370-4114.avif",
+  },
+  theme: {
+    button: { backgroundColor: "#303235" },
+    chatWindow: { backgroundColor: "#FFFFFF" },
+  },
+});
+`;
+
+  document.body.append(scriptElement);
+
+  return scriptElement;
+};
+
+const removeTypebotArtifacts = () => {
+  document
+    .querySelectorAll(`script[${TYPEBOT_SCRIPT_ATTRIBUTE}]`)
+    .forEach((element) => element.remove());
+
+  document
+    .querySelectorAll(TYPEBOT_BUBBLE_SELECTOR)
+    .forEach((element) => element.remove());
+
+  document
+    .querySelectorAll(TYPEBOT_STYLE_SELECTOR)
+    .forEach((element) => element.remove());
+
+  document
+    .querySelectorAll(TYPEBOT_CONTAINER_SELECTOR)
+    .forEach((element) => {
+      if (element instanceof HTMLElement && element.getAttribute(TYPEBOT_SCRIPT_ATTRIBUTE) === "true") {
+        return;
+      }
+
+      element.remove();
+    });
+};
+
+const TypebotBubble = () => {
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    activeInstances += 1;
+
+    const scriptElement = injectTypebotBubble();
+
+    return () => {
+      if (typeof document === "undefined") {
+        return;
+      }
+
+      scriptElement.remove();
+      activeInstances = Math.max(0, activeInstances - 1);
+
+      if (activeInstances === 0) {
+        removeTypebotArtifacts();
+      }
+    };
+  }, []);
+
+  return null;
+};
+
+export default TypebotBubble;

--- a/frontend/src/pages/site/Blog.tsx
+++ b/frontend/src/pages/site/Blog.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import TypebotBubble from "@/components/site/TypebotBubble";
 import SimpleBackground from "@/components/ui/SimpleBackground";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -91,6 +92,7 @@ const BlogPage = () => {
 
   return (
     <div className="min-h-screen flex flex-col bg-background text-foreground">
+      <TypebotBubble />
       <Header />
       <main className="flex-1">
         <section className="relative overflow-hidden border-b border-border/50">

--- a/frontend/src/pages/site/BlogArticle.tsx
+++ b/frontend/src/pages/site/BlogArticle.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Calendar, Clock, Share2, Sparkles, Tag } from "lucide-react"
 
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import TypebotBubble from "@/components/site/TypebotBubble";
 import SimpleBackground from "@/components/ui/SimpleBackground";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -45,6 +46,7 @@ const BlogArticle = () => {
 
   return (
     <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <TypebotBubble />
       <Header />
       <main className="flex-1">
         <section className="relative overflow-hidden border-b border-border/50">

--- a/frontend/src/pages/site/Index.tsx
+++ b/frontend/src/pages/site/Index.tsx
@@ -1,5 +1,6 @@
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import TypebotBubble from "@/components/site/TypebotBubble";
 import Hero from "@/pages/site/components/Hero";
 import Services from "@/pages/site/components/Services";
 import CRMAdvogados from "@/pages/site/components/CRMAdvogados";
@@ -10,6 +11,7 @@ import Contact from "@/pages/site/components/Contact";
 const Index = () => {
   return (
     <div className="min-h-screen">
+      <TypebotBubble />
       <Header />
       <main>
         <Hero />

--- a/frontend/src/pages/site/NossaHistoria.tsx
+++ b/frontend/src/pages/site/NossaHistoria.tsx
@@ -1,5 +1,6 @@
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import TypebotBubble from "@/components/site/TypebotBubble";
 import SimpleBackground from "@/components/ui/SimpleBackground";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -83,6 +84,7 @@ const recognitions = [
 const NossaHistoria = () => {
   return (
     <div className="min-h-screen bg-background text-foreground">
+      <TypebotBubble />
       <Header />
 
       <main>

--- a/frontend/src/pages/site/NotFound.tsx
+++ b/frontend/src/pages/site/NotFound.tsx
@@ -1,6 +1,8 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
 
+import TypebotBubble from "@/components/site/TypebotBubble";
+
 const NotFound = () => {
   const location = useLocation();
 
@@ -10,6 +12,7 @@ const NotFound = () => {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-100">
+      <TypebotBubble />
       <div className="text-center">
         <h1 className="mb-4 text-4xl font-bold">404</h1>
         <p className="mb-4 text-xl text-gray-600">Oops! Page not found</p>

--- a/frontend/src/pages/site/Services.tsx
+++ b/frontend/src/pages/site/Services.tsx
@@ -16,6 +16,7 @@ import {
 
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import TypebotBubble from "@/components/site/TypebotBubble";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
@@ -115,6 +116,7 @@ const processSteps = [
 const ServicesPage = () => {
   return (
     <div className="min-h-screen bg-background">
+      <TypebotBubble />
       <Header />
 
       <main>

--- a/frontend/src/pages/site/services/AssistenteIA.tsx
+++ b/frontend/src/pages/site/services/AssistenteIA.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Bot, MessageSquare, Zap, BarChart3, Clock, Shield, ArrowRight, CheckCircle } from "lucide-react";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import TypebotBubble from "@/components/site/TypebotBubble";
 import { useServiceBySlug } from "@/hooks/useServices";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getGtag } from "@/lib/gtag";
@@ -96,6 +97,7 @@ const AssistenteIA = () => {
 
   return (
     <div className="min-h-screen bg-background">
+      <TypebotBubble />
       <Header />
       
       {/* Hero Section */}

--- a/frontend/src/pages/site/services/Automacoes.tsx
+++ b/frontend/src/pages/site/services/Automacoes.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Settings, Workflow, Timer, TrendingUp, ArrowRight, CheckCircle, Cog, Database } from "lucide-react";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import TypebotBubble from "@/components/site/TypebotBubble";
 import { useServiceBySlug } from "@/hooks/useServices";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getGtag } from "@/lib/gtag";
@@ -99,6 +100,7 @@ const Automacoes = () => {
 
   return (
     <div className="min-h-screen bg-background">
+      <TypebotBubble />
       <Header />
       
       {/* Hero Section */}

--- a/frontend/src/pages/site/services/CRM.tsx
+++ b/frontend/src/pages/site/services/CRM.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/carousel";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import TypebotBubble from "@/components/site/TypebotBubble";
 import {
   ArrowRight,
   BarChart3,
@@ -502,6 +503,7 @@ const CRM = () => {
 
   return (
     <div className="min-h-screen bg-background">
+      <TypebotBubble />
       <Header />
 
       {/* Hero Section */}

--- a/frontend/src/pages/site/services/CRMAdvocacia.tsx
+++ b/frontend/src/pages/site/services/CRMAdvocacia.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import TypebotBubble from "@/components/site/TypebotBubble";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -237,6 +238,7 @@ const CRMAdvocacia = () => {
 
   return (
     <div className="min-h-screen bg-background text-foreground">
+      <TypebotBubble />
       <Header />
 
       <section className="relative overflow-hidden pt-24 pb-20 bg-gradient-hero text-white">

--- a/frontend/src/pages/site/services/Desenvolvimento.tsx
+++ b/frontend/src/pages/site/services/Desenvolvimento.tsx
@@ -33,6 +33,7 @@ import {
 } from "lucide-react";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import TypebotBubble from "@/components/site/TypebotBubble";
 import { useServiceBySlug } from "@/hooks/useServices";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getGtag } from "@/lib/gtag";
@@ -448,6 +449,7 @@ const Desenvolvimento = () => {
 
   return (
     <div className="min-h-screen bg-background text-foreground">
+      <TypebotBubble />
       <Header />
 
       {/* Hero Section */}


### PR DESCRIPTION
## Summary
- remove the global Typebot inline script from the HTML entry point
- add a reusable TypebotBubble component that injects and cleans up the chat widget when site pages mount or unmount
- mount the TypebotBubble component across the public site routes so the bot appears only on marketing pages

## Testing
- `npm run lint` *(fails: missing @eslint/js because npm install is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d463046c3083269eb03eaf550f944e