### PR TITLE
Add Judit provider to integration API key management

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ em `integration_api_keys`:
 Não são necessárias variáveis de ambiente adicionais além das credenciais
 registradas na tabela.
 
+### Integração com JUDIT
+
+Para consumir os recursos do JUDIT utilizando credenciais gerenciadas em
+`integration_api_keys`:
+
+1. Execute `psql -f sql/integration_api_keys.sql` para atualizar o `CHECK`
+   de provedores com o valor `judit`, caso ainda não tenha aplicado o script
+   recentemente.
+2. Cadastre uma chave com `provider` igual a `judit` (via API ou pela tela de
+   integrações), informando o token fornecido pelo JUDIT e o ambiente desejado.
+3. Se necessário auditar os acessos, utilize a consulta administrativa
+   [`backend/sql/queries/judit_credentials_audit.sql`](backend/sql/queries/judit_credentials_audit.sql)
+   para listar todas as credenciais cadastradas, com datas de uso e status.
+
+O backend não define URL padrão para o JUDIT; mantenha o campo `apiUrl` em
+branco para usar a configuração padrão do provedor ou preencha manualmente
+quando um endpoint específico for exigido.
+
 ## Frontend
 
 ```bash

--- a/backend/dist/routes/integrationApiKeyRoutes.js
+++ b/backend/dist/routes/integrationApiKeyRoutes.js
@@ -60,7 +60,7 @@ router.get('/integrations/api-keys/:id', integrationApiKeyController_1.getIntegr
  *             properties:
  *               provider:
  *                 type: string
- *                 enum: [gemini, openai, asaas]
+ *                 enum: [gemini, openai, asaas, judit]
  *               apiUrl:
  *                 type: string
  *                 format: uri
@@ -101,7 +101,7 @@ router.post('/integrations/api-keys', integrationApiKeyController_1.createIntegr
  *             properties:
  *               provider:
  *                 type: string
- *                 enum: [gemini, openai, asaas]
+ *                 enum: [gemini, openai, asaas, judit]
  *               apiUrl:
  *                 type: string
  *                 format: uri

--- a/backend/dist/services/integrationApiKeyService.js
+++ b/backend/dist/services/integrationApiKeyService.js
@@ -6,7 +6,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.ASAAS_DEFAULT_API_URLS = exports.ValidationError = exports.API_KEY_ENVIRONMENTS = exports.API_KEY_PROVIDERS = void 0;
 const url_1 = require("url");
 const db_1 = __importDefault(require("./db"));
-exports.API_KEY_PROVIDERS = ['gemini', 'openai', 'asaas'];
+exports.API_KEY_PROVIDERS = ['gemini', 'openai', 'asaas', 'judit'];
 exports.API_KEY_ENVIRONMENTS = ['producao', 'homologacao'];
 class ValidationError extends Error {
     constructor(message) {
@@ -34,7 +34,7 @@ function normalizeProvider(value) {
         throw new ValidationError('Provider is required');
     }
     if (!exports.API_KEY_PROVIDERS.includes(normalized)) {
-        throw new ValidationError('Provider must be Gemini, OpenAI or Asaas');
+        throw new ValidationError('Provider must be Gemini, OpenAI, Asaas or Judit');
     }
     return normalized;
 }

--- a/backend/dist/sql/integration_api_keys.sql
+++ b/backend/dist/sql/integration_api_keys.sql
@@ -1,7 +1,7 @@
 -- Estrutura para armazenamento de chaves de API das integrações
 CREATE TABLE IF NOT EXISTS integration_api_keys (
   id BIGSERIAL PRIMARY KEY,
-  provider TEXT NOT NULL CHECK (provider IN ('gemini', 'openai', 'asaas')),
+  provider TEXT NOT NULL CHECK (provider IN ('gemini', 'openai', 'asaas', 'judit')),
   url_api TEXT,
   key_value TEXT NOT NULL,
   url_api TEXT NULL,
@@ -20,7 +20,7 @@ ALTER TABLE integration_api_keys
 
 ALTER TABLE integration_api_keys
   ADD CONSTRAINT integration_api_keys_provider_check
-  CHECK (provider IN ('gemini', 'openai', 'asaas'));
+  CHECK (provider IN ('gemini', 'openai', 'asaas', 'judit'));
 
 CREATE INDEX IF NOT EXISTS idx_integration_api_keys_provider
   ON integration_api_keys (provider);

--- a/backend/dist/sql/queries/judit_credentials_audit.sql
+++ b/backend/dist/sql/queries/judit_credentials_audit.sql
@@ -1,0 +1,12 @@
+-- Consulta administrativa para listar credenciais JUDIT cadastradas
+SELECT
+  id,
+  provider,
+  environment,
+  active,
+  last_used,
+  created_at,
+  updated_at
+FROM integration_api_keys
+WHERE provider = 'judit'
+ORDER BY created_at DESC;

--- a/backend/sql/integration_api_keys.sql
+++ b/backend/sql/integration_api_keys.sql
@@ -1,7 +1,7 @@
 -- Estrutura para armazenamento de chaves de API das integrações
 CREATE TABLE IF NOT EXISTS integration_api_keys (
   id BIGSERIAL PRIMARY KEY,
-  provider TEXT NOT NULL CHECK (provider IN ('gemini', 'openai', 'asaas')),
+  provider TEXT NOT NULL CHECK (provider IN ('gemini', 'openai', 'asaas', 'judit')),
   url_api TEXT,
   key_value TEXT NOT NULL,
   url_api TEXT NULL,
@@ -20,7 +20,7 @@ ALTER TABLE integration_api_keys
 
 ALTER TABLE integration_api_keys
   ADD CONSTRAINT integration_api_keys_provider_check
-  CHECK (provider IN ('gemini', 'openai', 'asaas'));
+  CHECK (provider IN ('gemini', 'openai', 'asaas', 'judit'));
 
 CREATE INDEX IF NOT EXISTS idx_integration_api_keys_provider
   ON integration_api_keys (provider);

--- a/backend/sql/queries/judit_credentials_audit.sql
+++ b/backend/sql/queries/judit_credentials_audit.sql
@@ -1,0 +1,12 @@
+-- Consulta administrativa para listar credenciais JUDIT cadastradas
+SELECT
+  id,
+  provider,
+  environment,
+  active,
+  last_used,
+  created_at,
+  updated_at
+FROM integration_api_keys
+WHERE provider = 'judit'
+ORDER BY created_at DESC;

--- a/backend/src/routes/integrationApiKeyRoutes.ts
+++ b/backend/src/routes/integrationApiKeyRoutes.ts
@@ -70,7 +70,7 @@ router.get('/integrations/api-keys/:id', getIntegrationApiKey);
  *             properties:
  *               provider:
  *                 type: string
- *                 enum: [gemini, openai, asaas]
+ *                 enum: [gemini, openai, asaas, judit]
  *               apiUrl:
  *                 type: string
  *                 format: uri
@@ -112,7 +112,7 @@ router.post('/integrations/api-keys', createIntegrationApiKey);
  *             properties:
  *               provider:
  *                 type: string
- *                 enum: [gemini, openai, asaas]
+ *                 enum: [gemini, openai, asaas, judit]
  *               apiUrl:
  *                 type: string
  *                 format: uri

--- a/backend/src/services/integrationApiKeyService.ts
+++ b/backend/src/services/integrationApiKeyService.ts
@@ -2,7 +2,7 @@ import { QueryResultRow } from 'pg';
 import { URL } from 'url';
 import pool from './db';
 
-export const API_KEY_PROVIDERS = ['gemini', 'openai', 'asaas'] as const;
+export const API_KEY_PROVIDERS = ['gemini', 'openai', 'asaas', 'judit'] as const;
 export type ApiKeyProvider = (typeof API_KEY_PROVIDERS)[number];
 
 export const API_KEY_ENVIRONMENTS = ['producao', 'homologacao'] as const;
@@ -86,7 +86,7 @@ function normalizeProvider(value: string | undefined): ApiKeyProvider {
     throw new ValidationError('Provider is required');
   }
   if (!API_KEY_PROVIDERS.includes(normalized as ApiKeyProvider)) {
-    throw new ValidationError('Provider must be Gemini, OpenAI or Asaas');
+    throw new ValidationError('Provider must be Gemini, OpenAI, Asaas or Judit');
   }
   return normalized as ApiKeyProvider;
 }

--- a/backend/tests/integrationApiKeyService.test.ts
+++ b/backend/tests/integrationApiKeyService.test.ts
@@ -72,6 +72,47 @@ test('IntegrationApiKeyService.create normalizes payload and persists values', a
   assert.deepEqual(result, expected);
 });
 
+test('IntegrationApiKeyService.create normalizes Judit provider and omits default URL', async () => {
+  const insertedRow = {
+    id: 5,
+    provider: 'judit',
+    url_api: null,
+    key_value: 'judit_token_value',
+    environment: 'homologacao',
+    active: true,
+    last_used: null,
+    created_at: '2024-01-05T00:00:00.000Z',
+    updated_at: '2024-01-05T00:00:00.000Z',
+  };
+
+  const pool = new FakePool([
+    { rows: [insertedRow], rowCount: 1 },
+  ]);
+
+  const service = new IntegrationApiKeyService(pool as any);
+
+  const payload: CreateIntegrationApiKeyInput = {
+    provider: '  JuDiT  ',
+    key: '  judit_token_value  ',
+    environment: ' Homologacao ',
+  };
+
+  const result = await service.create(payload);
+
+  assert.deepEqual(pool.calls[0].values, [
+    'judit',
+    null,
+    'judit_token_value',
+    'homologacao',
+    true,
+    null,
+  ]);
+
+  assert.equal(result.provider, 'judit');
+  assert.equal(result.apiUrl, null);
+  assert.equal(result.environment, 'homologacao');
+});
+
 test('IntegrationApiKeyService.create assigns default API URL for Asaas in produção', async () => {
   const insertedRow = {
     id: 2,

--- a/frontend/src/lib/integrationApiKeys.ts
+++ b/frontend/src/lib/integrationApiKeys.ts
@@ -1,12 +1,13 @@
 import { getApiUrl } from './api';
 
-export const API_KEY_PROVIDERS = ['gemini', 'openai', 'asaas'] as const;
+export const API_KEY_PROVIDERS = ['gemini', 'openai', 'asaas', 'judit'] as const;
 export type ApiKeyProvider = (typeof API_KEY_PROVIDERS)[number];
 
 export const API_KEY_PROVIDER_LABELS: Record<ApiKeyProvider, string> = {
   gemini: 'Gemini',
   openai: 'OpenAI',
   asaas: 'Asaas',
+  judit: 'JUDIT',
 };
 
 export const API_KEY_ENVIRONMENTS = ['producao', 'homologacao'] as const;


### PR DESCRIPTION
## Summary
- add the Judit integration provider to backend validation, schema constraints, and Swagger docs
- cover Judit persistence in integration API key tests and expose the provider in the frontend constants
- document how to register the new credential and provide an administrative SQL query for audits

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5af3c44c883268d62e4c0cf1ef30c