### PR TITLE
feat: highlight current plan in header

### DIFF
--- a/frontend/src/components/layout/CRMLayout.tsx
+++ b/frontend/src/components/layout/CRMLayout.tsx
@@ -47,7 +47,7 @@ export function CRMLayout() {
         <div className={containerClassName}>
           <Header />
           <TrialBanner />
-          <main className={mainClassName}>
+          <main className={mainClassName} data-crm-scroll-container>
             <Outlet />
           </main>
         </div>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,27 +1,105 @@
-import { Search } from "lucide-react";
-import { Input } from "@/components/ui/input";
+import { useEffect, useMemo, useState } from "react";
+
 import { HeaderActions } from "@/components/layout/HeaderActions";
 import { SidebarTrigger } from "@/components/ui/sidebar";
+import { cn } from "@/lib/utils";
+import { usePlan } from "@/features/plans/PlanProvider";
+
+const getPlanDisplayName = (name: string | null | undefined, id: number | null | undefined) => {
+  const normalizedName = typeof name === "string" ? name.trim() : "";
+  if (normalizedName.length > 0) {
+    return normalizedName;
+  }
+
+  if (typeof id === "number" && Number.isFinite(id)) {
+    return `Plano ${id}`;
+  }
+
+  return "Plano não definido";
+};
 
 export function Header() {
+  const { plan, isLoading, error } = usePlan();
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const scrollContainer = document.querySelector<HTMLElement>("[data-crm-scroll-container]");
+
+    const updateScrollState = () => {
+      const scrollTop = scrollContainer?.scrollTop ?? window.scrollY ?? 0;
+      setIsScrolled(scrollTop > 0);
+    };
+
+    updateScrollState();
+
+    const options: AddEventListenerOptions = { passive: true };
+    if (scrollContainer) {
+      scrollContainer.addEventListener("scroll", updateScrollState, options);
+    } else {
+      window.addEventListener("scroll", updateScrollState, options);
+    }
+
+    return () => {
+      scrollContainer?.removeEventListener("scroll", updateScrollState);
+      window.removeEventListener("scroll", updateScrollState);
+    };
+  }, []);
+
+  const planName = useMemo(
+    () => getPlanDisplayName(plan?.nome, plan?.id),
+    [plan?.id, plan?.nome],
+  );
+
+  const planStatusLabel = useMemo(() => {
+    if (isLoading) {
+      return "Carregando plano...";
+    }
+
+    if (error) {
+      return "Não foi possível carregar o plano";
+    }
+
+    return planName;
+  }, [error, isLoading, planName]);
+
+  const planStatusTone = error
+    ? "text-destructive border-destructive/40 bg-destructive/10"
+    : "text-primary border-primary/30 bg-primary/10";
+
   return (
-    <header className="flex flex-wrap items-center gap-3 border-b border-border bg-card px-4 py-3 sm:px-6 sm:py-4">
-      {/* Search */}
-      <div className="flex min-w-0 flex-1 items-center gap-3">
-        <SidebarTrigger className="text-muted-foreground" />
-        <div className="max-w-md flex-1">
-          <div className="relative">
-            {/*<Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />*/}
-            {/*<Input*/}
-            {/*  placeholder="Pesquisar clientes, processos..."*/}
-            {/*  className="pl-9 bg-muted/50"*/}
-            {/*/>*/}
+    <header
+      className={cn(
+        "sticky top-0 z-50 border-b border-border/60 transition-colors",
+        isScrolled
+          ? "bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60"
+          : "bg-background",
+      )}
+    >
+      <div className="flex h-16 flex-wrap items-center gap-3 px-4 sm:px-6">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <SidebarTrigger className="text-muted-foreground" />
+
+          <div className="min-w-0">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Plano atual</p>
+            <span
+              className={cn(
+                "mt-1 inline-flex max-w-full items-center gap-2 truncate rounded-full border px-3 py-1 text-sm font-semibold",
+                planStatusTone,
+              )}
+              title={planStatusLabel}
+            >
+              {planStatusLabel}
+            </span>
           </div>
         </div>
-      </div>
 
-      {/* Actions */}
-      <HeaderActions />
+        {/* Actions */}
+        <HeaderActions />
+      </div>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- display the selected subscription plan in the CRM header with a highlighted badge
- keep the CRM header fixed with a translucent background when the content scrolls
- expose the CRM main scroll container so the header can react to scroll state

## Testing
- npm run lint *(fails: missing npm dependencies due to registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d47d9fa1148326a9d289f58eebf450