### PR TITLE
feat: support on-demand Judit sync requests

### DIFF
--- a/backend/src/services/cronJobs.ts
+++ b/backend/src/services/cronJobs.ts
@@ -495,6 +495,7 @@ export class CronJobsService {
           await juditProcessService.triggerRequestForProcess(row.id, row.numero, {
             source: 'cron',
             skipIfPending: true,
+            onDemand: false,
           });
           processed += 1;
         } catch (error) {

--- a/backend/src/services/juditProcessService.ts
+++ b/backend/src/services/juditProcessService.ts
@@ -148,6 +148,28 @@ function normalizeStatus(value: unknown, fallback: string): string {
   return normalized ?? fallback;
 }
 
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true' || normalized === '1') {
+      return true;
+    }
+    if (normalized === 'false' || normalized === '0') {
+      return false;
+    }
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value !== 0;
+  }
+
+  return fallback;
+}
+
 function normalizeRequestType(value: unknown): string | null {
   const normalized = normalizeOptionalString(value);
   if (!normalized) {
@@ -820,6 +842,7 @@ interface TriggerRequestOptions {
   source: JuditRequestSource;
   actorUserId?: number | null;
   skipIfPending?: boolean;
+  onDemand?: boolean | null;
   client?: PoolClient;
 }
 
@@ -1139,6 +1162,7 @@ export class JuditProcessService {
           search_key: processNumber,
         },
         with_attachments: false,
+        on_demand: false,
       }),
     });
   }
@@ -1265,6 +1289,7 @@ export class JuditProcessService {
     const shouldRelease = !options.client;
     const manageTransaction = !options.client;
     const requestType = normalizeRequestType(options.source ?? 'system') ?? 'system';
+    const onDemand = normalizeBoolean(options.onDemand, requestType === 'manual');
 
     try {
       if (manageTransaction) {
@@ -1327,6 +1352,7 @@ export class JuditProcessService {
           search_key: processNumber,
         },
         with_attachments: false,
+        on_demand: onDemand,
       } as const;
 
       const response = await this.requestWithRetry<JuditRequestResponse>(
@@ -1358,6 +1384,7 @@ export class JuditProcessService {
             source: options.source ?? 'system',
             result,
             trackingId: response.tracking_id ?? null,
+            onDemand,
           },
         },
         client,
@@ -1386,6 +1413,7 @@ export class JuditProcessService {
             requestId,
             status,
             source: options.source ?? 'system',
+            onDemand,
           },
         },
         client,

--- a/backend/tests/juditProcessService.test.ts
+++ b/backend/tests/juditProcessService.test.ts
@@ -513,6 +513,7 @@ test('Judit request lifecycle stores polling response and process_response entry
         },
 
         with_attachments: false,
+        on_demand: true,
       });
       return new Response(JSON.stringify({
         request_id: 'req-flow',
@@ -547,6 +548,7 @@ test('Judit request lifecycle stores polling response and process_response entry
   assert.equal(triggerRecord?.requestId, 'req-flow');
   assert.equal(triggerRecord?.status, 'pending');
   assert.equal(triggerRecord?.processSyncId, 777);
+  assert.equal((triggerRecord?.metadata as any).onDemand, true);
   assert.ok(requestClient.calls.some((call) => /INSERT INTO public\.process_sync/i.test(call.text)));
 
   const statusResponse = await service.getRequestStatusFromApi('req-flow');


### PR DESCRIPTION
## Summary
- allow manual Judit triggers to accept an on-demand flag and normalize it
- include the on_demand field when emitting Judit request payloads, metadata, and cron invocations
- update service tests to cover the new boolean serialization

## Testing
- node --test --import tsx tests/juditProcessService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d60850191c8326a0542fd9bb6f77e9