### PR TITLE
Normalize Judit request source before updating status

### DIFF
--- a/backend/src/controllers/juditProcessController.ts
+++ b/backend/src/controllers/juditProcessController.ts
@@ -4,6 +4,7 @@ import juditProcessService, {
   JuditApiError,
   JuditConfigurationError,
   type JuditRequestRecord,
+  type JuditRequestSource,
 } from '../services/juditProcessService';
 import { fetchAuthenticatedUserEmpresa } from '../utils/authUser';
 
@@ -15,6 +16,27 @@ const mapRecordToResponse = (record: JuditRequestRecord) => ({
   criado_em: record.createdAt,
   atualizado_em: record.updatedAt,
 });
+
+const VALID_REQUEST_SOURCES: ReadonlyArray<JuditRequestSource> = [
+  'details',
+  'manual',
+  'cron',
+  'webhook',
+  'system',
+];
+
+const resolveRequestSource = (
+  source: JuditRequestRecord['source'] | undefined,
+): JuditRequestSource => {
+  if (typeof source === 'string') {
+    const normalized = source.trim().toLowerCase();
+    if (VALID_REQUEST_SOURCES.includes(normalized as JuditRequestSource)) {
+      return normalized as JuditRequestSource;
+    }
+  }
+
+  return 'system';
+};
 
 export const triggerManualJuditSync = async (req: Request, res: Response) => {
   const { id } = req.params;
@@ -168,7 +190,7 @@ export const getJuditRequestStatus = async (req: Request, res: Response) => {
         apiResponse.request_id,
         apiResponse.status ?? 'pending',
         apiResponse.result ?? null,
-        { source: stored?.source ?? 'system' }
+        { source: resolveRequestSource(stored?.source) }
       );
     } catch (error) {
       if (error instanceof JuditConfigurationError) {


### PR DESCRIPTION
## Summary
- add a helper to sanitize stored Judit request sources in the controller
- ensure updateRequestStatus always receives a typed request source when polling Judit status

## Testing
- npm --prefix backend run build

------
https://chatgpt.com/codex/tasks/task_e_68d60879a75c8326a9c7641ab8e0b485