### PR TITLE
Ensure Meus Arquivos module is available in plan and profile forms

### DIFF
--- a/frontend/src/pages/administrator/NewPlan.tsx
+++ b/frontend/src/pages/administrator/NewPlan.tsx
@@ -44,6 +44,7 @@ import {
   parseCurrencyDigits,
   splitFeatureInput,
   buildRecursosPayload,
+  ensureDefaultModules,
 } from "./plans-utils";
 
 interface ModuleMultiSelectProps {
@@ -175,7 +176,7 @@ export default function NewPlan() {
           .filter((item): item is ModuleInfo => item !== null);
 
         if (!disposed) {
-          setAvailableModules(parsedModules);
+          setAvailableModules(ensureDefaultModules(parsedModules));
         }
       } catch (error) {
         if (!disposed) {

--- a/frontend/src/pages/administrator/Plans.tsx
+++ b/frontend/src/pages/administrator/Plans.tsx
@@ -65,6 +65,7 @@ import {
   extractCurrencyDigits,
   formatCurrencyInputValue,
   parseCurrencyDigits,
+  ensureDefaultModules,
 } from "./plans-utils";
 
 interface ModuleMultiSelectProps {
@@ -276,13 +277,15 @@ export default function Plans() {
         .map((entry) => parseModuleInfo(entry))
         .filter((item): item is ModuleInfo => item !== null);
 
+      const augmentedModules = ensureDefaultModules(parsedModules);
+
       const plansPayload = extractCollection(await plansResponse.json());
       const parsedPlans = plansPayload
         .map((entry) => parsePlan(entry))
         .filter((item): item is Plan => item !== null);
 
-      setAvailableModules(parsedModules);
-      setPlans(normalizePlans(parsedPlans, parsedModules));
+      setAvailableModules(augmentedModules);
+      setPlans(normalizePlans(parsedPlans, augmentedModules));
     } catch (err) {
       console.error(err);
       setAvailableModules([]);

--- a/frontend/src/pages/administrator/plans-utils.ts
+++ b/frontend/src/pages/administrator/plans-utils.ts
@@ -5,6 +5,30 @@ export interface ModuleInfo {
   categoria?: string;
 }
 
+const STATIC_MODULES: ModuleInfo[] = [
+  {
+    id: "arquivos",
+    nome: "Meus Arquivos",
+  },
+];
+
+export const ensureDefaultModules = (modules: ModuleInfo[]): ModuleInfo[] => {
+  if (modules.length === 0) {
+    return [...STATIC_MODULES];
+  }
+
+  const knownIds = new Set(modules.map((module) => module.id));
+  const augmented = [...modules];
+
+  STATIC_MODULES.forEach((module) => {
+    if (!knownIds.has(module.id)) {
+      augmented.push(module);
+    }
+  });
+
+  return augmented;
+};
+
 export interface Plan {
   id: number;
   name: string;

--- a/frontend/src/pages/operator/configuracoes/parametros/Perfis.tsx
+++ b/frontend/src/pages/operator/configuracoes/parametros/Perfis.tsx
@@ -23,6 +23,30 @@ interface ModuleInfo {
   categoria?: string;
 }
 
+const STATIC_MODULES: ModuleInfo[] = [
+  {
+    id: "arquivos",
+    nome: "Meus Arquivos",
+  },
+];
+
+const ensureDefaultModules = (modules: ModuleInfo[]): ModuleInfo[] => {
+  if (modules.length === 0) {
+    return [...STATIC_MODULES];
+  }
+
+  const knownIds = new Set(modules.map((module) => module.id));
+  const augmented = [...modules];
+
+  STATIC_MODULES.forEach((module) => {
+    if (!knownIds.has(module.id)) {
+      augmented.push(module);
+    }
+  });
+
+  return augmented;
+};
+
 interface PerfilItem {
   id: number;
   nome: string;
@@ -178,7 +202,9 @@ export default function Perfis() {
           })
           .filter((item): item is ModuleInfo => item !== null);
 
-        setAvailableModules(parsedModules);
+        const augmentedModules = ensureDefaultModules(parsedModules);
+
+        setAvailableModules(augmentedModules);
 
         const rawProfiles = extractCollection(await profilesRes.json());
         const parsedProfiles = rawProfiles
@@ -195,7 +221,7 @@ export default function Perfis() {
                   : typeof data.name === "string"
                     ? data.name
                     : "";
-            const modulos = orderModules(normalizeModuleIds(data.modulos), parsedModules);
+            const modulos = orderModules(normalizeModuleIds(data.modulos), augmentedModules);
             const viewAllConversations = parseViewAllConversations(
               data.viewAllConversations ??
                 data.visualizarTodasConversas ??


### PR DESCRIPTION
## Summary
- ensure the "Meus Arquivos" module is appended to the module list used by the admin new plan flow and plan management page
- include the static "Meus Arquivos" option when loading modules on the operator profile configuration page so it can be assigned to profiles

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a213a6688326a4648bb60a3febdc