### PR TITLE
feat: load Judit integration config from API key registry

### DIFF
--- a/backend/src/controllers/integrationApiKeyController.ts
+++ b/backend/src/controllers/integrationApiKeyController.ts
@@ -5,6 +5,7 @@ import IntegrationApiKeyService, {
   ValidationError,
 } from '../services/integrationApiKeyService';
 import IntegrationApiKeyValidationService from '../services/integrationApiKeyValidationService';
+import juditProcessService from '../services/juditProcessService';
 
 const service = new IntegrationApiKeyService();
 const validationService = new IntegrationApiKeyValidationService();
@@ -121,6 +122,7 @@ export async function createIntegrationApiKey(req: Request, res: Response) {
     }
 
     const created = await service.create(input);
+    juditProcessService.invalidateConfigurationCache();
     return res.status(201).json(created);
   } catch (error) {
     if (error instanceof ValidationError) {
@@ -175,6 +177,7 @@ export async function updateIntegrationApiKey(req: Request, res: Response) {
     if (!updated) {
       return res.status(404).json({ error: 'API key not found' });
     }
+    juditProcessService.invalidateConfigurationCache();
     return res.json(updated);
   } catch (error) {
     if (error instanceof ValidationError) {
@@ -197,6 +200,7 @@ export async function deleteIntegrationApiKey(req: Request, res: Response) {
     if (!deleted) {
       return res.status(404).json({ error: 'API key not found' });
     }
+    juditProcessService.invalidateConfigurationCache();
     return res.status(204).send();
   } catch (error) {
     console.error('Failed to delete integration API key:', error);

--- a/backend/src/controllers/juditProcessController.ts
+++ b/backend/src/controllers/juditProcessController.ts
@@ -27,7 +27,7 @@ export const triggerManualJuditSync = async (req: Request, res: Response) => {
     return res.status(401).json({ error: 'Token inválido.' });
   }
 
-  if (!juditProcessService.isEnabled()) {
+  if (!(await juditProcessService.isEnabled())) {
     return res.status(503).json({ error: 'Integração com a Judit não está configurada.' });
   }
 

--- a/backend/src/controllers/processoController.ts
+++ b/backend/src/controllers/processoController.ts
@@ -817,7 +817,8 @@ export const getProcessoById = async (req: Request, res: Response) => {
     processo.juditSyncs = juditSyncs;
     processo.juditResponses = juditResponses;
     processo.juditAuditTrail = juditAuditTrail;
-    if (juditProcessService.isEnabled()) {
+
+    if (await juditProcessService.isEnabled()) {
       try {
         const tracking = await juditProcessService.ensureTrackingForProcess(
           processo.id,

--- a/backend/tests/juditProcessService.test.ts
+++ b/backend/tests/juditProcessService.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import pool from '../src/services/db';
 import { handleJuditWebhook } from '../src/controllers/juditWebhookController';
-import juditProcessService, {
+import {
   JuditProcessService,
   findProcessByNumber,
   findProcessSyncByRemoteId,
@@ -360,7 +360,6 @@ test('handleJuditWebhook persists increments and updates request state', async (
 
   const client = new RecordingClient(handler);
   const connectMock = t.mock.method(pool, 'connect', async () => client as unknown as any);
-  const isEnabledMock = t.mock.method(juditProcessService, 'isEnabled', () => true);
 
   const increments = [
     { type: 'movement', payload: { id: 1 } },
@@ -389,7 +388,6 @@ test('handleJuditWebhook persists increments and updates request state', async (
   assert.equal(res.statusCode, 200);
   assert.deepEqual(res.jsonBody, { status: 'ok' });
   assert.equal(connectMock.mock.calls.length, 1);
-  assert.equal(isEnabledMock.mock.calls.length, 1);
   assert.ok(client.releaseCalled);
 
   const historyCalls = client.calls.filter((call) =>


### PR DESCRIPTION
## Summary
- resolve Judit API configuration dynamically via integration_api_keys with caching and usage tracking
- make cron jobs and controllers await Judit availability and allow webhook handling without a configured API key
- invalidate cached Judit credentials when API keys are created, updated or deleted and align tests with the new flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5db1c992c83268a6f64b15c75179c