### PR TITLE
Fix icon import collision in CRM page

### DIFF
--- a/frontend/src/pages/site/services/CRMAdvocacia.tsx
+++ b/frontend/src/pages/site/services/CRMAdvocacia.tsx
@@ -29,7 +29,7 @@ import {
   FolderCog,
   Gavel,
   Layers,
-  Link,
+  Link as LinkIcon,
   MessageSquare,
   Scale,
   Workflow
@@ -108,7 +108,7 @@ const CRMAdvocacia = () => {
         description: "Atenda clientes sem sair da tela, mantendo histórico unificado e automações de atendimento.",
       },
       {
-        icon: Link,
+        icon: LinkIcon,
         title: "Integrações judiciais e financeiras",
         description: "Receba intimações do PJe, PROJUDI e mais, além de conectar gateways de pagamento ao seu CRM.",
       },
@@ -202,7 +202,7 @@ const CRMAdvocacia = () => {
       ],
     },
     {
-      icon: Link,
+      icon: LinkIcon,
       title: "Integrações judiciais e financeiras",
       description:
         "Sincronize o CRM com PJe, PROJUDI e principais sistemas judiciais, além de gateways de pagamento para receber online.",


### PR DESCRIPTION
## Summary
- alias the lucide-react Link icon to LinkIcon to avoid conflicting with react-router Link import
- update Link icon references to use the new alias

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d4747b581c8326bd7bb8ae43bc6435