### PR TITLE
Add JUDIT process sync persistence and webhook logging

### DIFF
--- a/backend/dist/controllers/processoController.js
+++ b/backend/dist/controllers/processoController.js
@@ -7,6 +7,7 @@ exports.deleteProcesso = exports.updateProcesso = exports.createProcesso = expor
 const planLimitsService_1 = require("../services/planLimitsService");
 const db_1 = __importDefault(require("../services/db"));
 const notificationService_1 = require("../services/notificationService");
+const juditProcessService_1 = require("../services/juditProcessService");
 const authUser_1 = require("../utils/authUser");
 const normalizeString = (value) => {
     if (typeof value !== 'string') {
@@ -568,6 +569,14 @@ const getProcessoById = async (req, res) => {
         }
         const processo = mapProcessoRow(result.rows[0]);
         processo.movimentacoes = await fetchProcessoMovimentacoes(parsedId);
+        const [juditSyncs, juditResponses, juditAuditTrail] = await Promise.all([
+            (0, juditProcessService_1.listProcessSyncs)(parsedId),
+            (0, juditProcessService_1.listProcessResponses)(parsedId),
+            (0, juditProcessService_1.listSyncAudits)(parsedId),
+        ]);
+        processo.juditSyncs = juditSyncs;
+        processo.juditResponses = juditResponses;
+        processo.juditAuditTrail = juditAuditTrail;
         res.json(processo);
     }
     catch (error) {

--- a/backend/dist/index.js
+++ b/backend/dist/index.js
@@ -1,4 +1,37 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -11,9 +44,11 @@ const tipoEventoRoutes_1 = __importDefault(require("./routes/tipoEventoRoutes"))
 const tipoProcessoRoutes_1 = __importDefault(require("./routes/tipoProcessoRoutes"));
 const escritorioRoutes_1 = __importDefault(require("./routes/escritorioRoutes"));
 const perfilRoutes_1 = __importDefault(require("./routes/perfilRoutes"));
-const planoRoutes_1 = __importDefault(require("./routes/planoRoutes"));
+const planoRoutes_1 = __importStar(require("./routes/planoRoutes"));
+const planPaymentRoutes_1 = __importDefault(require("./routes/planPaymentRoutes"));
 const subscriptionRoutes_1 = __importDefault(require("./routes/subscriptionRoutes"));
 const situacaoClienteRoutes_1 = __importDefault(require("./routes/situacaoClienteRoutes"));
+const categoriaRoutes_1 = __importDefault(require("./routes/categoriaRoutes"));
 const situacaoProcessoRoutes_1 = __importDefault(require("./routes/situacaoProcessoRoutes"));
 const situacaoPropostaRoutes_1 = __importDefault(require("./routes/situacaoPropostaRoutes"));
 const etiquetaRoutes_1 = __importDefault(require("./routes/etiquetaRoutes"));
@@ -25,6 +60,7 @@ const agendaRoutes_1 = __importDefault(require("./routes/agendaRoutes"));
 const templateRoutes_1 = __importDefault(require("./routes/templateRoutes"));
 const tagRoutes_1 = __importDefault(require("./routes/tagRoutes"));
 const documentRoutes_1 = __importDefault(require("./routes/documentRoutes"));
+const blogPostRoutes_1 = __importStar(require("./routes/blogPostRoutes"));
 const financialRoutes_1 = __importDefault(require("./routes/financialRoutes"));
 const processoRoutes_1 = __importDefault(require("./routes/processoRoutes"));
 const fluxoTrabalhoRoutes_1 = __importDefault(require("./routes/fluxoTrabalhoRoutes"));
@@ -49,6 +85,7 @@ const swagger_jsdoc_1 = __importDefault(require("swagger-jsdoc"));
 const swagger_1 = __importDefault(require("./swagger"));
 const cronJobs_1 = __importDefault(require("./services/cronJobs"));
 const chatSchema_1 = require("./services/chatSchema");
+const processSyncSchema_1 = require("./services/processSyncSchema");
 const supportSchema_1 = require("./services/supportSchema");
 const authMiddleware_1 = require("./middlewares/authMiddleware");
 const moduleAuthorization_1 = require("./middlewares/moduleAuthorization");
@@ -68,6 +105,7 @@ const defaultAllowedOrigins = [
     'http://localhost:8080',
     'http://127.0.0.1:8080',
     'http://localhost:4200',
+    'https://jusconnec.quantumtecnologia.com.br',
     'https://quantumtecnologia.com.br',
 ];
 const additionalAllowedOrigins = (process.env.CORS_ALLOWED_ORIGINS || '')
@@ -155,10 +193,12 @@ registerModuleRoutes(['configuracoes-parametros', 'configuracoes-parametros-escr
 registerModuleRoutes(['configuracoes-parametros', 'configuracoes-parametros-perfis'], perfilRoutes_1.default);
 registerModuleRoutes(['configuracoes', 'dashboard'], planoRoutes_1.default);
 registerModuleRoutes(['configuracoes', 'dashboard'], subscriptionRoutes_1.default);
+registerModuleRoutes('meu-plano', planPaymentRoutes_1.default);
 registerModuleRoutes(['configuracoes-parametros', 'configuracoes-parametros-situacao-processo'], situacaoProcessoRoutes_1.default);
 registerModuleRoutes(['configuracoes-parametros', 'configuracoes-parametros-situacao-cliente'], situacaoClienteRoutes_1.default);
 registerModuleRoutes(['configuracoes-parametros', 'configuracoes-parametros-situacao-proposta'], situacaoPropostaRoutes_1.default);
 registerModuleRoutes(['configuracoes-parametros', 'configuracoes-parametros-etiquetas'], etiquetaRoutes_1.default);
+registerModuleRoutes(['configuracoes-parametros', 'configuracoes-parametros-categorias'], categoriaRoutes_1.default);
 registerModuleRoutes(['configuracoes', 'dashboard'], empresaRoutes_1.default);
 registerModuleRoutes('configuracoes-usuarios', usuarioRoutes_1.default);
 registerModuleRoutes(['clientes', 'dashboard'], clienteRoutes_1.default);
@@ -168,6 +208,7 @@ registerModuleRoutes('agenda', agendaRoutes_1.default);
 registerModuleRoutes('documentos', templateRoutes_1.default);
 registerModuleRoutes('documentos', tagRoutes_1.default);
 registerModuleRoutes('documentos', documentRoutes_1.default);
+registerModuleRoutes(['configuracoes', 'configuracoes-conteudo-blog'], blogPostRoutes_1.default);
 registerModuleRoutes(['financeiro', 'dashboard'], financialRoutes_1.default);
 registerModuleRoutes(['processos', 'dashboard'], processoRoutes_1.default);
 registerModuleRoutes('pipeline', fluxoTrabalhoRoutes_1.default);
@@ -184,6 +225,8 @@ registerModuleRoutes('conversas', chatRoutes_1.default);
 protectedApiRouter.use(userProfileRoutes_1.default);
 app.use('/api', wahaWebhookRoutes_1.default);
 app.use('/api', asaasWebhookRoutes_1.default);
+app.use('/api', blogPostRoutes_1.publicBlogPostRoutes);
+app.use('/api', planoRoutes_1.publicPlanoRoutes);
 app.use('/api', authRoutes_1.default);
 app.use('/api', protectedApiRouter);
 app.use('/api/v1', authMiddleware_1.authenticateRequest, usuarioRoutes_1.default);
@@ -233,7 +276,7 @@ else {
 }
 async function startServer() {
     try {
-        await Promise.all([(0, chatSchema_1.ensureChatSchema)(), (0, supportSchema_1.ensureSupportSchema)()]);
+        await Promise.all([(0, chatSchema_1.ensureChatSchema)(), (0, supportSchema_1.ensureSupportSchema)(), (0, processSyncSchema_1.ensureProcessSyncSchema)()]);
     }
     catch (error) {
         console.error('Failed to initialize application storage schema', error);

--- a/backend/dist/routes/processoRoutes.js
+++ b/backend/dist/routes/processoRoutes.js
@@ -74,8 +74,153 @@ const router = (0, express_1.Router)();
  *               type: string
  *             tipo:
  *               type: string
+ *         judit_syncs:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/ProcessoSync'
+ *         judit_responses:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/ProcessoSyncResponse'
+ *         judit_audit_trail:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/ProcessoSyncAudit'
+ *     ProcessoSyncIntegration:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *         provider:
+ *           type: string
+ *         environment:
+ *           type: string
+ *         apiUrl:
+ *           type: string
+ *           nullable: true
+ *         active:
+ *           type: boolean
+ *     ProcessoSync:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *         processoId:
+ *           type: integer
+ *           nullable: true
+ *         integrationApiKeyId:
+ *           type: integer
+ *           nullable: true
+ *         integration:
+ *           $ref: '#/components/schemas/ProcessoSyncIntegration'
+ *         remoteRequestId:
+ *           type: string
+ *           nullable: true
+ *         requestType:
+ *           type: string
+ *         requestedBy:
+ *           type: integer
+ *           nullable: true
+ *         requestedAt:
+ *           type: string
+ *           format: date-time
+ *         requestPayload:
+ *           type: object
+ *           additionalProperties: true
+ *         requestHeaders:
+ *           type: object
+ *           nullable: true
+ *           additionalProperties: true
+ *         status:
+ *           type: string
+ *         statusReason:
+ *           type: string
+ *           nullable: true
+ *         completedAt:
+ *           type: string
+ *           format: date-time
+ *           nullable: true
+ *         metadata:
+ *           type: object
+ *           additionalProperties: true
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *         updatedAt:
+ *           type: string
+ *           format: date-time
+ *     ProcessoSyncResponse:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *         processoId:
+ *           type: integer
+ *           nullable: true
+ *         processSyncId:
+ *           type: integer
+ *           nullable: true
+ *         integrationApiKeyId:
+ *           type: integer
+ *           nullable: true
+ *         integration:
+ *           $ref: '#/components/schemas/ProcessoSyncIntegration'
+ *         deliveryId:
+ *           type: string
+ *           nullable: true
+ *         source:
+ *           type: string
+ *         statusCode:
+ *           type: integer
+ *           nullable: true
+ *         receivedAt:
+ *           type: string
+ *           format: date-time
+ *         payload:
+ *           type: object
+ *           additionalProperties: true
+ *         headers:
+ *           type: object
+ *           nullable: true
+ *           additionalProperties: true
+ *         errorMessage:
+ *           type: string
+ *           nullable: true
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *     ProcessoSyncAudit:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *         processoId:
+ *           type: integer
+ *           nullable: true
+ *         processSyncId:
+ *           type: integer
+ *           nullable: true
+ *         processResponseId:
+ *           type: integer
+ *           nullable: true
+ *         integrationApiKeyId:
+ *           type: integer
+ *           nullable: true
+ *         integration:
+ *           $ref: '#/components/schemas/ProcessoSyncIntegration'
+ *         eventType:
+ *           type: string
+ *         eventDetails:
+ *           type: object
+ *           additionalProperties: true
+ *         observedAt:
+ *           type: string
+ *           format: date-time
+ *         createdAt:
+ *           type: string
+ *           format: date-time
 
- */
+*/
 /**
  * @swagger
  * /api/processos:

--- a/backend/dist/services/juditProcessService.js
+++ b/backend/dist/services/juditProcessService.js
@@ -1,0 +1,475 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.registerProcessRequest = registerProcessRequest;
+exports.updateProcessSyncStatus = updateProcessSyncStatus;
+exports.registerProcessResponse = registerProcessResponse;
+exports.registerSyncAudit = registerSyncAudit;
+exports.listProcessSyncs = listProcessSyncs;
+exports.listProcessResponses = listProcessResponses;
+exports.listSyncAudits = listSyncAudits;
+exports.findProcessByNumber = findProcessByNumber;
+exports.findProcessSyncByRemoteId = findProcessSyncByRemoteId;
+const db_1 = __importDefault(require("./db"));
+const EMPTY_OBJECT = {};
+function normalizeOptionalString(value) {
+    if (typeof value !== 'string') {
+        return null;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+}
+function normalizeNullableNumber(value) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return Math.trunc(value);
+    }
+    if (typeof value === 'string') {
+        const parsed = Number.parseInt(value, 10);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+    return null;
+}
+function normalizeStatus(value, fallback) {
+    const normalized = normalizeOptionalString(value);
+    return normalized ?? fallback;
+}
+function normalizeRequestType(value) {
+    const normalized = normalizeOptionalString(value);
+    if (!normalized) {
+        return null;
+    }
+    return normalized.toLowerCase();
+}
+function normalizeDateInput(value) {
+    if (value === undefined) {
+        return null;
+    }
+    if (value === null) {
+        return null;
+    }
+    if (value instanceof Date) {
+        return value;
+    }
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed ? trimmed : null;
+    }
+    return null;
+}
+function toJsonText(value, fallback) {
+    if (value === undefined || value === null) {
+        return fallback;
+    }
+    try {
+        return JSON.stringify(value);
+    }
+    catch (error) {
+        if (fallback !== undefined) {
+            return fallback;
+        }
+        throw error;
+    }
+}
+function parseJsonColumn(value, fallback) {
+    if (value === null || value === undefined) {
+        return fallback;
+    }
+    if (typeof value === 'string') {
+        try {
+            return JSON.parse(value);
+        }
+        catch (error) {
+            return fallback;
+        }
+    }
+    if (typeof value === 'object') {
+        return value;
+    }
+    return fallback;
+}
+function formatTimestamp(value) {
+    if (value instanceof Date) {
+        return value.toISOString();
+    }
+    return new Date(value).toISOString();
+}
+function formatNullableTimestamp(value) {
+    if (!value) {
+        return null;
+    }
+    return formatTimestamp(value);
+}
+function mapIntegration(row) {
+    if (!row.integration_api_key_id) {
+        return null;
+    }
+    return {
+        id: row.integration_api_key_id,
+        provider: row.provider ?? 'judit',
+        environment: row.environment ?? 'producao',
+        apiUrl: row.url_api ?? null,
+        active: row.active ?? true,
+    };
+}
+function mapProcessSyncRow(row) {
+    return {
+        id: row.id,
+        processoId: row.processo_id ?? null,
+        integrationApiKeyId: row.integration_api_key_id ?? null,
+        integration: mapIntegration(row),
+        remoteRequestId: row.remote_request_id ?? null,
+        requestType: row.request_type,
+        requestedBy: row.requested_by ?? null,
+        requestedAt: formatTimestamp(row.requested_at),
+        requestPayload: parseJsonColumn(row.request_payload, { ...EMPTY_OBJECT }),
+        requestHeaders: parseJsonColumn(row.request_headers, null),
+        status: row.status,
+        statusReason: row.status_reason ?? null,
+        completedAt: formatNullableTimestamp(row.completed_at ?? null),
+        metadata: parseJsonColumn(row.metadata, { ...EMPTY_OBJECT }),
+        createdAt: formatTimestamp(row.created_at),
+        updatedAt: formatTimestamp(row.updated_at),
+    };
+}
+function mapProcessResponseRow(row) {
+    return {
+        id: row.id,
+        processoId: row.processo_id ?? null,
+        processSyncId: row.process_sync_id ?? null,
+        integrationApiKeyId: row.integration_api_key_id ?? null,
+        integration: mapIntegration(row),
+        deliveryId: row.delivery_id ?? null,
+        source: row.source,
+        statusCode: row.status_code ?? null,
+        receivedAt: formatTimestamp(row.received_at),
+        payload: parseJsonColumn(row.payload, { ...EMPTY_OBJECT }),
+        headers: parseJsonColumn(row.headers, null),
+        errorMessage: row.error_message ?? null,
+        createdAt: formatTimestamp(row.created_at),
+    };
+}
+function mapSyncAuditRow(row) {
+    return {
+        id: row.id,
+        processoId: row.processo_id ?? null,
+        processSyncId: row.process_sync_id ?? null,
+        processResponseId: row.process_response_id ?? null,
+        integrationApiKeyId: row.integration_api_key_id ?? null,
+        integration: mapIntegration(row),
+        eventType: row.event_type,
+        eventDetails: parseJsonColumn(row.event_details, { ...EMPTY_OBJECT }),
+        observedAt: formatTimestamp(row.observed_at),
+        createdAt: formatTimestamp(row.created_at),
+    };
+}
+async function registerProcessRequest(input, client = db_1.default) {
+    const requestType = normalizeRequestType(input.requestType);
+    const statusValue = normalizeStatus(input.status, 'pending');
+    const result = await client.query(`INSERT INTO public.process_sync (
+       processo_id,
+       integration_api_key_id,
+       remote_request_id,
+       request_type,
+       requested_by,
+       requested_at,
+       request_payload,
+       request_headers,
+       status,
+       status_reason,
+       metadata
+     ) VALUES (
+       $1,
+       $2,
+       $3,
+       COALESCE($4, 'manual'),
+       $5,
+       COALESCE($6::timestamptz, NOW()),
+       COALESCE($7::jsonb, '{}'::jsonb),
+       $8::jsonb,
+       $9,
+       $10,
+       $11::jsonb
+     )
+     RETURNING
+       id,
+       processo_id,
+       integration_api_key_id,
+       remote_request_id,
+       request_type,
+       requested_by,
+       requested_at,
+       request_payload,
+       request_headers,
+       status,
+       status_reason,
+       completed_at,
+       metadata,
+       created_at,
+       updated_at`, [
+        normalizeNullableNumber(input.processoId),
+        normalizeNullableNumber(input.integrationApiKeyId),
+        normalizeOptionalString(input.remoteRequestId),
+        requestType,
+        normalizeNullableNumber(input.requestedBy),
+        normalizeDateInput(input.requestedAt),
+        toJsonText(input.requestPayload, '{}'),
+        toJsonText(input.requestHeaders, null),
+        statusValue,
+        normalizeOptionalString(input.statusReason),
+        toJsonText(input.metadata, '{}'),
+    ]);
+    return mapProcessSyncRow(result.rows[0]);
+}
+async function updateProcessSyncStatus(id, updates, client = db_1.default) {
+    const assignments = [];
+    const values = [];
+    let index = 1;
+    if (Object.prototype.hasOwnProperty.call(updates, 'status')) {
+        assignments.push(`status = $${index++}`);
+        values.push(updates.status === null ? null : normalizeStatus(updates.status, 'pending'));
+    }
+    if (Object.prototype.hasOwnProperty.call(updates, 'statusReason')) {
+        assignments.push(`status_reason = $${index++}`);
+        values.push(updates.statusReason === null ? null : normalizeOptionalString(updates.statusReason));
+    }
+    if (Object.prototype.hasOwnProperty.call(updates, 'completedAt')) {
+        assignments.push(`completed_at = $${index++}::timestamptz`);
+        values.push(normalizeDateInput(updates.completedAt ?? null));
+    }
+    if (Object.prototype.hasOwnProperty.call(updates, 'metadata')) {
+        assignments.push(`metadata = $${index++}::jsonb`);
+        values.push(toJsonText(updates.metadata ?? null, '{}'));
+    }
+    assignments.push(`updated_at = NOW()`);
+    const query = `UPDATE public.process_sync SET ${assignments.join(', ')} WHERE id = $${index} RETURNING
+      id,
+      processo_id,
+      integration_api_key_id,
+      remote_request_id,
+      request_type,
+      requested_by,
+      requested_at,
+      request_payload,
+      request_headers,
+      status,
+      status_reason,
+      completed_at,
+      metadata,
+      created_at,
+      updated_at`;
+    values.push(id);
+    const result = await client.query(query, values);
+    if (result.rowCount === 0) {
+        return null;
+    }
+    return mapProcessSyncRow(result.rows[0]);
+}
+async function registerProcessResponse(input, client = db_1.default) {
+    const result = await client.query(`INSERT INTO public.process_response (
+       processo_id,
+       process_sync_id,
+       integration_api_key_id,
+       delivery_id,
+       source,
+       status_code,
+       received_at,
+       payload,
+       headers,
+       error_message
+     ) VALUES (
+       $1,
+       $2,
+       $3,
+       $4,
+       COALESCE($5, 'webhook'),
+       $6,
+       COALESCE($7::timestamptz, NOW()),
+       COALESCE($8::jsonb, '{}'::jsonb),
+       $9::jsonb,
+       $10
+     )
+     RETURNING
+       id,
+       processo_id,
+       process_sync_id,
+       integration_api_key_id,
+       delivery_id,
+       source,
+       status_code,
+       received_at,
+       payload,
+       headers,
+       error_message,
+       created_at`, [
+        normalizeNullableNumber(input.processoId),
+        normalizeNullableNumber(input.processSyncId),
+        normalizeNullableNumber(input.integrationApiKeyId),
+        normalizeOptionalString(input.deliveryId),
+        normalizeOptionalString(input.source),
+        input.statusCode === undefined ? null : normalizeNullableNumber(input.statusCode),
+        normalizeDateInput(input.receivedAt),
+        toJsonText(input.payload, '{}'),
+        toJsonText(input.headers, null),
+        normalizeOptionalString(input.errorMessage),
+    ]);
+    return mapProcessResponseRow(result.rows[0]);
+}
+async function registerSyncAudit(input, client = db_1.default) {
+    const eventType = normalizeStatus(input.eventType, 'event');
+    const result = await client.query(`INSERT INTO public.sync_audit (
+       processo_id,
+       process_sync_id,
+       process_response_id,
+       integration_api_key_id,
+       event_type,
+       event_details,
+       observed_at
+     ) VALUES (
+       $1,
+       $2,
+       $3,
+       $4,
+       $5,
+       COALESCE($6::jsonb, '{}'::jsonb),
+       COALESCE($7::timestamptz, NOW())
+     )
+     RETURNING
+       id,
+       processo_id,
+       process_sync_id,
+       process_response_id,
+       integration_api_key_id,
+       event_type,
+       event_details,
+       observed_at,
+       created_at`, [
+        normalizeNullableNumber(input.processoId),
+        normalizeNullableNumber(input.processSyncId),
+        normalizeNullableNumber(input.processResponseId),
+        normalizeNullableNumber(input.integrationApiKeyId),
+        eventType,
+        toJsonText(input.eventDetails, '{}'),
+        normalizeDateInput(input.observedAt),
+    ]);
+    return mapSyncAuditRow(result.rows[0]);
+}
+async function listProcessSyncs(processoId, client = db_1.default) {
+    const result = await client.query(`SELECT
+       ps.id,
+       ps.processo_id,
+       ps.integration_api_key_id,
+       ps.remote_request_id,
+       ps.request_type,
+       ps.requested_by,
+       ps.requested_at,
+       ps.request_payload,
+       ps.request_headers,
+       ps.status,
+       ps.status_reason,
+       ps.completed_at,
+       ps.metadata,
+       ps.created_at,
+       ps.updated_at,
+       iak.provider,
+       iak.environment,
+       iak.url_api,
+       iak.active
+     FROM public.process_sync ps
+     LEFT JOIN public.integration_api_keys iak ON iak.id = ps.integration_api_key_id
+     WHERE ps.processo_id = $1
+     ORDER BY ps.requested_at DESC, ps.id DESC`, [processoId]);
+    return result.rows.map((row) => mapProcessSyncRow(row));
+}
+async function listProcessResponses(processoId, client = db_1.default) {
+    const result = await client.query(`SELECT
+       pr.id,
+       pr.processo_id,
+       pr.process_sync_id,
+       pr.integration_api_key_id,
+       pr.delivery_id,
+       pr.source,
+       pr.status_code,
+       pr.received_at,
+       pr.payload,
+       pr.headers,
+       pr.error_message,
+       pr.created_at,
+       iak.provider,
+       iak.environment,
+       iak.url_api,
+       iak.active
+     FROM public.process_response pr
+     LEFT JOIN public.integration_api_keys iak ON iak.id = pr.integration_api_key_id
+     WHERE pr.processo_id = $1
+     ORDER BY pr.received_at DESC, pr.id DESC`, [processoId]);
+    return result.rows.map((row) => mapProcessResponseRow(row));
+}
+async function listSyncAudits(processoId, client = db_1.default) {
+    const result = await client.query(`SELECT
+       sa.id,
+       sa.processo_id,
+       sa.process_sync_id,
+       sa.process_response_id,
+       sa.integration_api_key_id,
+       sa.event_type,
+       sa.event_details,
+       sa.observed_at,
+       sa.created_at,
+       iak.provider,
+       iak.environment,
+       iak.url_api,
+       iak.active
+     FROM public.sync_audit sa
+     LEFT JOIN public.integration_api_keys iak ON iak.id = sa.integration_api_key_id
+     WHERE sa.processo_id = $1
+     ORDER BY sa.observed_at DESC, sa.id DESC`, [processoId]);
+    return result.rows.map((row) => mapSyncAuditRow(row));
+}
+async function findProcessByNumber(processNumber, client = db_1.default) {
+    const normalized = normalizeOptionalString(processNumber);
+    if (!normalized) {
+        return null;
+    }
+    const result = await client.query(`SELECT id FROM public.processos WHERE numero = $1 ORDER BY id ASC LIMIT 1`, [normalized]);
+    if (result.rowCount === 0) {
+        return null;
+    }
+    return { id: result.rows[0].id };
+}
+async function findProcessSyncByRemoteId(remoteRequestId, client = db_1.default) {
+    const normalized = normalizeOptionalString(remoteRequestId);
+    if (!normalized) {
+        return null;
+    }
+    const result = await client.query(`SELECT
+       ps.id,
+       ps.processo_id,
+       ps.integration_api_key_id,
+       ps.remote_request_id,
+       ps.request_type,
+       ps.requested_by,
+       ps.requested_at,
+       ps.request_payload,
+       ps.request_headers,
+       ps.status,
+       ps.status_reason,
+       ps.completed_at,
+       ps.metadata,
+       ps.created_at,
+       ps.updated_at,
+       iak.provider,
+       iak.environment,
+       iak.url_api,
+       iak.active
+     FROM public.process_sync ps
+     LEFT JOIN public.integration_api_keys iak ON iak.id = ps.integration_api_key_id
+     WHERE ps.remote_request_id = $1
+     ORDER BY ps.id DESC
+     LIMIT 1`, [normalized]);
+    if (result.rowCount === 0) {
+        return null;
+    }
+    return mapProcessSyncRow(result.rows[0]);
+}

--- a/backend/dist/services/notificationProviders/juditNotificationService.js
+++ b/backend/dist/services/notificationProviders/juditNotificationService.js
@@ -1,0 +1,285 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.juditNotificationProvider = exports.JuditNotificationProvider = void 0;
+const juditProcessService_1 = require("../juditProcessService");
+const types_1 = require("./types");
+function pickHeader(headers, name) {
+    const value = headers[name];
+    if (Array.isArray(value)) {
+        const first = value.find((item) => typeof item === 'string' && item.trim().length > 0);
+        return first ? first.trim() : undefined;
+    }
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : undefined;
+    }
+    return undefined;
+}
+function normalizeString(value) {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+}
+function parseNumeric(value) {
+    if (value === null || value === undefined) {
+        return undefined;
+    }
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return Math.trunc(value);
+    }
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return undefined;
+        }
+        const parsed = Number.parseInt(trimmed, 10);
+        return Number.isFinite(parsed) ? parsed : undefined;
+    }
+    return undefined;
+}
+function cloneHeaders(headers) {
+    const result = {};
+    for (const [key, value] of Object.entries(headers)) {
+        result[key] = value;
+    }
+    return result;
+}
+function resolveProcessNumber(payload) {
+    const candidateKeys = [
+        'processNumber',
+        'numeroProcesso',
+        'numero_processo',
+        'processoNumero',
+        'numero',
+    ];
+    for (const key of candidateKeys) {
+        const value = normalizeString(payload[key]);
+        if (value) {
+            return value;
+        }
+    }
+    return undefined;
+}
+function resolveSyncReference(payload) {
+    const candidateKeys = [
+        'syncId',
+        'processSyncId',
+        'syncReference',
+        'requestId',
+        'remoteRequestId',
+        'idSincronizacao',
+    ];
+    for (const key of candidateKeys) {
+        const value = normalizeString(payload[key]);
+        if (value) {
+            return value;
+        }
+    }
+    return undefined;
+}
+function resolveStatusCode(payload) {
+    const candidateKeys = ['statusCode', 'httpStatus', 'code'];
+    for (const key of candidateKeys) {
+        const value = parseNumeric(payload[key]);
+        if (value !== undefined) {
+            return value;
+        }
+    }
+    return undefined;
+}
+function resolveErrorMessage(payload) {
+    const candidateKeys = ['error', 'errorMessage', 'mensagem', 'message', 'descricaoErro'];
+    for (const key of candidateKeys) {
+        const value = normalizeString(payload[key]);
+        if (value) {
+            return value;
+        }
+    }
+    return undefined;
+}
+function resolveSyncStatus(payload) {
+    const candidateKeys = ['status', 'syncStatus', 'resultado'];
+    for (const key of candidateKeys) {
+        const value = normalizeString(payload[key]);
+        if (value) {
+            return value.toLowerCase();
+        }
+    }
+    return undefined;
+}
+function resolveSuccessFlag(payload) {
+    const candidateKeys = ['success', 'sucesso', 'ok'];
+    for (const key of candidateKeys) {
+        const value = payload[key];
+        if (typeof value === 'boolean') {
+            return value;
+        }
+        if (typeof value === 'string') {
+            const normalized = value.trim().toLowerCase();
+            if (['true', '1', 'yes', 'sim'].includes(normalized)) {
+                return true;
+            }
+            if (['false', '0', 'no', 'nao', 'não'].includes(normalized)) {
+                return false;
+            }
+        }
+    }
+    return undefined;
+}
+function normalizePayload(body) {
+    if (body === null || body === undefined) {
+        throw new types_1.NotificationProviderError('JUDIT webhook payload cannot be empty', 400);
+    }
+    if (typeof body === 'string') {
+        try {
+            const parsed = JSON.parse(body);
+            if (parsed && typeof parsed === 'object') {
+                return parsed;
+            }
+        }
+        catch (error) {
+            throw new types_1.NotificationProviderError('JUDIT webhook payload must be valid JSON', 400);
+        }
+    }
+    if (typeof body !== 'object') {
+        throw new types_1.NotificationProviderError('JUDIT webhook payload must be an object', 400);
+    }
+    return body;
+}
+function resolveDeliveryId(req, payload) {
+    const headerKeys = ['x-delivery-id', 'x-request-id', 'x-correlation-id', 'x-message-id'];
+    for (const key of headerKeys) {
+        const value = pickHeader(req.headers, key);
+        if (value) {
+            return value;
+        }
+    }
+    const payloadKeys = ['deliveryId', 'requestId', 'correlationId'];
+    for (const key of payloadKeys) {
+        const value = normalizeString(payload[key]);
+        if (value) {
+            return value;
+        }
+    }
+    return undefined;
+}
+function resolveIntegrationId(req, payload) {
+    const headerKeys = ['x-integration-key-id', 'x-judit-credential-id', 'x-credential-id'];
+    for (const key of headerKeys) {
+        const value = pickHeader(req.headers, key);
+        if (value) {
+            const parsed = parseNumeric(value);
+            if (parsed !== undefined) {
+                return parsed;
+            }
+        }
+    }
+    const payloadKeys = ['integrationKeyId', 'credentialId', 'apiKeyId'];
+    for (const key of payloadKeys) {
+        const value = parseNumeric(payload[key]);
+        if (value !== undefined) {
+            return value;
+        }
+    }
+    return undefined;
+}
+function shouldMarkSyncCompleted(payload, currentSync) {
+    const statusUpdate = resolveSyncStatus(payload);
+    const successFlag = resolveSuccessFlag(payload);
+    const errorMessage = resolveErrorMessage(payload);
+    const updates = {};
+    if (statusUpdate) {
+        updates.status = statusUpdate;
+    }
+    if (successFlag === true) {
+        updates.completedAt = new Date();
+        if (!updates.status) {
+            updates.status = 'completed';
+        }
+        updates.statusReason = null;
+    }
+    else if (successFlag === false) {
+        if (!updates.status) {
+            updates.status = statusUpdate ?? 'failed';
+        }
+        updates.completedAt = new Date();
+        updates.statusReason = errorMessage ?? updates.statusReason ?? 'JUDIT retornou falha na sincronização';
+    }
+    else if (errorMessage && !updates.statusReason) {
+        updates.statusReason = errorMessage;
+    }
+    if (!updates.status && !updates.statusReason && !updates.completedAt) {
+        return null;
+    }
+    if (currentSync && updates.status === currentSync.status && !updates.statusReason && !updates.completedAt) {
+        return null;
+    }
+    return updates;
+}
+class JuditNotificationProvider {
+    constructor() {
+        this.id = 'judit';
+    }
+    async subscribe() {
+        // JUDIT não requer assinatura ativa via API.
+    }
+    async fetchUpdates() {
+        return [];
+    }
+    async handleWebhook(req) {
+        const payload = normalizePayload(req.body);
+        const deliveryId = resolveDeliveryId(req, payload);
+        const integrationId = resolveIntegrationId(req, payload);
+        const processNumber = resolveProcessNumber(payload);
+        const syncReference = resolveSyncReference(payload);
+        let processoId = null;
+        if (processNumber) {
+            const processo = await (0, juditProcessService_1.findProcessByNumber)(processNumber);
+            processoId = processo?.id ?? null;
+        }
+        let syncRecord = null;
+        if (syncReference) {
+            syncRecord = await (0, juditProcessService_1.findProcessSyncByRemoteId)(syncReference);
+            if (!processoId && syncRecord?.processoId) {
+                processoId = syncRecord.processoId;
+            }
+        }
+        const responsePayload = {
+            processoId: processoId ?? syncRecord?.processoId ?? null,
+            processSyncId: syncRecord?.id ?? null,
+            integrationApiKeyId: integrationId ?? syncRecord?.integrationApiKeyId ?? null,
+            deliveryId: deliveryId ?? null,
+            source: 'webhook',
+            statusCode: resolveStatusCode(payload),
+            payload,
+            headers: cloneHeaders(req.headers),
+            errorMessage: resolveErrorMessage(payload),
+        };
+        const responseRecord = await (0, juditProcessService_1.registerProcessResponse)(responsePayload);
+        await (0, juditProcessService_1.registerSyncAudit)({
+            processoId: responseRecord.processoId ?? processoId ?? null,
+            processSyncId: responseRecord.processSyncId ?? syncRecord?.id ?? null,
+            processResponseId: responseRecord.id,
+            integrationApiKeyId: responseRecord.integrationApiKeyId ?? integrationId ?? syncRecord?.integrationApiKeyId ?? null,
+            eventType: 'webhook_received',
+            eventDetails: {
+                deliveryId: deliveryId ?? null,
+                processNumber: processNumber ?? null,
+                syncReference: syncReference ?? null,
+                status: resolveSyncStatus(payload) ?? null,
+                success: resolveSuccessFlag(payload) ?? null,
+            },
+        });
+        if (syncRecord?.id) {
+            const updates = shouldMarkSyncCompleted(payload, syncRecord);
+            if (updates) {
+                await (0, juditProcessService_1.updateProcessSyncStatus)(syncRecord.id, updates);
+            }
+        }
+        return [];
+    }
+}
+exports.JuditNotificationProvider = JuditNotificationProvider;
+exports.juditNotificationProvider = new JuditNotificationProvider();

--- a/backend/dist/services/notificationProviders/registry.js
+++ b/backend/dist/services/notificationProviders/registry.js
@@ -5,6 +5,7 @@ exports.registerNotificationProvider = registerNotificationProvider;
 exports.getNotificationProvider = getNotificationProvider;
 exports.listNotificationProviders = listNotificationProviders;
 const pjeNotificationService_1 = require("./pjeNotificationService");
+const juditNotificationService_1 = require("./juditNotificationService");
 const projudiNotificationService_1 = require("./projudiNotificationService");
 const registry = new Map();
 function registerNotificationProvider(provider, identifier) {
@@ -24,5 +25,6 @@ function listNotificationProviders() {
     return Array.from(registry.values());
 }
 registerNotificationProvider(pjeNotificationService_1.pjeNotificationProvider, 'pje');
+registerNotificationProvider(juditNotificationService_1.juditNotificationProvider, 'judit');
 registerNotificationProvider(projudiNotificationService_1.projudiNotificationProvider, 'projudi');
 exports.notificationProviderRegistry = registry;

--- a/backend/dist/services/processSyncSchema.js
+++ b/backend/dist/services/processSyncSchema.js
@@ -1,0 +1,65 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ensureProcessSyncSchema = ensureProcessSyncSchema;
+const promises_1 = require("node:fs/promises");
+const node_fs_1 = require("node:fs");
+const node_path_1 = __importDefault(require("node:path"));
+const db_1 = __importDefault(require("./db"));
+const SCHEMA_FILES = ['process_sync.sql', 'process_response.sql', 'sync_audit.sql'];
+let cachedEntries = null;
+let initializationPromise = null;
+async function resolveFilePath(file) {
+    const candidatePaths = [
+        node_path_1.default.resolve(__dirname, '..', 'sql', file),
+        node_path_1.default.resolve(__dirname, '../..', 'sql', file),
+        node_path_1.default.resolve(process.cwd(), 'sql', file),
+        node_path_1.default.resolve(process.cwd(), 'backend', 'sql', file),
+    ];
+    for (const candidate of candidatePaths) {
+        try {
+            await (0, promises_1.access)(candidate, node_fs_1.constants.R_OK);
+            return candidate;
+        }
+        catch (error) {
+            const errno = error.code;
+            if (errno && ['ENOENT', 'ENOTDIR'].includes(errno)) {
+                continue;
+            }
+            throw error;
+        }
+    }
+    throw new Error(`Process sync schema file "${file}" not found. Checked: ${candidatePaths
+        .map((candidate) => `"${candidate}"`)
+        .join(', ')}`);
+}
+async function loadSchemaSql() {
+    if (cachedEntries) {
+        return cachedEntries;
+    }
+    const entries = [];
+    for (const file of SCHEMA_FILES) {
+        const schemaPath = await resolveFilePath(file);
+        const sql = await (0, promises_1.readFile)(schemaPath, 'utf-8');
+        entries.push({ file, sql });
+    }
+    cachedEntries = entries;
+    return entries;
+}
+async function executeSchemas(client) {
+    const entries = await loadSchemaSql();
+    for (const entry of entries) {
+        await client.query(entry.sql);
+    }
+}
+async function ensureProcessSyncSchema(client = db_1.default) {
+    if (!initializationPromise) {
+        initializationPromise = executeSchemas(client).catch((error) => {
+            initializationPromise = null;
+            throw error;
+        });
+    }
+    await initializationPromise;
+}

--- a/backend/dist/sql/process_response.sql
+++ b/backend/dist/sql/process_response.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS public.process_response (
+  id BIGSERIAL PRIMARY KEY,
+  processo_id INTEGER REFERENCES public.processos(id) ON DELETE SET NULL,
+  process_sync_id BIGINT REFERENCES public.process_sync(id) ON DELETE SET NULL,
+  integration_api_key_id INTEGER REFERENCES public.integration_api_keys(id) ON DELETE SET NULL,
+  delivery_id TEXT,
+  source TEXT NOT NULL DEFAULT 'webhook',
+  status_code INTEGER,
+  received_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  headers JSONB,
+  error_message TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_process_response_delivery
+  ON public.process_response (delivery_id)
+  WHERE delivery_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_process_response_processo
+  ON public.process_response (processo_id);
+
+CREATE INDEX IF NOT EXISTS idx_process_response_sync
+  ON public.process_response (process_sync_id);
+
+CREATE INDEX IF NOT EXISTS idx_process_response_integration
+  ON public.process_response (integration_api_key_id);

--- a/backend/dist/sql/process_sync.sql
+++ b/backend/dist/sql/process_sync.sql
@@ -1,0 +1,44 @@
+CREATE TABLE IF NOT EXISTS public.process_sync (
+  id BIGSERIAL PRIMARY KEY,
+  processo_id INTEGER REFERENCES public.processos(id) ON DELETE CASCADE,
+  integration_api_key_id INTEGER REFERENCES public.integration_api_keys(id) ON DELETE SET NULL,
+  remote_request_id TEXT,
+  request_type TEXT NOT NULL DEFAULT 'manual',
+  requested_by INTEGER REFERENCES public.usuarios(id) ON DELETE SET NULL,
+  requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  request_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  request_headers JSONB,
+  status TEXT NOT NULL DEFAULT 'pending',
+  status_reason TEXT,
+  completed_at TIMESTAMPTZ,
+  metadata JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_process_sync_remote_request
+  ON public.process_sync (remote_request_id)
+  WHERE remote_request_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_process_sync_processo
+  ON public.process_sync (processo_id);
+
+CREATE INDEX IF NOT EXISTS idx_process_sync_integration
+  ON public.process_sync (integration_api_key_id);
+
+CREATE INDEX IF NOT EXISTS idx_process_sync_status
+  ON public.process_sync (status);
+
+CREATE OR REPLACE FUNCTION set_process_sync_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_process_sync_updated_at ON public.process_sync;
+CREATE TRIGGER trg_process_sync_updated_at
+  BEFORE UPDATE ON public.process_sync
+  FOR EACH ROW
+  EXECUTE FUNCTION set_process_sync_updated_at();

--- a/backend/dist/sql/sync_audit.sql
+++ b/backend/dist/sql/sync_audit.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS public.sync_audit (
+  id BIGSERIAL PRIMARY KEY,
+  processo_id INTEGER REFERENCES public.processos(id) ON DELETE SET NULL,
+  process_sync_id BIGINT REFERENCES public.process_sync(id) ON DELETE SET NULL,
+  process_response_id BIGINT REFERENCES public.process_response(id) ON DELETE SET NULL,
+  integration_api_key_id INTEGER REFERENCES public.integration_api_keys(id) ON DELETE SET NULL,
+  event_type TEXT NOT NULL,
+  event_details JSONB NOT NULL DEFAULT '{}'::jsonb,
+  observed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_audit_processo
+  ON public.sync_audit (processo_id);
+
+CREATE INDEX IF NOT EXISTS idx_sync_audit_sync
+  ON public.sync_audit (process_sync_id);
+
+CREATE INDEX IF NOT EXISTS idx_sync_audit_response
+  ON public.sync_audit (process_response_id);

--- a/backend/sql/process_response.sql
+++ b/backend/sql/process_response.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS public.process_response (
+  id BIGSERIAL PRIMARY KEY,
+  processo_id INTEGER REFERENCES public.processos(id) ON DELETE SET NULL,
+  process_sync_id BIGINT REFERENCES public.process_sync(id) ON DELETE SET NULL,
+  integration_api_key_id INTEGER REFERENCES public.integration_api_keys(id) ON DELETE SET NULL,
+  delivery_id TEXT,
+  source TEXT NOT NULL DEFAULT 'webhook',
+  status_code INTEGER,
+  received_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  headers JSONB,
+  error_message TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_process_response_delivery
+  ON public.process_response (delivery_id)
+  WHERE delivery_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_process_response_processo
+  ON public.process_response (processo_id);
+
+CREATE INDEX IF NOT EXISTS idx_process_response_sync
+  ON public.process_response (process_sync_id);
+
+CREATE INDEX IF NOT EXISTS idx_process_response_integration
+  ON public.process_response (integration_api_key_id);

--- a/backend/sql/process_sync.sql
+++ b/backend/sql/process_sync.sql
@@ -1,0 +1,44 @@
+CREATE TABLE IF NOT EXISTS public.process_sync (
+  id BIGSERIAL PRIMARY KEY,
+  processo_id INTEGER REFERENCES public.processos(id) ON DELETE CASCADE,
+  integration_api_key_id INTEGER REFERENCES public.integration_api_keys(id) ON DELETE SET NULL,
+  remote_request_id TEXT,
+  request_type TEXT NOT NULL DEFAULT 'manual',
+  requested_by INTEGER REFERENCES public.usuarios(id) ON DELETE SET NULL,
+  requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  request_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  request_headers JSONB,
+  status TEXT NOT NULL DEFAULT 'pending',
+  status_reason TEXT,
+  completed_at TIMESTAMPTZ,
+  metadata JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_process_sync_remote_request
+  ON public.process_sync (remote_request_id)
+  WHERE remote_request_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_process_sync_processo
+  ON public.process_sync (processo_id);
+
+CREATE INDEX IF NOT EXISTS idx_process_sync_integration
+  ON public.process_sync (integration_api_key_id);
+
+CREATE INDEX IF NOT EXISTS idx_process_sync_status
+  ON public.process_sync (status);
+
+CREATE OR REPLACE FUNCTION set_process_sync_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_process_sync_updated_at ON public.process_sync;
+CREATE TRIGGER trg_process_sync_updated_at
+  BEFORE UPDATE ON public.process_sync
+  FOR EACH ROW
+  EXECUTE FUNCTION set_process_sync_updated_at();

--- a/backend/sql/sync_audit.sql
+++ b/backend/sql/sync_audit.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS public.sync_audit (
+  id BIGSERIAL PRIMARY KEY,
+  processo_id INTEGER REFERENCES public.processos(id) ON DELETE SET NULL,
+  process_sync_id BIGINT REFERENCES public.process_sync(id) ON DELETE SET NULL,
+  process_response_id BIGINT REFERENCES public.process_response(id) ON DELETE SET NULL,
+  integration_api_key_id INTEGER REFERENCES public.integration_api_keys(id) ON DELETE SET NULL,
+  event_type TEXT NOT NULL,
+  event_details JSONB NOT NULL DEFAULT '{}'::jsonb,
+  observed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_audit_processo
+  ON public.sync_audit (processo_id);
+
+CREATE INDEX IF NOT EXISTS idx_sync_audit_sync
+  ON public.sync_audit (process_sync_id);
+
+CREATE INDEX IF NOT EXISTS idx_sync_audit_response
+  ON public.sync_audit (process_response_id);

--- a/backend/src/controllers/processoController.ts
+++ b/backend/src/controllers/processoController.ts
@@ -7,6 +7,7 @@ import {
 
 import pool from '../services/db';
 import { createNotification } from '../services/notificationService';
+import { listProcessResponses, listProcessSyncs, listSyncAudits } from '../services/juditProcessService';
 import { Processo } from '../models/processo';
 import { fetchAuthenticatedUserEmpresa } from '../utils/authUser';
 
@@ -722,6 +723,16 @@ export const getProcessoById = async (req: Request, res: Response) => {
 
     const processo = mapProcessoRow(result.rows[0]);
     processo.movimentacoes = await fetchProcessoMovimentacoes(parsedId);
+
+    const [juditSyncs, juditResponses, juditAuditTrail] = await Promise.all([
+      listProcessSyncs(parsedId),
+      listProcessResponses(parsedId),
+      listSyncAudits(parsedId),
+    ]);
+
+    processo.juditSyncs = juditSyncs;
+    processo.juditResponses = juditResponses;
+    processo.juditAuditTrail = juditAuditTrail;
 
     res.json(processo);
   } catch (error) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -48,6 +48,7 @@ import swaggerJsdoc from 'swagger-jsdoc';
 import swaggerOptions from './swagger';
 import cronJobs from './services/cronJobs';
 import { ensureChatSchema } from './services/chatSchema';
+import { ensureProcessSyncSchema } from './services/processSyncSchema';
 import { ensureSupportSchema } from './services/supportSchema';
 import { authenticateRequest } from './middlewares/authMiddleware';
 import { authorizeModules } from './middlewares/moduleAuthorization';
@@ -324,7 +325,7 @@ if (!hasFrontendBuild) {
 
 async function startServer() {
   try {
-    await Promise.all([ensureChatSchema(), ensureSupportSchema()]);
+    await Promise.all([ensureChatSchema(), ensureSupportSchema(), ensureProcessSyncSchema()]);
   } catch (error) {
     console.error('Failed to initialize application storage schema', error);
     process.exit(1);

--- a/backend/src/models/processo.ts
+++ b/backend/src/models/processo.ts
@@ -23,6 +23,62 @@ export interface ProcessoMovimentacao {
   atualizado_em?: string | null;
 }
 
+export interface ProcessoSyncIntegrationInfo {
+  id: number;
+  provider: string;
+  environment: string;
+  apiUrl: string | null;
+  active: boolean;
+}
+
+export interface ProcessoSync {
+  id: number;
+  processoId: number | null;
+  integrationApiKeyId: number | null;
+  integration?: ProcessoSyncIntegrationInfo | null;
+  remoteRequestId: string | null;
+  requestType: string;
+  requestedBy: number | null;
+  requestedAt: string;
+  requestPayload: unknown;
+  requestHeaders: unknown;
+  status: string;
+  statusReason: string | null;
+  completedAt: string | null;
+  metadata: unknown;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProcessoSyncResponse {
+  id: number;
+  processoId: number | null;
+  processSyncId: number | null;
+  integrationApiKeyId: number | null;
+  integration?: ProcessoSyncIntegrationInfo | null;
+  deliveryId: string | null;
+  source: string;
+  statusCode: number | null;
+  receivedAt: string;
+  payload: unknown;
+  headers: unknown;
+  errorMessage: string | null;
+  createdAt: string;
+}
+
+export interface ProcessoSyncAudit {
+  id: number;
+  processoId: number | null;
+  processSyncId: number | null;
+  processResponseId: number | null;
+  integrationApiKeyId: number | null;
+  integration?: ProcessoSyncIntegrationInfo | null;
+  eventType: string;
+  eventDetails: unknown;
+  observedAt: string;
+  createdAt: string;
+}
+
 export interface ProcessoOportunidadeResumo {
   id: number;
   sequencial_empresa: number | null;
@@ -58,4 +114,7 @@ export interface Processo {
   oportunidade?: ProcessoOportunidadeResumo | null;
   advogados: ProcessoAdvogado[];
   movimentacoes?: ProcessoMovimentacao[];
+  juditSyncs?: ProcessoSync[];
+  juditResponses?: ProcessoSyncResponse[];
+  juditAuditTrail?: ProcessoSyncAudit[];
 }

--- a/backend/src/routes/processoRoutes.ts
+++ b/backend/src/routes/processoRoutes.ts
@@ -81,8 +81,153 @@ const router = Router();
  *               type: string
  *             tipo:
  *               type: string
+ *         judit_syncs:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/ProcessoSync'
+ *         judit_responses:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/ProcessoSyncResponse'
+ *         judit_audit_trail:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/ProcessoSyncAudit'
+ *     ProcessoSyncIntegration:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *         provider:
+ *           type: string
+ *         environment:
+ *           type: string
+ *         apiUrl:
+ *           type: string
+ *           nullable: true
+ *         active:
+ *           type: boolean
+ *     ProcessoSync:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *         processoId:
+ *           type: integer
+ *           nullable: true
+ *         integrationApiKeyId:
+ *           type: integer
+ *           nullable: true
+ *         integration:
+ *           $ref: '#/components/schemas/ProcessoSyncIntegration'
+ *         remoteRequestId:
+ *           type: string
+ *           nullable: true
+ *         requestType:
+ *           type: string
+ *         requestedBy:
+ *           type: integer
+ *           nullable: true
+ *         requestedAt:
+ *           type: string
+ *           format: date-time
+ *         requestPayload:
+ *           type: object
+ *           additionalProperties: true
+ *         requestHeaders:
+ *           type: object
+ *           nullable: true
+ *           additionalProperties: true
+ *         status:
+ *           type: string
+ *         statusReason:
+ *           type: string
+ *           nullable: true
+ *         completedAt:
+ *           type: string
+ *           format: date-time
+ *           nullable: true
+ *         metadata:
+ *           type: object
+ *           additionalProperties: true
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *         updatedAt:
+ *           type: string
+ *           format: date-time
+ *     ProcessoSyncResponse:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *         processoId:
+ *           type: integer
+ *           nullable: true
+ *         processSyncId:
+ *           type: integer
+ *           nullable: true
+ *         integrationApiKeyId:
+ *           type: integer
+ *           nullable: true
+ *         integration:
+ *           $ref: '#/components/schemas/ProcessoSyncIntegration'
+ *         deliveryId:
+ *           type: string
+ *           nullable: true
+ *         source:
+ *           type: string
+ *         statusCode:
+ *           type: integer
+ *           nullable: true
+ *         receivedAt:
+ *           type: string
+ *           format: date-time
+ *         payload:
+ *           type: object
+ *           additionalProperties: true
+ *         headers:
+ *           type: object
+ *           nullable: true
+ *           additionalProperties: true
+ *         errorMessage:
+ *           type: string
+ *           nullable: true
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *     ProcessoSyncAudit:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *         processoId:
+ *           type: integer
+ *           nullable: true
+ *         processSyncId:
+ *           type: integer
+ *           nullable: true
+ *         processResponseId:
+ *           type: integer
+ *           nullable: true
+ *         integrationApiKeyId:
+ *           type: integer
+ *           nullable: true
+ *         integration:
+ *           $ref: '#/components/schemas/ProcessoSyncIntegration'
+ *         eventType:
+ *           type: string
+ *         eventDetails:
+ *           type: object
+ *           additionalProperties: true
+ *         observedAt:
+ *           type: string
+ *           format: date-time
+ *         createdAt:
+ *           type: string
+ *           format: date-time
 
- */
+*/
 
 /**
  * @swagger

--- a/backend/src/services/juditProcessService.ts
+++ b/backend/src/services/juditProcessService.ts
@@ -1,0 +1,725 @@
+import { QueryResultRow } from 'pg';
+import pool from './db';
+
+type Queryable = {
+  query: (
+    text: string,
+    params?: unknown[],
+  ) => Promise<{ rows: QueryResultRow[]; rowCount: number }>;
+};
+
+export interface ProcessSyncIntegrationInfo {
+  id: number;
+  provider: string;
+  environment: string;
+  apiUrl: string | null;
+  active: boolean;
+}
+
+export interface ProcessSyncRecord {
+  id: number;
+  processoId: number | null;
+  integrationApiKeyId: number | null;
+  integration?: ProcessSyncIntegrationInfo | null;
+  remoteRequestId: string | null;
+  requestType: string;
+  requestedBy: number | null;
+  requestedAt: string;
+  requestPayload: unknown;
+  requestHeaders: unknown;
+  status: string;
+  statusReason: string | null;
+  completedAt: string | null;
+  metadata: unknown;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProcessResponseRecord {
+  id: number;
+  processoId: number | null;
+  processSyncId: number | null;
+  integrationApiKeyId: number | null;
+  integration?: ProcessSyncIntegrationInfo | null;
+  deliveryId: string | null;
+  source: string;
+  statusCode: number | null;
+  receivedAt: string;
+  payload: unknown;
+  headers: unknown;
+  errorMessage: string | null;
+  createdAt: string;
+}
+
+export interface SyncAuditRecord {
+  id: number;
+  processoId: number | null;
+  processSyncId: number | null;
+  processResponseId: number | null;
+  integrationApiKeyId: number | null;
+  integration?: ProcessSyncIntegrationInfo | null;
+  eventType: string;
+  eventDetails: unknown;
+  observedAt: string;
+  createdAt: string;
+}
+
+interface ProcessSyncRow extends QueryResultRow {
+  id: number;
+  processo_id: number | null;
+  integration_api_key_id: number | null;
+  remote_request_id: string | null;
+  request_type: string;
+  requested_by: number | null;
+  requested_at: string | Date;
+  request_payload: unknown;
+  request_headers: unknown;
+  status: string;
+  status_reason: string | null;
+  completed_at: string | Date | null;
+  metadata: unknown;
+  created_at: string | Date;
+  updated_at: string | Date;
+  provider?: string | null;
+  environment?: string | null;
+  url_api?: string | null;
+  active?: boolean | null;
+}
+
+interface ProcessResponseRow extends QueryResultRow {
+  id: number;
+  processo_id: number | null;
+  process_sync_id: number | null;
+  integration_api_key_id: number | null;
+  delivery_id: string | null;
+  source: string;
+  status_code: number | null;
+  received_at: string | Date;
+  payload: unknown;
+  headers: unknown;
+  error_message: string | null;
+  created_at: string | Date;
+  provider?: string | null;
+  environment?: string | null;
+  url_api?: string | null;
+  active?: boolean | null;
+}
+
+interface SyncAuditRow extends QueryResultRow {
+  id: number;
+  processo_id: number | null;
+  process_sync_id: number | null;
+  process_response_id: number | null;
+  integration_api_key_id: number | null;
+  event_type: string;
+  event_details: unknown;
+  observed_at: string | Date;
+  created_at: string | Date;
+  provider?: string | null;
+  environment?: string | null;
+  url_api?: string | null;
+  active?: boolean | null;
+}
+
+const EMPTY_OBJECT = {} as const;
+
+function normalizeOptionalString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeNullableNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function normalizeStatus(value: unknown, fallback: string): string {
+  const normalized = normalizeOptionalString(value);
+  return normalized ?? fallback;
+}
+
+function normalizeRequestType(value: unknown): string | null {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    return null;
+  }
+  return normalized.toLowerCase();
+}
+
+function normalizeDateInput(value: unknown): string | Date | null {
+  if (value === undefined) {
+    return null;
+  }
+  if (value === null) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+  }
+  return null;
+}
+
+function toJsonText(value: unknown, fallback: string | null): string | null {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    if (fallback !== undefined) {
+      return fallback;
+    }
+    throw error;
+  }
+}
+
+function parseJsonColumn<T>(value: unknown, fallback: T): T {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value) as T;
+    } catch (error) {
+      return fallback;
+    }
+  }
+
+  if (typeof value === 'object') {
+    return value as T;
+  }
+
+  return fallback;
+}
+
+function formatTimestamp(value: string | Date): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  return new Date(value).toISOString();
+}
+
+function formatNullableTimestamp(value: string | Date | null): string | null {
+  if (!value) {
+    return null;
+  }
+  return formatTimestamp(value);
+}
+
+function mapIntegration(row: { integration_api_key_id?: number | null; provider?: string | null; environment?: string | null; url_api?: string | null; active?: boolean | null; }): ProcessSyncIntegrationInfo | null {
+  if (!row.integration_api_key_id) {
+    return null;
+  }
+  return {
+    id: row.integration_api_key_id,
+    provider: row.provider ?? 'judit',
+    environment: row.environment ?? 'producao',
+    apiUrl: row.url_api ?? null,
+    active: row.active ?? true,
+  };
+}
+
+function mapProcessSyncRow(row: ProcessSyncRow): ProcessSyncRecord {
+  return {
+    id: row.id,
+    processoId: row.processo_id ?? null,
+    integrationApiKeyId: row.integration_api_key_id ?? null,
+    integration: mapIntegration(row),
+    remoteRequestId: row.remote_request_id ?? null,
+    requestType: row.request_type,
+    requestedBy: row.requested_by ?? null,
+    requestedAt: formatTimestamp(row.requested_at),
+    requestPayload: parseJsonColumn(row.request_payload, { ...EMPTY_OBJECT }),
+    requestHeaders: parseJsonColumn(row.request_headers, null),
+    status: row.status,
+    statusReason: row.status_reason ?? null,
+    completedAt: formatNullableTimestamp(row.completed_at ?? null),
+    metadata: parseJsonColumn(row.metadata, { ...EMPTY_OBJECT }),
+    createdAt: formatTimestamp(row.created_at),
+    updatedAt: formatTimestamp(row.updated_at),
+  };
+}
+
+function mapProcessResponseRow(row: ProcessResponseRow): ProcessResponseRecord {
+  return {
+    id: row.id,
+    processoId: row.processo_id ?? null,
+    processSyncId: row.process_sync_id ?? null,
+    integrationApiKeyId: row.integration_api_key_id ?? null,
+    integration: mapIntegration(row),
+    deliveryId: row.delivery_id ?? null,
+    source: row.source,
+    statusCode: row.status_code ?? null,
+    receivedAt: formatTimestamp(row.received_at),
+    payload: parseJsonColumn(row.payload, { ...EMPTY_OBJECT }),
+    headers: parseJsonColumn(row.headers, null),
+    errorMessage: row.error_message ?? null,
+    createdAt: formatTimestamp(row.created_at),
+  };
+}
+
+function mapSyncAuditRow(row: SyncAuditRow): SyncAuditRecord {
+  return {
+    id: row.id,
+    processoId: row.processo_id ?? null,
+    processSyncId: row.process_sync_id ?? null,
+    processResponseId: row.process_response_id ?? null,
+    integrationApiKeyId: row.integration_api_key_id ?? null,
+    integration: mapIntegration(row),
+    eventType: row.event_type,
+    eventDetails: parseJsonColumn(row.event_details, { ...EMPTY_OBJECT }),
+    observedAt: formatTimestamp(row.observed_at),
+    createdAt: formatTimestamp(row.created_at),
+  };
+}
+
+export interface RegisterProcessRequestInput {
+  processoId?: number | null;
+  integrationApiKeyId?: number | null;
+  remoteRequestId?: string | null;
+  requestType?: string | null;
+  requestedBy?: number | null;
+  requestedAt?: string | Date | null;
+  requestPayload?: unknown;
+  requestHeaders?: unknown;
+  status?: string | null;
+  statusReason?: string | null;
+  metadata?: unknown;
+}
+
+export async function registerProcessRequest(
+  input: RegisterProcessRequestInput,
+  client: Queryable = pool,
+): Promise<ProcessSyncRecord> {
+  const requestType = normalizeRequestType(input.requestType);
+  const statusValue = normalizeStatus(input.status, 'pending');
+
+  const result = await client.query(
+    `INSERT INTO public.process_sync (
+       processo_id,
+       integration_api_key_id,
+       remote_request_id,
+       request_type,
+       requested_by,
+       requested_at,
+       request_payload,
+       request_headers,
+       status,
+       status_reason,
+       metadata
+     ) VALUES (
+       $1,
+       $2,
+       $3,
+       COALESCE($4, 'manual'),
+       $5,
+       COALESCE($6::timestamptz, NOW()),
+       COALESCE($7::jsonb, '{}'::jsonb),
+       $8::jsonb,
+       $9,
+       $10,
+       $11::jsonb
+     )
+     RETURNING
+       id,
+       processo_id,
+       integration_api_key_id,
+       remote_request_id,
+       request_type,
+       requested_by,
+       requested_at,
+       request_payload,
+       request_headers,
+       status,
+       status_reason,
+       completed_at,
+       metadata,
+       created_at,
+       updated_at`,
+    [
+      normalizeNullableNumber(input.processoId),
+      normalizeNullableNumber(input.integrationApiKeyId),
+      normalizeOptionalString(input.remoteRequestId),
+      requestType,
+      normalizeNullableNumber(input.requestedBy),
+      normalizeDateInput(input.requestedAt),
+      toJsonText(input.requestPayload, '{}'),
+      toJsonText(input.requestHeaders, null),
+      statusValue,
+      normalizeOptionalString(input.statusReason),
+      toJsonText(input.metadata, '{}'),
+    ],
+  );
+
+  return mapProcessSyncRow(result.rows[0] as ProcessSyncRow);
+}
+
+export interface UpdateProcessSyncStatusInput {
+  status?: string | null;
+  statusReason?: string | null;
+  completedAt?: string | Date | null;
+  metadata?: unknown;
+}
+
+export async function updateProcessSyncStatus(
+  id: number,
+  updates: UpdateProcessSyncStatusInput,
+  client: Queryable = pool,
+): Promise<ProcessSyncRecord | null> {
+  const assignments: string[] = [];
+  const values: unknown[] = [];
+  let index = 1;
+
+  if (Object.prototype.hasOwnProperty.call(updates, 'status')) {
+    assignments.push(`status = $${index++}`);
+    values.push(updates.status === null ? null : normalizeStatus(updates.status, 'pending'));
+  }
+
+  if (Object.prototype.hasOwnProperty.call(updates, 'statusReason')) {
+    assignments.push(`status_reason = $${index++}`);
+    values.push(updates.statusReason === null ? null : normalizeOptionalString(updates.statusReason));
+  }
+
+  if (Object.prototype.hasOwnProperty.call(updates, 'completedAt')) {
+    assignments.push(`completed_at = $${index++}::timestamptz`);
+    values.push(normalizeDateInput(updates.completedAt ?? null));
+  }
+
+  if (Object.prototype.hasOwnProperty.call(updates, 'metadata')) {
+    assignments.push(`metadata = $${index++}::jsonb`);
+    values.push(toJsonText(updates.metadata ?? null, '{}'));
+  }
+
+  assignments.push(`updated_at = NOW()`);
+
+  const query = `UPDATE public.process_sync SET ${assignments.join(', ')} WHERE id = $${index} RETURNING
+      id,
+      processo_id,
+      integration_api_key_id,
+      remote_request_id,
+      request_type,
+      requested_by,
+      requested_at,
+      request_payload,
+      request_headers,
+      status,
+      status_reason,
+      completed_at,
+      metadata,
+      created_at,
+      updated_at`;
+
+  values.push(id);
+
+  const result = await client.query(query, values);
+  if (result.rowCount === 0) {
+    return null;
+  }
+  return mapProcessSyncRow(result.rows[0] as ProcessSyncRow);
+}
+
+export interface RegisterProcessResponseInput {
+  processoId?: number | null;
+  processSyncId?: number | null;
+  integrationApiKeyId?: number | null;
+  deliveryId?: string | null;
+  source?: string | null;
+  statusCode?: number | null;
+  receivedAt?: string | Date | null;
+  payload?: unknown;
+  headers?: unknown;
+  errorMessage?: string | null;
+}
+
+export async function registerProcessResponse(
+  input: RegisterProcessResponseInput,
+  client: Queryable = pool,
+): Promise<ProcessResponseRecord> {
+  const result = await client.query(
+    `INSERT INTO public.process_response (
+       processo_id,
+       process_sync_id,
+       integration_api_key_id,
+       delivery_id,
+       source,
+       status_code,
+       received_at,
+       payload,
+       headers,
+       error_message
+     ) VALUES (
+       $1,
+       $2,
+       $3,
+       $4,
+       COALESCE($5, 'webhook'),
+       $6,
+       COALESCE($7::timestamptz, NOW()),
+       COALESCE($8::jsonb, '{}'::jsonb),
+       $9::jsonb,
+       $10
+     )
+     RETURNING
+       id,
+       processo_id,
+       process_sync_id,
+       integration_api_key_id,
+       delivery_id,
+       source,
+       status_code,
+       received_at,
+       payload,
+       headers,
+       error_message,
+       created_at`,
+    [
+      normalizeNullableNumber(input.processoId),
+      normalizeNullableNumber(input.processSyncId),
+      normalizeNullableNumber(input.integrationApiKeyId),
+      normalizeOptionalString(input.deliveryId),
+      normalizeOptionalString(input.source),
+      input.statusCode === undefined ? null : normalizeNullableNumber(input.statusCode),
+      normalizeDateInput(input.receivedAt),
+      toJsonText(input.payload, '{}'),
+      toJsonText(input.headers, null),
+      normalizeOptionalString(input.errorMessage),
+    ],
+  );
+
+  return mapProcessResponseRow(result.rows[0] as ProcessResponseRow);
+}
+
+export interface RegisterSyncAuditInput {
+  processoId?: number | null;
+  processSyncId?: number | null;
+  processResponseId?: number | null;
+  integrationApiKeyId?: number | null;
+  eventType: string;
+  eventDetails?: unknown;
+  observedAt?: string | Date | null;
+}
+
+export async function registerSyncAudit(
+  input: RegisterSyncAuditInput,
+  client: Queryable = pool,
+): Promise<SyncAuditRecord> {
+  const eventType = normalizeStatus(input.eventType, 'event');
+
+  const result = await client.query(
+    `INSERT INTO public.sync_audit (
+       processo_id,
+       process_sync_id,
+       process_response_id,
+       integration_api_key_id,
+       event_type,
+       event_details,
+       observed_at
+     ) VALUES (
+       $1,
+       $2,
+       $3,
+       $4,
+       $5,
+       COALESCE($6::jsonb, '{}'::jsonb),
+       COALESCE($7::timestamptz, NOW())
+     )
+     RETURNING
+       id,
+       processo_id,
+       process_sync_id,
+       process_response_id,
+       integration_api_key_id,
+       event_type,
+       event_details,
+       observed_at,
+       created_at`,
+    [
+      normalizeNullableNumber(input.processoId),
+      normalizeNullableNumber(input.processSyncId),
+      normalizeNullableNumber(input.processResponseId),
+      normalizeNullableNumber(input.integrationApiKeyId),
+      eventType,
+      toJsonText(input.eventDetails, '{}'),
+      normalizeDateInput(input.observedAt),
+    ],
+  );
+
+  return mapSyncAuditRow(result.rows[0] as SyncAuditRow);
+}
+
+export async function listProcessSyncs(
+  processoId: number,
+  client: Queryable = pool,
+): Promise<ProcessSyncRecord[]> {
+  const result = await client.query(
+    `SELECT
+       ps.id,
+       ps.processo_id,
+       ps.integration_api_key_id,
+       ps.remote_request_id,
+       ps.request_type,
+       ps.requested_by,
+       ps.requested_at,
+       ps.request_payload,
+       ps.request_headers,
+       ps.status,
+       ps.status_reason,
+       ps.completed_at,
+       ps.metadata,
+       ps.created_at,
+       ps.updated_at,
+       iak.provider,
+       iak.environment,
+       iak.url_api,
+       iak.active
+     FROM public.process_sync ps
+     LEFT JOIN public.integration_api_keys iak ON iak.id = ps.integration_api_key_id
+     WHERE ps.processo_id = $1
+     ORDER BY ps.requested_at DESC, ps.id DESC`,
+    [processoId],
+  );
+
+  return result.rows.map((row) => mapProcessSyncRow(row as ProcessSyncRow));
+}
+
+export async function listProcessResponses(
+  processoId: number,
+  client: Queryable = pool,
+): Promise<ProcessResponseRecord[]> {
+  const result = await client.query(
+    `SELECT
+       pr.id,
+       pr.processo_id,
+       pr.process_sync_id,
+       pr.integration_api_key_id,
+       pr.delivery_id,
+       pr.source,
+       pr.status_code,
+       pr.received_at,
+       pr.payload,
+       pr.headers,
+       pr.error_message,
+       pr.created_at,
+       iak.provider,
+       iak.environment,
+       iak.url_api,
+       iak.active
+     FROM public.process_response pr
+     LEFT JOIN public.integration_api_keys iak ON iak.id = pr.integration_api_key_id
+     WHERE pr.processo_id = $1
+     ORDER BY pr.received_at DESC, pr.id DESC`,
+    [processoId],
+  );
+
+  return result.rows.map((row) => mapProcessResponseRow(row as ProcessResponseRow));
+}
+
+export async function listSyncAudits(
+  processoId: number,
+  client: Queryable = pool,
+): Promise<SyncAuditRecord[]> {
+  const result = await client.query(
+    `SELECT
+       sa.id,
+       sa.processo_id,
+       sa.process_sync_id,
+       sa.process_response_id,
+       sa.integration_api_key_id,
+       sa.event_type,
+       sa.event_details,
+       sa.observed_at,
+       sa.created_at,
+       iak.provider,
+       iak.environment,
+       iak.url_api,
+       iak.active
+     FROM public.sync_audit sa
+     LEFT JOIN public.integration_api_keys iak ON iak.id = sa.integration_api_key_id
+     WHERE sa.processo_id = $1
+     ORDER BY sa.observed_at DESC, sa.id DESC`,
+    [processoId],
+  );
+
+  return result.rows.map((row) => mapSyncAuditRow(row as SyncAuditRow));
+}
+
+export async function findProcessByNumber(
+  processNumber: string,
+  client: Queryable = pool,
+): Promise<{ id: number } | null> {
+  const normalized = normalizeOptionalString(processNumber);
+  if (!normalized) {
+    return null;
+  }
+
+  const result = await client.query(
+    `SELECT id FROM public.processos WHERE numero = $1 ORDER BY id ASC LIMIT 1`,
+    [normalized],
+  );
+
+  if (result.rowCount === 0) {
+    return null;
+  }
+
+  return { id: (result.rows[0] as QueryResultRow).id as number };
+}
+
+export async function findProcessSyncByRemoteId(
+  remoteRequestId: string,
+  client: Queryable = pool,
+): Promise<ProcessSyncRecord | null> {
+  const normalized = normalizeOptionalString(remoteRequestId);
+  if (!normalized) {
+    return null;
+  }
+
+  const result = await client.query(
+    `SELECT
+       ps.id,
+       ps.processo_id,
+       ps.integration_api_key_id,
+       ps.remote_request_id,
+       ps.request_type,
+       ps.requested_by,
+       ps.requested_at,
+       ps.request_payload,
+       ps.request_headers,
+       ps.status,
+       ps.status_reason,
+       ps.completed_at,
+       ps.metadata,
+       ps.created_at,
+       ps.updated_at,
+       iak.provider,
+       iak.environment,
+       iak.url_api,
+       iak.active
+     FROM public.process_sync ps
+     LEFT JOIN public.integration_api_keys iak ON iak.id = ps.integration_api_key_id
+     WHERE ps.remote_request_id = $1
+     ORDER BY ps.id DESC
+     LIMIT 1`,
+    [normalized],
+  );
+
+  if (result.rowCount === 0) {
+    return null;
+  }
+
+  return mapProcessSyncRow(result.rows[0] as ProcessSyncRow);
+}

--- a/backend/src/services/notificationProviders/juditNotificationService.ts
+++ b/backend/src/services/notificationProviders/juditNotificationService.ts
@@ -1,0 +1,341 @@
+import type { Request } from 'express';
+import type { Notification } from '../notificationService';
+import {
+  findProcessByNumber,
+  findProcessSyncByRemoteId,
+  registerProcessResponse,
+  registerSyncAudit,
+  updateProcessSyncStatus,
+  type ProcessSyncRecord,
+  type RegisterProcessResponseInput,
+  type UpdateProcessSyncStatusInput,
+} from '../juditProcessService';
+import { INotificationProvider, NotificationProviderError } from './types';
+
+function pickHeader(headers: Request['headers'], name: string): string | undefined {
+  const value = headers[name];
+  if (Array.isArray(value)) {
+    const first = value.find((item) => typeof item === 'string' && item.trim().length > 0);
+    return first ? first.trim() : undefined;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  return undefined;
+}
+
+function normalizeString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseNumeric(value: unknown): number | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const parsed = Number.parseInt(trimmed, 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function cloneHeaders(headers: Request['headers']): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    result[key] = value as unknown;
+  }
+  return result;
+}
+
+function resolveProcessNumber(payload: Record<string, unknown>): string | undefined {
+  const candidateKeys = [
+    'processNumber',
+    'numeroProcesso',
+    'numero_processo',
+    'processoNumero',
+    'numero',
+  ];
+
+  for (const key of candidateKeys) {
+    const value = normalizeString(payload[key]);
+    if (value) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function resolveSyncReference(payload: Record<string, unknown>): string | undefined {
+  const candidateKeys = [
+    'syncId',
+    'processSyncId',
+    'syncReference',
+    'requestId',
+    'remoteRequestId',
+    'idSincronizacao',
+  ];
+
+  for (const key of candidateKeys) {
+    const value = normalizeString(payload[key]);
+    if (value) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function resolveStatusCode(payload: Record<string, unknown>): number | undefined {
+  const candidateKeys = ['statusCode', 'httpStatus', 'code'];
+
+  for (const key of candidateKeys) {
+    const value = parseNumeric(payload[key]);
+    if (value !== undefined) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function resolveErrorMessage(payload: Record<string, unknown>): string | undefined {
+  const candidateKeys = ['error', 'errorMessage', 'mensagem', 'message', 'descricaoErro'];
+
+  for (const key of candidateKeys) {
+    const value = normalizeString(payload[key]);
+    if (value) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function resolveSyncStatus(payload: Record<string, unknown>): string | undefined {
+  const candidateKeys = ['status', 'syncStatus', 'resultado'];
+
+  for (const key of candidateKeys) {
+    const value = normalizeString(payload[key]);
+    if (value) {
+      return value.toLowerCase();
+    }
+  }
+
+  return undefined;
+}
+
+function resolveSuccessFlag(payload: Record<string, unknown>): boolean | undefined {
+  const candidateKeys = ['success', 'sucesso', 'ok'];
+  for (const key of candidateKeys) {
+    const value = payload[key];
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    if (typeof value === 'string') {
+      const normalized = value.trim().toLowerCase();
+      if (['true', '1', 'yes', 'sim'].includes(normalized)) {
+        return true;
+      }
+      if (['false', '0', 'no', 'nao', 'não'].includes(normalized)) {
+        return false;
+      }
+    }
+  }
+  return undefined;
+}
+
+function normalizePayload(body: unknown): Record<string, unknown> {
+  if (body === null || body === undefined) {
+    throw new NotificationProviderError('JUDIT webhook payload cannot be empty', 400);
+  }
+
+  if (typeof body === 'string') {
+    try {
+      const parsed = JSON.parse(body);
+      if (parsed && typeof parsed === 'object') {
+        return parsed as Record<string, unknown>;
+      }
+    } catch (error) {
+      throw new NotificationProviderError('JUDIT webhook payload must be valid JSON', 400);
+    }
+  }
+
+  if (typeof body !== 'object') {
+    throw new NotificationProviderError('JUDIT webhook payload must be an object', 400);
+  }
+
+  return body as Record<string, unknown>;
+}
+
+function resolveDeliveryId(req: Request, payload: Record<string, unknown>): string | undefined {
+  const headerKeys = ['x-delivery-id', 'x-request-id', 'x-correlation-id', 'x-message-id'];
+
+  for (const key of headerKeys) {
+    const value = pickHeader(req.headers, key);
+    if (value) {
+      return value;
+    }
+  }
+
+  const payloadKeys = ['deliveryId', 'requestId', 'correlationId'];
+  for (const key of payloadKeys) {
+    const value = normalizeString(payload[key]);
+    if (value) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function resolveIntegrationId(req: Request, payload: Record<string, unknown>): number | undefined {
+  const headerKeys = ['x-integration-key-id', 'x-judit-credential-id', 'x-credential-id'];
+
+  for (const key of headerKeys) {
+    const value = pickHeader(req.headers, key);
+    if (value) {
+      const parsed = parseNumeric(value);
+      if (parsed !== undefined) {
+        return parsed;
+      }
+    }
+  }
+
+  const payloadKeys = ['integrationKeyId', 'credentialId', 'apiKeyId'];
+  for (const key of payloadKeys) {
+    const value = parseNumeric(payload[key]);
+    if (value !== undefined) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function shouldMarkSyncCompleted(
+  payload: Record<string, unknown>,
+  currentSync: ProcessSyncRecord | null,
+): UpdateProcessSyncStatusInput | null {
+  const statusUpdate = resolveSyncStatus(payload);
+  const successFlag = resolveSuccessFlag(payload);
+  const errorMessage = resolveErrorMessage(payload);
+
+  const updates: UpdateProcessSyncStatusInput = {};
+
+  if (statusUpdate) {
+    updates.status = statusUpdate;
+  }
+
+  if (successFlag === true) {
+    updates.completedAt = new Date();
+    if (!updates.status) {
+      updates.status = 'completed';
+    }
+    updates.statusReason = null;
+  } else if (successFlag === false) {
+    if (!updates.status) {
+      updates.status = statusUpdate ?? 'failed';
+    }
+    updates.completedAt = new Date();
+    updates.statusReason = errorMessage ?? updates.statusReason ?? 'JUDIT retornou falha na sincronização';
+  } else if (errorMessage && !updates.statusReason) {
+    updates.statusReason = errorMessage;
+  }
+
+  if (!updates.status && !updates.statusReason && !updates.completedAt) {
+    return null;
+  }
+
+  if (currentSync && updates.status === currentSync.status && !updates.statusReason && !updates.completedAt) {
+    return null;
+  }
+
+  return updates;
+}
+
+export class JuditNotificationProvider implements INotificationProvider {
+  public readonly id = 'judit';
+
+  async subscribe(): Promise<void> {
+    // JUDIT não requer assinatura ativa via API.
+  }
+
+  async fetchUpdates(): Promise<Notification[]> {
+    return [];
+  }
+
+  async handleWebhook(req: Request): Promise<Notification[]> {
+    const payload = normalizePayload(req.body);
+    const deliveryId = resolveDeliveryId(req, payload);
+    const integrationId = resolveIntegrationId(req, payload);
+    const processNumber = resolveProcessNumber(payload);
+    const syncReference = resolveSyncReference(payload);
+
+    let processoId: number | null = null;
+    if (processNumber) {
+      const processo = await findProcessByNumber(processNumber);
+      processoId = processo?.id ?? null;
+    }
+
+    let syncRecord: ProcessSyncRecord | null = null;
+    if (syncReference) {
+      syncRecord = await findProcessSyncByRemoteId(syncReference);
+      if (!processoId && syncRecord?.processoId) {
+        processoId = syncRecord.processoId;
+      }
+    }
+
+    const responsePayload: RegisterProcessResponseInput = {
+      processoId: processoId ?? syncRecord?.processoId ?? null,
+      processSyncId: syncRecord?.id ?? null,
+      integrationApiKeyId: integrationId ?? syncRecord?.integrationApiKeyId ?? null,
+      deliveryId: deliveryId ?? null,
+      source: 'webhook',
+      statusCode: resolveStatusCode(payload),
+      payload,
+      headers: cloneHeaders(req.headers),
+      errorMessage: resolveErrorMessage(payload),
+    };
+
+    const responseRecord = await registerProcessResponse(responsePayload);
+
+    await registerSyncAudit({
+      processoId: responseRecord.processoId ?? processoId ?? null,
+      processSyncId: responseRecord.processSyncId ?? syncRecord?.id ?? null,
+      processResponseId: responseRecord.id,
+      integrationApiKeyId: responseRecord.integrationApiKeyId ?? integrationId ?? syncRecord?.integrationApiKeyId ?? null,
+      eventType: 'webhook_received',
+      eventDetails: {
+        deliveryId: deliveryId ?? null,
+        processNumber: processNumber ?? null,
+        syncReference: syncReference ?? null,
+        status: resolveSyncStatus(payload) ?? null,
+        success: resolveSuccessFlag(payload) ?? null,
+      },
+    });
+
+    if (syncRecord?.id) {
+      const updates = shouldMarkSyncCompleted(payload, syncRecord);
+      if (updates) {
+        await updateProcessSyncStatus(syncRecord.id, updates);
+      }
+    }
+
+    return [];
+  }
+}
+
+export const juditNotificationProvider = new JuditNotificationProvider();

--- a/backend/src/services/notificationProviders/registry.ts
+++ b/backend/src/services/notificationProviders/registry.ts
@@ -1,5 +1,6 @@
 import type { INotificationProvider } from './types';
 import { pjeNotificationProvider } from './pjeNotificationService';
+import { juditNotificationProvider } from './juditNotificationService';
 import { projudiNotificationProvider } from './projudiNotificationService';
 
 const registry = new Map<string, INotificationProvider>();
@@ -30,6 +31,7 @@ export function listNotificationProviders(): INotificationProvider[] {
 }
 
 registerNotificationProvider(pjeNotificationProvider, 'pje');
+registerNotificationProvider(juditNotificationProvider, 'judit');
 registerNotificationProvider(projudiNotificationProvider, 'projudi');
 
 export const notificationProviderRegistry = registry;

--- a/backend/src/services/processSyncSchema.ts
+++ b/backend/src/services/processSyncSchema.ts
@@ -1,0 +1,82 @@
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import path from 'node:path';
+import pool from './db';
+
+const SCHEMA_FILES = ['process_sync.sql', 'process_response.sql', 'sync_audit.sql'] as const;
+
+type Queryable = {
+  query: (text: string) => Promise<unknown>;
+};
+
+type CachedSqlEntry = {
+  file: string;
+  sql: string;
+};
+
+let cachedEntries: CachedSqlEntry[] | null = null;
+let initializationPromise: Promise<void> | null = null;
+
+async function resolveFilePath(file: string): Promise<string> {
+  const candidatePaths = [
+    path.resolve(__dirname, '..', 'sql', file),
+    path.resolve(__dirname, '../..', 'sql', file),
+    path.resolve(process.cwd(), 'sql', file),
+    path.resolve(process.cwd(), 'backend', 'sql', file),
+  ];
+
+  for (const candidate of candidatePaths) {
+    try {
+      await access(candidate, constants.R_OK);
+      return candidate;
+    } catch (error) {
+      const errno = (error as NodeJS.ErrnoException).code;
+      if (errno && ['ENOENT', 'ENOTDIR'].includes(errno)) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw new Error(
+    `Process sync schema file "${file}" not found. Checked: ${candidatePaths
+      .map((candidate) => `"${candidate}"`)
+      .join(', ')}`,
+  );
+}
+
+async function loadSchemaSql(): Promise<CachedSqlEntry[]> {
+  if (cachedEntries) {
+    return cachedEntries;
+  }
+
+  const entries: CachedSqlEntry[] = [];
+
+  for (const file of SCHEMA_FILES) {
+    const schemaPath = await resolveFilePath(file);
+    const sql = await readFile(schemaPath, 'utf-8');
+    entries.push({ file, sql });
+  }
+
+  cachedEntries = entries;
+  return entries;
+}
+
+async function executeSchemas(client: Queryable): Promise<void> {
+  const entries = await loadSchemaSql();
+
+  for (const entry of entries) {
+    await client.query(entry.sql);
+  }
+}
+
+export async function ensureProcessSyncSchema(client: Queryable = pool): Promise<void> {
+  if (!initializationPromise) {
+    initializationPromise = executeSchemas(client).catch((error) => {
+      initializationPromise = null;
+      throw error;
+    });
+  }
+
+  await initializationPromise;
+}

--- a/backend/tests/juditProcessService.test.ts
+++ b/backend/tests/juditProcessService.test.ts
@@ -1,0 +1,257 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  findProcessByNumber,
+  findProcessSyncByRemoteId,
+  listProcessSyncs,
+  registerProcessRequest,
+  registerProcessResponse,
+  registerSyncAudit,
+  type ProcessSyncRecord,
+} from '../src/services/juditProcessService';
+
+interface QueryCall {
+  text: string;
+  values?: unknown[];
+}
+
+interface QueryResponse {
+  rows: any[];
+  rowCount: number;
+}
+
+class FakePool {
+  public readonly calls: QueryCall[] = [];
+
+  constructor(private readonly responses: QueryResponse[] = []) {}
+
+  async query(text: string, values?: unknown[]) {
+    this.calls.push({ text, values });
+    if (this.responses.length === 0) {
+      throw new Error('No response configured for query');
+    }
+    return this.responses.shift()!;
+  }
+}
+
+test('registerProcessRequest inserts payload and maps response', async () => {
+  const insertedRow = {
+    id: 101,
+    processo_id: 55,
+    integration_api_key_id: 7,
+    remote_request_id: 'req-123',
+    request_type: 'manual',
+    requested_by: 9,
+    requested_at: '2024-02-01T10:00:00.000Z',
+    request_payload: { foo: 'bar' },
+    request_headers: null,
+    status: 'pending',
+    status_reason: null,
+    completed_at: null,
+    metadata: { attempt: 1 },
+    created_at: '2024-02-01T10:00:01.000Z',
+    updated_at: '2024-02-01T10:00:01.000Z',
+  };
+
+  const pool = new FakePool([{ rows: [insertedRow], rowCount: 1 }]);
+
+  const record = await registerProcessRequest(
+    {
+      processoId: 55,
+      integrationApiKeyId: 7,
+      remoteRequestId: 'req-123',
+      requestType: 'Manual',
+      requestedBy: 9,
+      requestPayload: { foo: 'bar' },
+      status: 'pending',
+      metadata: { attempt: 1 },
+    },
+    pool as unknown as any,
+  );
+
+  assert.equal(pool.calls.length, 1);
+  const call = pool.calls[0];
+  assert.match(call.text, /INSERT INTO public\.process_sync/i);
+  assert.deepEqual(call.values, [
+    55,
+    7,
+    'req-123',
+    'manual',
+    9,
+    null,
+    JSON.stringify({ foo: 'bar' }),
+    null,
+    'pending',
+    null,
+    JSON.stringify({ attempt: 1 }),
+  ]);
+
+  assert.equal(record.id, 101);
+  assert.equal(record.processoId, 55);
+  assert.equal(record.integrationApiKeyId, 7);
+  assert.equal(record.remoteRequestId, 'req-123');
+  assert.equal(record.requestType, 'manual');
+  assert.equal(record.status, 'pending');
+  assert.deepEqual(record.requestPayload, { foo: 'bar' });
+  assert.equal(record.statusReason, null);
+});
+
+test('registerProcessResponse stores webhook payload with defaults', async () => {
+  const insertedRow = {
+    id: 88,
+    processo_id: 55,
+    process_sync_id: 101,
+    integration_api_key_id: 7,
+    delivery_id: 'delivery-xyz',
+    source: 'webhook',
+    status_code: 200,
+    received_at: '2024-02-01T10:01:00.000Z',
+    payload: { success: true },
+    headers: { 'x-header': 'value' },
+    error_message: null,
+    created_at: '2024-02-01T10:01:00.000Z',
+  };
+
+  const pool = new FakePool([{ rows: [insertedRow], rowCount: 1 }]);
+
+  const record = await registerProcessResponse(
+    {
+      processoId: 55,
+      processSyncId: 101,
+      integrationApiKeyId: 7,
+      deliveryId: 'delivery-xyz',
+      statusCode: '200',
+      payload: { success: true },
+      headers: { 'x-header': 'value' },
+    },
+    pool as unknown as any,
+  );
+
+  assert.equal(pool.calls.length, 1);
+  const call = pool.calls[0];
+  assert.match(call.text, /INSERT INTO public\.process_response/i);
+  assert.deepEqual(call.values, [
+    55,
+    101,
+    7,
+    'delivery-xyz',
+    null,
+    200,
+    null,
+    JSON.stringify({ success: true }),
+    JSON.stringify({ 'x-header': 'value' }),
+    null,
+  ]);
+
+  assert.equal(record.id, 88);
+  assert.equal(record.processSyncId, 101);
+  assert.deepEqual(record.payload, { success: true });
+  assert.equal(record.statusCode, 200);
+});
+
+test('registerSyncAudit persists audit trail', async () => {
+  const insertedRow = {
+    id: 5,
+    processo_id: 55,
+    process_sync_id: 101,
+    process_response_id: 88,
+    integration_api_key_id: 7,
+    event_type: 'webhook_received',
+    event_details: { deliveryId: 'delivery-xyz' },
+    observed_at: '2024-02-01T10:02:00.000Z',
+    created_at: '2024-02-01T10:02:00.000Z',
+  };
+
+  const pool = new FakePool([{ rows: [insertedRow], rowCount: 1 }]);
+
+  const record = await registerSyncAudit(
+    {
+      processoId: 55,
+      processSyncId: 101,
+      processResponseId: 88,
+      integrationApiKeyId: 7,
+      eventType: 'webhook_received',
+      eventDetails: { deliveryId: 'delivery-xyz' },
+    },
+    pool as unknown as any,
+  );
+
+  assert.equal(pool.calls.length, 1);
+  const call = pool.calls[0];
+  assert.match(call.text, /INSERT INTO public\.sync_audit/i);
+  assert.equal(call.values?.[0], 55);
+  assert.equal(record.eventType, 'webhook_received');
+  assert.deepEqual(record.eventDetails, { deliveryId: 'delivery-xyz' });
+});
+
+test('listProcessSyncs returns integration metadata when available', async () => {
+  const row = {
+    id: 101,
+    processo_id: 55,
+    integration_api_key_id: 7,
+    remote_request_id: 'req-123',
+    request_type: 'manual',
+    requested_by: 9,
+    requested_at: '2024-02-01T10:00:00.000Z',
+    request_payload: { foo: 'bar' },
+    request_headers: null,
+    status: 'pending',
+    status_reason: null,
+    completed_at: null,
+    metadata: { attempt: 1 },
+    created_at: '2024-02-01T10:00:01.000Z',
+    updated_at: '2024-02-01T10:00:01.000Z',
+    provider: 'judit',
+    environment: 'homologacao',
+    url_api: 'https://judit.test',
+    active: true,
+  };
+
+  const pool = new FakePool([{ rows: [row], rowCount: 1 }]);
+
+  const records = await listProcessSyncs(55, pool as unknown as any);
+
+  assert.equal(pool.calls.length, 1);
+  const call = pool.calls[0];
+  assert.match(call.text, /FROM public\.process_sync ps/i);
+  assert.deepEqual(call.values, [55]);
+  assert.equal(records.length, 1);
+  const [record] = records;
+  assert.equal(record.integration?.provider, 'judit');
+  assert.equal(record.integration?.environment, 'homologacao');
+});
+
+test('findProcessByNumber returns null when not found', async () => {
+  const pool = new FakePool([{ rows: [], rowCount: 0 }]);
+  const result = await findProcessByNumber('0000000-00.0000.0.00.0000', pool as unknown as any);
+  assert.equal(result, null);
+});
+
+test('findProcessSyncByRemoteId returns latest match', async () => {
+  const latestRow = {
+    id: 105,
+    processo_id: 55,
+    integration_api_key_id: 7,
+    remote_request_id: 'req-123',
+    request_type: 'manual',
+    requested_by: 9,
+    requested_at: '2024-02-01T10:00:00.000Z',
+    request_payload: {},
+    request_headers: null,
+    status: 'pending',
+    status_reason: null,
+    completed_at: null,
+    metadata: {},
+    created_at: '2024-02-01T10:00:01.000Z',
+    updated_at: '2024-02-01T10:00:01.000Z',
+  } satisfies Partial<ProcessSyncRecord> as any;
+
+  const pool = new FakePool([{ rows: [latestRow], rowCount: 1 }]);
+
+  const result = await findProcessSyncByRemoteId('req-123', pool as unknown as any);
+  assert.equal(pool.calls.length, 1);
+  const call = pool.calls[0];
+  assert.match(call.text, /WHERE ps\.remote_request_id = \$1/i);
+  assert.equal(call.values?.[0], 'req-123');
+  assert.equal(result?.id, 105);
+});


### PR DESCRIPTION
## Summary
- create `process_sync`, `process_response` and `sync_audit` tables and ensure the schema is applied during startup
- implement a JUDIT process repository plus webhook provider to record requests, responses and audit events
- expose sync history in process details, extend API documentation and add unit coverage for the new storage layer

## Testing
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68d5b71ef0248326a0fae3c8472397a3