### PR TITLE
Fix duplicate withAttachmentsFlag declaration

### DIFF
--- a/backend/src/controllers/juditProcessController.ts
+++ b/backend/src/controllers/juditProcessController.ts
@@ -230,9 +230,6 @@ export const triggerManualJuditSync = async (req: Request, res: Response) => {
     const withAttachmentsFlag = parseOptionalBoolean(withAttachmentsValue);
 
     const onDemandFlag = parseOptionalBoolean(body.onDemand ?? body.on_demand);
-    const withAttachmentsFlag = parseOptionalBoolean(
-      body.withAttachments ?? body.with_attachments,
-    );
 
     const requestRecord = await juditProcessService.triggerRequestForProcess(
       processo.id,


### PR DESCRIPTION
## Summary
- remove the duplicate declaration of the `withAttachmentsFlag` variable in the Judit manual sync controller so the backend build succeeds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d61f4fb7c88326aba750f701bb5775