### PR TITLE
Fix Judit endpoint resolution for tracking URLs

### DIFF
--- a/backend/src/services/juditProcessService.ts
+++ b/backend/src/services/juditProcessService.ts
@@ -883,13 +883,19 @@ export class JuditProcessService {
       if (trimmed) {
         try {
           const base = new URL(trimmed);
-          const baseSegments = base.pathname.split('/').filter(Boolean);
+          const baseSegments = base.pathname
+            .split('/')
+            .map((segment) => segment.trim())
+            .filter(Boolean);
 
           const requestsUrl = new URL(base.href);
           requestsUrl.search = '';
           requestsUrl.hash = '';
-          const requestsSegments = baseSegments.slice();
-          if (requestsSegments[requestsSegments.length - 1] !== 'requests') {
+          requestsUrl.hostname = requestsUrl.hostname.replace(/^tracking\./i, 'requests.');
+          const requestsSegments = baseSegments
+            .filter((segment) => segment.toLowerCase() !== 'tracking');
+          const lastRequestSegment = requestsSegments[requestsSegments.length - 1];
+          if (!lastRequestSegment || lastRequestSegment.toLowerCase() !== 'requests') {
             requestsSegments.push('requests');
           }
           requestsUrl.pathname = `/${requestsSegments.join('/')}`;
@@ -897,12 +903,13 @@ export class JuditProcessService {
           const trackingUrl = new URL(base.href);
           trackingUrl.search = '';
           trackingUrl.hash = '';
-          let trackingSegments = baseSegments.slice();
-          if (/^requests\./i.test(trackingUrl.hostname)) {
-            trackingUrl.hostname = trackingUrl.hostname.replace(/^requests\./i, 'tracking.');
-            trackingSegments = [];
+          trackingUrl.hostname = trackingUrl.hostname.replace(/^requests\./i, 'tracking.');
+          const trackingSegments = baseSegments
+            .filter((segment) => segment.toLowerCase() !== 'requests');
+          const lastTrackingSegment = trackingSegments[trackingSegments.length - 1];
+          if (!lastTrackingSegment || lastTrackingSegment.toLowerCase() !== 'tracking') {
+            trackingSegments.push('tracking');
           }
-          trackingSegments.push('tracking');
           trackingUrl.pathname = `/${trackingSegments.join('/')}`;
 
           return {

--- a/backend/tests/juditProcessService.test.ts
+++ b/backend/tests/juditProcessService.test.ts
@@ -105,6 +105,54 @@ test('loadConfigurationFromSources resolves endpoints for requests host base url
   assert.equal(config?.trackingEndpoint, 'https://tracking.prod.judit.io/tracking');
 });
 
+test('loadConfigurationFromSources swaps host when base url points to tracking domain', async () => {
+  const pool = new FakePool([
+    {
+      rows: [
+        {
+          id: 77,
+          key_value: 'db-key',
+          url_api: 'https://tracking.prod.judit.io/tracking',
+        },
+      ],
+      rowCount: 1,
+    },
+  ]);
+
+  const service = new JuditProcessService(null);
+
+  const config = await (service as any).loadConfigurationFromSources(pool as unknown as any);
+
+  assert.ok(config);
+  assert.equal(config?.apiKey, 'db-key');
+  assert.equal(config?.requestsEndpoint, 'https://requests.prod.judit.io/requests');
+  assert.equal(config?.trackingEndpoint, 'https://tracking.prod.judit.io/tracking');
+});
+
+test('loadConfigurationFromSources preserves custom path segments when deriving endpoints', async () => {
+  const pool = new FakePool([
+    {
+      rows: [
+        {
+          id: 88,
+          key_value: 'db-key',
+          url_api: 'https://tracking.prod.judit.io/api/v1/tracking',
+        },
+      ],
+      rowCount: 1,
+    },
+  ]);
+
+  const service = new JuditProcessService(null);
+
+  const config = await (service as any).loadConfigurationFromSources(pool as unknown as any);
+
+  assert.ok(config);
+  assert.equal(config?.apiKey, 'db-key');
+  assert.equal(config?.requestsEndpoint, 'https://requests.prod.judit.io/api/v1/requests');
+  assert.equal(config?.trackingEndpoint, 'https://tracking.prod.judit.io/api/v1/tracking');
+});
+
 test('registerProcessRequest inserts payload and maps response', async () => {
   const insertedRow = {
     id: 101,


### PR DESCRIPTION
## Summary
- normalize Judit endpoint derivation to swap tracking hosts to requests hosts and avoid duplicate segments
- ensure custom path segments are preserved when computing Judit endpoints
- add unit tests covering tracking host and nested path scenarios

## Testing
- node --test --test-name-pattern "loadConfigurationFromSources" --import tsx tests/juditProcessService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d60e2340f08326856e5f6121c1c41e