### PR TITLE
Refine processo instancia selection

### DIFF
--- a/frontend/src/pages/operator/Processos.tsx
+++ b/frontend/src/pages/operator/Processos.tsx
@@ -209,6 +209,7 @@ interface ProcessFormState {
   propostaId: string;
   dataDistribuicao: string;
   instancia: string;
+  instanciaOutro: string;
 }
 
 const formatProcessNumber = (value: string) => {
@@ -390,6 +391,29 @@ const formatPropostaLabel = (
   return `Proposta #${numero}/${ano}${solicitanteNome ? ` - ${solicitanteNome}` : ""}`;
 };
 
+const INSTANCIA_OUTRO_VALUE = "Outro / Especificar";
+
+const INSTANCIA_OPTIONS = [
+  "1ª Vara Cível",
+  "2ª Vara Cível",
+  "Vara Criminal",
+  "Vara de Família",
+  "Vara da Fazenda Pública",
+  "Juizado Especial Cível",
+  "Juizado Especial Criminal",
+  "Vara do Trabalho",
+  "Tribunal de Justiça (TJ) — 2ª Instância",
+  "Tribunal Regional Federal (TRF) — 2ª Instância",
+  "Tribunal Regional do Trabalho (TRT) — 2ª Instância",
+  "Tribunal Regional Eleitoral (TRE) — 2ª Instância",
+  "Turma Recursal (Juizados)",
+  "Tribunal Superior do Trabalho (TST)",
+  "Tribunal Superior Eleitoral (TSE)",
+  "Superior Tribunal de Justiça (STJ)",
+  "Supremo Tribunal Federal (STF)",
+  INSTANCIA_OUTRO_VALUE,
+];
+
 const createEmptyProcessForm = (): ProcessFormState => ({
   numero: "",
   uf: "",
@@ -399,6 +423,7 @@ const createEmptyProcessForm = (): ProcessFormState => ({
   propostaId: "",
   dataDistribuicao: "",
   instancia: "",
+  instanciaOutro: "",
 });
 
 const mapApiProcessoToProcesso = (processo: ApiProcesso): Processo => {
@@ -1157,7 +1182,10 @@ export default function Processos() {
         advogados: advogadosPayload,
       };
 
-      const instanciaPayload = processForm.instancia.trim();
+      const instanciaPayload =
+        processForm.instancia === INSTANCIA_OUTRO_VALUE
+          ? processForm.instanciaOutro.trim()
+          : processForm.instancia.trim();
       if (instanciaPayload) {
         payload.orgao_julgador = instanciaPayload;
       }
@@ -1241,11 +1269,14 @@ export default function Processos() {
     [navigate, toast],
   );
 
+  const isInstanciaOutroSelected = processForm.instancia === INSTANCIA_OUTRO_VALUE;
+
   const isCreateDisabled =
     !processForm.numero ||
     !processForm.uf ||
     !processForm.municipio ||
     !processForm.clienteId ||
+    (isInstanciaOutroSelected && processForm.instanciaOutro.trim().length === 0) ||
     creatingProcess;
 
   const filteredProcessos = useMemo(() => {
@@ -1981,33 +2012,62 @@ export default function Processos() {
                 </p>
               )}
             </div>
-            <div className="space-y-2 sm:col-span-2 md:col-span-1">
-              <Label htmlFor="process-number">Número do processo</Label>
-              <Input
-                id="process-number"
-                placeholder="0000000-00.0000.0.00.0000"
-                value={processForm.numero}
-                onChange={(event) =>
-                  setProcessForm((prev) => ({
-                    ...prev,
-                    numero: formatProcessNumber(event.target.value),
-                  }))
-                }
-              />
-            </div>
-            <div className="space-y-2 sm:col-span-2 md:col-span-1">
-              <Label htmlFor="process-instancia">Instância do processo</Label>
-              <Input
-                id="process-instancia"
-                placeholder="Ex.: 1ª Vara Cível"
-                value={processForm.instancia}
-                onChange={(event) =>
-                  setProcessForm((prev) => ({
-                    ...prev,
-                    instancia: event.target.value,
-                  }))
-                }
-              />
+            <div className="space-y-4 sm:col-span-2 md:col-span-1">
+              <div className="space-y-2">
+                <Label htmlFor="process-number">Número do processo</Label>
+                <Input
+                  id="process-number"
+                  placeholder="0000000-00.0000.0.00.0000"
+                  value={processForm.numero}
+                  onChange={(event) =>
+                    setProcessForm((prev) => ({
+                      ...prev,
+                      numero: formatProcessNumber(event.target.value),
+                    }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="process-instancia">Instância do processo</Label>
+                <Select
+                  value={processForm.instancia}
+                  onValueChange={(value) =>
+                    setProcessForm((prev) => ({
+                      ...prev,
+                      instancia: value,
+                      instanciaOutro:
+                        value === INSTANCIA_OUTRO_VALUE ? prev.instanciaOutro : "",
+                    }))
+                  }
+                >
+                  <SelectTrigger id="process-instancia">
+                    <SelectValue placeholder="Selecione a instância" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {INSTANCIA_OPTIONS.map((option) => (
+                      <SelectItem key={option} value={option}>
+                        {option}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              {isInstanciaOutroSelected ? (
+                <div className="space-y-2">
+                  <Label htmlFor="process-instancia-outro">Especificar instância</Label>
+                  <Input
+                    id="process-instancia-outro"
+                    placeholder="Descreva a instância"
+                    value={processForm.instanciaOutro}
+                    onChange={(event) =>
+                      setProcessForm((prev) => ({
+                        ...prev,
+                        instanciaOutro: event.target.value,
+                      }))
+                    }
+                  />
+                </div>
+              ) : null}
             </div>
             <div className="space-y-2 sm:col-span-2 md:col-span-1">
               <Label htmlFor="process-distribution-date">Data da distribuição</Label>


### PR DESCRIPTION
## Summary
- ensure the judicial instance dropdown appears directly beneath the process number input
- add a custom "Outro / Especificar" flow that reveals a free-text field when selected
- require a specification for the custom instance before allowing submission and send it in the payload

## Testing
- `npm run lint` *(fails: cannot resolve @eslint/js in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d499185d7c8326ba171849f292e23f