### PR TITLE
Fix Asaas base URL normalization for Asaas integration

### DIFF
--- a/backend/tests/asaasIntegrationResolver.test.ts
+++ b/backend/tests/asaasIntegrationResolver.test.ts
@@ -72,6 +72,50 @@ test('resolveAsaasIntegration prioritizes custom API URL for production', async 
   assert.equal(integration.environment, 'producao');
 });
 
+test('resolveAsaasIntegration appends API path when missing for known Asaas hosts', async () => {
+  const pool = new FakePool([
+    {
+      rowCount: 1,
+      rows: [
+        {
+          id: 4,
+          provider: 'asaas',
+          url_api: 'https://sandbox.asaas.com',
+          key_value: 'sandbox-token',
+          environment: 'homologacao',
+          active: true,
+        },
+      ],
+    },
+  ]);
+
+  const integration = await resolveAsaasIntegration(pool as any);
+
+  assert.equal(integration.baseUrl, 'https://sandbox.asaas.com/api/v3');
+});
+
+test('resolveAsaasIntegration completes API version when only /api is provided', async () => {
+  const pool = new FakePool([
+    {
+      rowCount: 1,
+      rows: [
+        {
+          id: 5,
+          provider: 'asaas',
+          url_api: 'https://sandbox.asaas.com/api/',
+          key_value: 'sandbox-token',
+          environment: 'homologacao',
+          active: true,
+        },
+      ],
+    },
+  ]);
+
+  const integration = await resolveAsaasIntegration(pool as any);
+
+  assert.equal(integration.baseUrl, 'https://sandbox.asaas.com/api/v3');
+});
+
 test('resolveAsaasIntegration throws a specific error when no active credential exists', async () => {
   const pool = new FakePool([
     {


### PR DESCRIPTION
## Summary
- ensure the Asaas integration resolver appends the API path for known Asaas hosts when missing
- extend resolver tests to cover missing /api and /api/v3 cases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60dd154548326b02acd0a7ba74f34