### PR TITLE
Fix register gradient button visibility

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -52,7 +52,7 @@
     --radius: 0.75rem;
 
     /* Gradients */
-    --gradient-primary: linear-gradient(135deg, hsl(var(--primary)), hsl(217 91% 30%));
+    --gradient-primary: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary-hover)));
     --gradient-secondary: linear-gradient(135deg, hsl(var(--secondary)), hsl(210 20% 98%));
     --gradient-success: linear-gradient(135deg, hsl(var(--success)), hsl(142 71% 50%));
     
@@ -129,6 +129,8 @@
     --sidebar-accent-foreground: 210 20% 96%;
     --sidebar-border: 217 15% 28%;
     --sidebar-ring: 217 85% 55%;
+
+    --gradient-primary: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary-hover)));
   }
 
 }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -79,6 +79,8 @@ export default {
                 },
             },
             backgroundImage: {
+                "gradient-primary":
+                    "linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--primary-hover)) 100%)",
                 "gradient-hero":
                     "linear-gradient(135deg, rgba(6,55,105,0.95) 0%, rgba(3,94,140,0.90) 55%, rgba(4,37,70,0.95) 100%)",
                 "gradient-quantum":


### PR DESCRIPTION
## Summary
- ensure the primary gradient colors respond to the current theme variables
- expose the primary gradient utility through Tailwind for consistent usage across buttons and headings

## Testing
- ⚠️ `npm run lint` *(fails: npm install blocked by 403 when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d47b56293c83268aa704ad6420b516