### PR TITLE
Fix Judit tracking endpoint resolution

### DIFF
--- a/backend/tests/juditProcessService.test.ts
+++ b/backend/tests/juditProcessService.test.ts
@@ -81,6 +81,30 @@ class MockResponse {
   }
 }
 
+test('loadConfigurationFromSources resolves endpoints for requests host base url', async () => {
+  const pool = new FakePool([
+    {
+      rows: [
+        {
+          id: 55,
+          key_value: 'db-key',
+          url_api: 'https://requests.prod.judit.io',
+        },
+      ],
+      rowCount: 1,
+    },
+  ]);
+
+  const service = new JuditProcessService(null);
+
+  const config = await (service as any).loadConfigurationFromSources(pool as unknown as any);
+
+  assert.ok(config);
+  assert.equal(config?.apiKey, 'db-key');
+  assert.equal(config?.requestsEndpoint, 'https://requests.prod.judit.io/requests');
+  assert.equal(config?.trackingEndpoint, 'https://tracking.prod.judit.io/tracking');
+});
+
 test('registerProcessRequest inserts payload and maps response', async () => {
   const insertedRow = {
     id: 101,


### PR DESCRIPTION
## Summary
- parse the configured Judit base URL when building API endpoints
- redirect tracking endpoints to the tracking.* host when integrations use requests.*
- add coverage for resolving endpoints from a requests.prod.judit.io configuration

## Testing
- npm test -- juditProcessService *(fails: createPlanPayment tests expect HTTP 201 but received 503)*
- node --test --test-concurrency=1 --import tsx tests/juditProcessService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d5ffbf790c8326b1e7b9154bc30fe3