### PR TITLE
Adjust settle action button styling

### DIFF
--- a/frontend/src/pages/operator/FinancialFlows.tsx
+++ b/frontend/src/pages/operator/FinancialFlows.tsx
@@ -1346,7 +1346,7 @@ const FinancialFlows = () => {
                               {flow.computedStatus !== 'pago' ? (
                                 <Button
                                   size="sm"
-                                  variant="outline"
+                                  variant="outline_quantum"
                                   onClick={() => handleOpenSettleDialog(flow)}
                                   disabled={settleMutation.isPending || !flow.canManuallySettle}
                                   title={


### PR DESCRIPTION
## Summary
- switch the financial flows "Marcar como pago" button to the branded outline style so it stays visible in the table

## Testing
- npm run lint *(fails: missing dependencies because npm install is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a50cd4988326a43668c46dec303e