### PR TITLE
Allow settle button action when manual settlement is restricted

### DIFF
--- a/frontend/src/pages/operator/FinancialFlows.tsx
+++ b/frontend/src/pages/operator/FinancialFlows.tsx
@@ -1346,15 +1346,15 @@ const FinancialFlows = () => {
                               {flow.computedStatus !== 'pago' ? (
                                 <Button
                                   size="sm"
-                                  variant="outline"
+                                  variant="outline_quantum"
                                   onClick={() => handleOpenSettleDialog(flow)}
-                                  disabled={settleMutation.isPending || !flow.canManuallySettle}
+                                  disabled={settleMutation.isPending}
                                   title={
                                     !flow.canManuallySettle
                                       ? 'Somente lançamentos cadastrados no Quantum JUD podem ser marcados manualmente como pagos.'
                                       : undefined
                                   }
-
+                                  aria-disabled={settleMutation.isPending || !flow.canManuallySettle}
                                 >
                                   Marcar como pago
                                 </Button>


### PR DESCRIPTION
## Summary
- keep the "Marcar como pago" action clickable even when manual settlement is restricted so the toast feedback appears
- expose the manual restriction state through `aria-disabled` instead of the native disabled attribute

## Testing
- npm run lint *(fails: missing @eslint/js dependency in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a50cd4988326a43668c46dec303e