### PR TITLE
Remove Typebot bootstrap from global index

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,27 +20,5 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <script>
-      const typebotInitScript = document.createElement("script");
-      typebotInitScript.type = "module";
-      typebotInitScript.innerHTML = `import Typebot from 'https://cdn.jsdelivr.net/npm/@typebot.io/js@0/dist/web.js'
-
-Typebot.initBubble({
-  typebot: "quantumbot",
-  apiHost: "https://form.quantumtecnologia.com.br",
-  previewMessage: {
-    message: "Olá, sou o QuantumBot. Em que posso ajudá-lo?",
-    autoShowDelay: 10000,
-    avatarUrl:
-      "https://i.postimg.cc/CLKVTcfx/graident-ai-robot-vectorart-em-ingles-78370-4114.avif",
-  },
-  theme: {
-    button: { backgroundColor: "#303235" },
-    chatWindow: { backgroundColor: "#FFFFFF" },
-  },
-});
-`;
-      document.body.append(typebotInitScript);
-    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the global Typebot initialization script from `frontend/index.html` so the bubble only loads where the React component is rendered

## Testing
- npm install *(fails: 403 Forbidden when downloading dependencies from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d47d2aafe48326934a9a2d78c02f43