### PR TITLE
Adjust Judit request payload

### DIFF
--- a/backend/src/services/juditProcessService.ts
+++ b/backend/src/services/juditProcessService.ts
@@ -1079,7 +1079,13 @@ export class JuditProcessService {
     const resolvedConfig = config ?? (await this.requireConfiguration());
     return this.requestWithRetry<JuditRequestResponse>(resolvedConfig, resolvedConfig.requestsEndpoint, {
       method: 'POST',
-      body: JSON.stringify({ process_number: processNumber }),
+      body: JSON.stringify({
+        search: {
+          search_type: 'lawsuit_cnj',
+          search_key: processNumber,
+        },
+        with_attachments: false,
+      }),
     });
   }
 

--- a/backend/tests/juditProcessService.test.ts
+++ b/backend/tests/juditProcessService.test.ts
@@ -436,6 +436,15 @@ test('Judit request lifecycle stores polling response and process_response entry
 
     if (url === 'https://requests.prod.judit.io/requests') {
       assert.equal(init?.method, 'POST');
+      assert.equal(typeof init?.body, 'string');
+      const payload = JSON.parse(init?.body as string);
+      assert.deepEqual(payload, {
+        search: {
+          search_type: 'lawsuit_cnj',
+          search_key: '0000000-00.0000.0.00.0000',
+        },
+        with_attachments: false,
+      });
       return new Response(JSON.stringify({
         request_id: 'req-flow',
         status: 'pending',


### PR DESCRIPTION
## Summary
- update the Judit manual sync request payload to use the new search contract
- extend the process lifecycle test to assert the payload format and keep the success flow covered

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5e344754883268acd3356103c67c0