### PR TITLE
Fix Processos accordion markup

### DIFF
--- a/frontend/src/pages/operator/Processos.tsx
+++ b/frontend/src/pages/operator/Processos.tsx
@@ -2258,7 +2258,6 @@ export default function Processos() {
                         </span>
                       </div>
                     </div>
-                  </div>
                 </AccordionTrigger>
                 <AccordionContent className="border-t border-border/40 px-6 pb-6 pt-6 sm:px-8">
                   <div className="space-y-6">


### PR DESCRIPTION
## Summary
- remove an extra closing div inside the Processos accordion trigger so the JSX compiles
- tidy the indentation for the accordion trigger wrapper

## Testing
- npm install *(fails: registry.npmjs.org/vitest returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d8643b9c8326b399c863f168f8c1