### PR TITLE
feat: refresh Judit cron on credential changes

### DIFF
--- a/backend/src/controllers/integrationApiKeyController.ts
+++ b/backend/src/controllers/integrationApiKeyController.ts
@@ -6,6 +6,7 @@ import IntegrationApiKeyService, {
 } from '../services/integrationApiKeyService';
 import IntegrationApiKeyValidationService from '../services/integrationApiKeyValidationService';
 import juditProcessService from '../services/juditProcessService';
+import cronJobs from '../services/cronJobs';
 
 const service = new IntegrationApiKeyService();
 const validationService = new IntegrationApiKeyValidationService();
@@ -123,6 +124,7 @@ export async function createIntegrationApiKey(req: Request, res: Response) {
 
     const created = await service.create(input);
     juditProcessService.invalidateConfigurationCache();
+    await cronJobs.refreshJuditIntegration();
     return res.status(201).json(created);
   } catch (error) {
     if (error instanceof ValidationError) {
@@ -178,6 +180,7 @@ export async function updateIntegrationApiKey(req: Request, res: Response) {
       return res.status(404).json({ error: 'API key not found' });
     }
     juditProcessService.invalidateConfigurationCache();
+    await cronJobs.refreshJuditIntegration();
     return res.json(updated);
   } catch (error) {
     if (error instanceof ValidationError) {
@@ -201,6 +204,7 @@ export async function deleteIntegrationApiKey(req: Request, res: Response) {
       return res.status(404).json({ error: 'API key not found' });
     }
     juditProcessService.invalidateConfigurationCache();
+    await cronJobs.refreshJuditIntegration();
     return res.status(204).send();
   } catch (error) {
     console.error('Failed to delete integration API key:', error);

--- a/backend/src/services/cronJobs.ts
+++ b/backend/src/services/cronJobs.ts
@@ -171,6 +171,10 @@ export class CronJobsService {
     void this.initializeJuditIntegration();
   }
 
+  async refreshJuditIntegration(): Promise<void> {
+    await this.initializeJuditIntegration();
+  }
+
   startProjudiSyncJob(): void {
     if (!this.projudiService.hasValidConfiguration()) {
       this.stopProjudiSyncJob();

--- a/backend/tests/cronJobs.test.ts
+++ b/backend/tests/cronJobs.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { CronJobsService } from '../src/services/cronJobs';
+import juditProcessService from '../src/services/juditProcessService';
+
+const waitForAsyncTasks = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+let sequence: boolean[] = [];
+let fallbackState = false;
+
+const isEnabledMock = test.mock.method(juditProcessService, 'isEnabled', async () => {
+  if (sequence.length > 0) {
+    return sequence.shift()!;
+  }
+  return fallbackState;
+});
+
+test.after(() => {
+  isEnabledMock.mock.restore();
+});
+
+const createCronJobs = (states: boolean[], fallback = false) => {
+  sequence = [...states];
+  fallbackState = fallback;
+
+  const projudiStub = {
+    hasValidConfiguration: () => false,
+  };
+
+  const asaasStub = {
+    hasValidConfiguration: () => false,
+  };
+
+  return new CronJobsService(projudiStub as any, asaasStub as any);
+};
+
+test('refreshJuditIntegration schedules timers when integration is enabled', async () => {
+  const cron = createCronJobs([false, true, true, true, true], false);
+
+  await waitForAsyncTasks();
+  await cron.refreshJuditIntegration();
+  await waitForAsyncTasks();
+
+  const schedules = (cron as any).juditSchedules as Array<{
+    timer: ReturnType<typeof setTimeout> | null;
+    nextRunAt: Date | null;
+  }>;
+
+  assert.equal(schedules.length, 3);
+
+  for (const schedule of schedules) {
+    assert.notEqual(schedule.timer, null, 'Expected Judit timer to be armed');
+    assert.ok(schedule.nextRunAt instanceof Date, 'Expected Judit schedule to have next run');
+  }
+
+  sequence = [false];
+  await cron.refreshJuditIntegration();
+  await waitForAsyncTasks();
+});
+
+test('refreshJuditIntegration clears timers when integration is disabled', async () => {
+  const cron = createCronJobs([true, true, true, true], false);
+
+  await waitForAsyncTasks();
+
+  const schedules = (cron as any).juditSchedules as Array<{
+    timer: ReturnType<typeof setTimeout> | null;
+    nextRunAt: Date | null;
+  }>;
+
+  assert.equal(schedules.length, 3);
+
+  for (const schedule of schedules) {
+    assert.notEqual(schedule.timer, null, 'Expected Judit timer to be armed before disabling');
+    assert.ok(schedule.nextRunAt instanceof Date, 'Expected Judit schedule to have next run before disabling');
+  }
+
+  sequence = [false];
+  await cron.refreshJuditIntegration();
+  await waitForAsyncTasks();
+
+  for (const schedule of schedules) {
+    assert.equal(schedule.timer, null, 'Expected Judit timer to be cleared when disabled');
+    assert.equal(schedule.nextRunAt, null, 'Expected Judit schedule to lose next run when disabled');
+  }
+});


### PR DESCRIPTION
## Summary
- expose a public cron job helper to reinitialize Judit scheduling when configuration changes
- refresh Judit timers after creating, updating, or deleting integration API keys
- cover the new refresh flow with targeted cron job tests to ensure timers arm and clear appropriately

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d618a47ae88326991ddb21f15c54da