### PR TITLE
Enforce password reset for provisioned users

### DIFF
--- a/backend/src/controllers/usuarioController.ts
+++ b/backend/src/controllers/usuarioController.ts
@@ -324,7 +324,7 @@ export const createUsuario = async (req: Request, res: Response) => {
     const hashedPassword = hashPassword(temporaryPassword);
 
     const result = await pool.query(
-      'INSERT INTO public.usuarios (nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, NOW()) RETURNING id, nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, telefone, ultimo_login, observacoes, datacriacao',
+      'INSERT INTO public.usuarios (nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, must_change_password, telefone, ultimo_login, observacoes, datacriacao) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, TRUE, $10, $11, $12, NOW()) RETURNING id, nome_completo, cpf, email, perfil, empresa, setor, oab, status, senha, must_change_password, telefone, ultimo_login, observacoes, datacriacao',
       [
         nome_completo,
         cpf,


### PR DESCRIPTION
## Summary
- ensure collaborators created with a provisional password are saved with must_change_password=true so they are forced to update their password on first login

## Testing
- npm test *(fails: existing register test cases expect a plan selection and return 400 even without the change)*

------
https://chatgpt.com/codex/tasks/task_e_68d47f90861483269aae3ff763168edc