### PR TITLE
Propagate Judit attachment preference to sync requests

### DIFF
--- a/backend/src/controllers/juditProcessController.ts
+++ b/backend/src/controllers/juditProcessController.ts
@@ -18,6 +18,9 @@ const mapRecordToResponse = (record: JuditRequestRecord) => ({
 
 export const triggerManualJuditSync = async (req: Request, res: Response) => {
   const { id } = req.params;
+  const { withAttachments } = (req.body ?? {}) as {
+    withAttachments?: unknown;
+  };
   const processoId = Number(id);
 
   if (!Number.isInteger(processoId) || processoId <= 0) {
@@ -79,6 +82,7 @@ export const triggerManualJuditSync = async (req: Request, res: Response) => {
       {
         source: 'manual',
         actorUserId: req.auth.userId,
+        withAttachments: typeof withAttachments === 'boolean' ? withAttachments : undefined,
       }
     );
 

--- a/backend/src/controllers/processoController.ts
+++ b/backend/src/controllers/processoController.ts
@@ -852,6 +852,7 @@ export const getProcessoById = async (req: Request, res: Response) => {
           {
             source: 'details',
             skipIfPending: true,
+            withAttachments: true,
           }
         );
 

--- a/backend/src/services/cronJobs.ts
+++ b/backend/src/services/cronJobs.ts
@@ -495,6 +495,7 @@ export class CronJobsService {
           await juditProcessService.triggerRequestForProcess(row.id, row.numero, {
             source: 'cron',
             skipIfPending: true,
+            withAttachments: true,
           });
           processed += 1;
         } catch (error) {

--- a/backend/src/services/juditProcessService.ts
+++ b/backend/src/services/juditProcessService.ts
@@ -820,6 +820,7 @@ interface TriggerRequestOptions {
   source: JuditRequestSource;
   actorUserId?: number | null;
   skipIfPending?: boolean;
+  withAttachments?: boolean;
   client?: PoolClient;
 }
 
@@ -1321,13 +1322,18 @@ export class JuditProcessService {
         return null;
       }
 
+      const includeAttachments =
+        typeof options.withAttachments === 'boolean'
+          ? options.withAttachments
+          : true;
+
       const requestPayload = {
         search: {
           search_type: 'lawsuit_cnj',
           search_key: processNumber,
         },
-        with_attachments: false,
-      } as const;
+        with_attachments: includeAttachments,
+      };
 
       const response = await this.requestWithRetry<JuditRequestResponse>(
         config,

--- a/backend/tests/juditProcessService.test.ts
+++ b/backend/tests/juditProcessService.test.ts
@@ -512,7 +512,7 @@ test('Judit request lifecycle stores polling response and process_response entry
           search_key: '0000000-00.0000.0.00.0000',
         },
 
-        with_attachments: false,
+        with_attachments: true,
       });
       return new Response(JSON.stringify({
         request_id: 'req-flow',
@@ -618,6 +618,130 @@ test('Judit request lifecycle stores polling response and process_response entry
 
   assert.equal(fetchMock.mock.calls.length, 2);
 
+});
+
+test('triggerRequestForProcess forwards attachment preference to Judit', async (t) => {
+  const service = new JuditProcessService('test-key');
+
+  const config = {
+    apiKey: 'test-key',
+    requestsEndpoint: 'https://requests.prod.judit.io/requests',
+    trackingEndpoint: 'https://tracking.prod.judit.io/tracking',
+    integrationId: 15,
+  };
+
+  const resolveMock = t.mock.method(service as any, 'resolveConfiguration', async () => config);
+
+  const requestHandler: QueryHandler = (text, values) => {
+    if (/INSERT INTO public\.process_sync/.test(text)) {
+      const payload = values?.[6] ? JSON.parse(String(values?.[6])) : {};
+      const headers = values?.[7] ? JSON.parse(String(values?.[7])) : null;
+      const metadata = values?.[10] ? JSON.parse(String(values?.[10])) : {};
+
+      return {
+        rows: [
+          {
+            id: 701,
+            processo_id: values?.[0],
+            integration_api_key_id: values?.[1],
+            remote_request_id: values?.[2],
+            request_type: values?.[3] ?? 'manual',
+            requested_by: values?.[4] ?? null,
+            requested_at: new Date('2024-01-01T10:00:00.000Z'),
+            request_payload: payload,
+            request_headers: headers,
+            status: values?.[8] ?? 'pending',
+            status_reason: values?.[9] ?? null,
+            completed_at: null,
+            metadata,
+            created_at: new Date('2024-01-01T10:00:01.000Z'),
+            updated_at: new Date('2024-01-01T10:00:01.000Z'),
+          },
+        ],
+        rowCount: 1,
+      } satisfies QueryResponse;
+    }
+
+    if (/INSERT INTO public\.sync_audit/.test(text)) {
+      const eventDetails = values?.[5] ? JSON.parse(String(values?.[5])) : {};
+      return {
+        rows: [
+          {
+            id: 801,
+            processo_id: values?.[0] ?? null,
+            process_sync_id: values?.[1] ?? null,
+            process_response_id: values?.[2] ?? null,
+            integration_api_key_id: values?.[3] ?? null,
+            event_type: values?.[4] ?? 'request_triggered',
+            event_details: eventDetails,
+            observed_at: new Date('2024-01-01T10:00:02.000Z'),
+            created_at: new Date('2024-01-01T10:00:02.000Z'),
+          },
+        ],
+        rowCount: 1,
+      } satisfies QueryResponse;
+    }
+
+    return null;
+  };
+
+  const requestClient = new RecordingClient(requestHandler);
+
+  let requestCalls = 0;
+
+  const fetchMock = t.mock.method(globalThis as any, 'fetch', async (input: any, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : String(input);
+
+    if (url === config.requestsEndpoint) {
+      requestCalls += 1;
+      const payload = JSON.parse(String(init?.body ?? '{}'));
+
+      if (requestCalls === 1) {
+        assert.equal(payload.with_attachments, true);
+      } else if (requestCalls === 2) {
+        assert.equal(payload.with_attachments, false);
+      } else {
+        assert.fail(`Unexpected number of request calls: ${requestCalls}`);
+      }
+
+      return new Response(
+        JSON.stringify({
+          request_id: `req-${requestCalls}`,
+          status: 'pending',
+          result: null,
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }
+
+    throw new Error(`Unexpected fetch call to ${url}`);
+  });
+
+  try {
+    const defaultRecord = await service.triggerRequestForProcess(55, '0000000-00.0000.0.00.0000', {
+      source: 'manual',
+      client: requestClient as unknown as any,
+    });
+
+    assert.equal(defaultRecord?.requestId, 'req-1');
+    assert.equal(defaultRecord?.status, 'pending');
+
+    const withoutAttachments = await service.triggerRequestForProcess(56, '1111111-11.1111.1.11.1111', {
+      source: 'manual',
+      client: requestClient as unknown as any,
+      withAttachments: false,
+    });
+
+    assert.equal(withoutAttachments?.requestId, 'req-2');
+    assert.equal(withoutAttachments?.status, 'pending');
+    assert.equal(requestCalls, 2);
+  } finally {
+    fetchMock.mock.restore();
+    resolveMock.mock.restore();
+  }
 });
 
 test('handleJuditWebhook persists data retrievable via list helpers', async (t) => {


### PR DESCRIPTION
## Summary
- allow the manual Judit sync endpoint to accept a withAttachments flag and pass it to the service layer
- default Judit request payloads to include attachments and update automatic triggers to match
- add coverage for attachment preferences in the Judit process service tests

## Testing
- npm test *(fails: backend/tests/planPaymentController.test.ts expects 201 but received 503 in three plan payment scenarios)*

------
https://chatgpt.com/codex/tasks/task_e_68d6084dfeb88326b941afa3406a93bd