### PR TITLE
Limit plan usage user count to company members

### DIFF
--- a/frontend/src/pages/operator/MeuPlano.tsx
+++ b/frontend/src/pages/operator/MeuPlano.tsx
@@ -557,7 +557,7 @@ function MeuPlanoContent() {
 
       const planosUrl = joinUrl(apiBaseUrl, "/api/planos");
       const empresasUrl = joinUrl(apiBaseUrl, "/api/empresas");
-      const usuariosUrl = joinUrl(apiBaseUrl, "/api/usuarios");
+      const usuariosUrl = joinUrl(apiBaseUrl, "/api/usuarios/empresa");
       const clientesUrl = joinUrl(apiBaseUrl, "/api/clientes/ativos/total");
 
       try {


### PR DESCRIPTION
## Summary
- update the Meu Plano metrics fetch to call the company-scoped users endpoint
- ensure the active user count in the utilization card reflects only members of the signed-in company

## Testing
- `npm run lint` *(fails: Missing @eslint/js dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d48560e1a88326bc27958f66f498bc