### PR TITLE
Adjust Judit manual sync request payload

### DIFF
--- a/backend/src/services/juditProcessService.ts
+++ b/backend/src/services/juditProcessService.ts
@@ -1079,7 +1079,13 @@ export class JuditProcessService {
     const resolvedConfig = config ?? (await this.requireConfiguration());
     return this.requestWithRetry<JuditRequestResponse>(resolvedConfig, resolvedConfig.requestsEndpoint, {
       method: 'POST',
-      body: JSON.stringify({ process_number: processNumber }),
+      body: JSON.stringify({
+        search: {
+          search_type: 'lawsuit_cnj',
+          search_key: processNumber,
+        },
+        with_attachments: true,
+      }),
     });
   }
 

--- a/backend/tests/juditProcessService.test.ts
+++ b/backend/tests/juditProcessService.test.ts
@@ -436,6 +436,15 @@ test('Judit request lifecycle stores polling response and process_response entry
 
     if (url === 'https://requests.prod.judit.io/requests') {
       assert.equal(init?.method, 'POST');
+      assert.equal(typeof init?.body, 'string');
+      const payload = JSON.parse(init?.body as string);
+      assert.deepEqual(payload, {
+        search: {
+          search_type: 'lawsuit_cnj',
+          search_key: '0000000-00.0000.0.00.0000',
+        },
+        with_attachments: true,
+      });
       return new Response(JSON.stringify({
         request_id: 'req-flow',
         status: 'pending',


### PR DESCRIPTION
## Summary
- ensure the Judit manual sync request includes attachments so the provider accepts the payload
- update the Judit lifecycle test to assert the revised request body structure

## Testing
- npm test --prefix backend

------
https://chatgpt.com/codex/tasks/task_e_68d5e344754883268acd3356103c67c0