### PR TITLE
Lock conversation responsible filter for assigned-only profiles

### DIFF
--- a/frontend/src/features/chat/components/ChatSidebar.tsx
+++ b/frontend/src/features/chat/components/ChatSidebar.tsx
@@ -20,6 +20,7 @@ interface ChatSidebarProps {
   onLoadMore?: () => void;
   isLoadingMore?: boolean;
   allowUnassignedFilter?: boolean;
+  isResponsibleFilterLocked?: boolean;
 }
 
 export const ChatSidebar = ({
@@ -38,6 +39,7 @@ export const ChatSidebar = ({
   onLoadMore,
   isLoadingMore = false,
   allowUnassignedFilter = true,
+  isResponsibleFilterLocked = false,
 }: ChatSidebarProps) => {
   const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
   const filtered = useMemo(() => {
@@ -142,9 +144,12 @@ export const ChatSidebar = ({
             className={styles.filterSelect}
             value={responsibleFilter}
             onChange={(event) => onResponsibleFilterChange(event.target.value)}
+            disabled={isResponsibleFilterLocked}
           >
-            <option value="all">Todos</option>
-            {allowUnassignedFilter && <option value="unassigned">Sem responsável</option>}
+            {!isResponsibleFilterLocked && <option value="all">Todos</option>}
+            {!isResponsibleFilterLocked && allowUnassignedFilter && (
+              <option value="unassigned">Sem responsável</option>
+            )}
             {responsibleOptions.map((option) => (
               <option key={option.id} value={option.id}>
                 {option.name}


### PR DESCRIPTION
## Summary
- ensure WAHA chat sidebar enforces the current user as the responsible filter when the profile only sees assigned conversations
- limit the sidebar responsible dropdown options and disable it while still exposing all responsibles inside the conversation details for reassignment
- add a lock flag to the shared chat sidebar component to hide global options when the filter is fixed

## Testing
- `npm run lint` *(fails: missing @eslint/js because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a88283a48326abe018a56d219dbd