### PR TITLE
Use non-slim Node image for runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,10 @@ RUN npm --prefix backend run build
 RUN npm --prefix frontend run build
 
 # ---------- Production stage ----------
-FROM node:20-bullseye-slim AS runtime
+# NOTE: The build agents running our Docker image do not have credentials to
+# pull images that require token-based access. Using the non-slim variant keeps
+# the base image public while remaining Debian-based for compatibility.
+FROM node:20-bullseye AS runtime
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
 ENV PORT=3000


### PR DESCRIPTION
## Summary
- switch the runtime stage to use the public node:20-bullseye image
- document the rationale so builders without Docker Hub credentials can pull the base image

## Testing
- not run (infrastructure-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d48b949bb08326a04d14b1e5d3ad60