### PR TITLE
Handle duplicate CPF error when creating client

### DIFF
--- a/frontend/src/pages/operator/NovoCliente.tsx
+++ b/frontend/src/pages/operator/NovoCliente.tsx
@@ -113,7 +113,7 @@ export default function NovoCliente() {
           tipo: values.type === "pj" ? "2" : "1",
           documento: values.cpf.replace(/\D/g, ""),
           email: values.email || null,
-           telefone: values.phone ? values.phone.replace(/\D/g, "") : null,
+          telefone: values.phone ? values.phone.replace(/\D/g, "") : null,
           cep: values.cep || null,
           rua: values.street || null,
           numero: values.number || null,
@@ -126,13 +126,28 @@ export default function NovoCliente() {
         }),
       });
       if (!response.ok) {
-        throw new Error("Failed to create client");
+        const errorPayload = await response.json().catch(() => null);
+
+        const duplicateDocument =
+          response.status === 409 ||
+          (typeof errorPayload?.error === "string" &&
+            errorPayload.error.toLowerCase().includes("documento"));
+
+        const errorMessage = duplicateDocument
+          ? "Já existe cliente com o CPF informado."
+          : "Erro ao criar cliente";
+
+        throw new Error(errorMessage);
       }
       toast({ title: "Cliente cadastrado com sucesso" });
       navigate("/clientes");
     } catch (error) {
       console.error("Erro ao criar cliente:", error);
-      toast({ title: "Erro ao criar cliente", variant: "destructive" });
+      toast({
+        title:
+          error instanceof Error ? error.message : "Erro ao criar cliente",
+        variant: "destructive",
+      });
     }
   };
 


### PR DESCRIPTION
## Summary
- enhance the new client form submission error handling to detect duplicate CPF responses
- show a specific destructive toast when the API indicates an existing document instead of a generic error

## Testing
- npm --prefix frontend install *(fails: npm error 403 Forbidden when fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68d49bf39d188326ab5c5fe41973f1d4