### PR TITLE
Fix duplicate payload declarations in manual sync flow

### DIFF
--- a/frontend/src/pages/operator/Processos.tsx
+++ b/frontend/src/pages/operator/Processos.tsx
@@ -1788,14 +1788,14 @@ export default function Processos() {
       setSyncErrors((prev) => ({ ...prev, [processoToSync.id]: null }));
 
       try {
-        const payload: Record<string, unknown> = {};
+        const requestPayload: Record<string, unknown> = {};
 
         if (typeof flags?.withAttachments === "boolean") {
-          payload.withAttachments = flags.withAttachments;
+          requestPayload.withAttachments = flags.withAttachments;
         }
 
         if (typeof flags?.onDemand === "boolean") {
-          payload.onDemand = flags.onDemand;
+          requestPayload.onDemand = flags.onDemand;
         }
 
         const res = await fetch(getApiUrl(`processos/${processoToSync.id}/judit/sync`), {
@@ -1804,7 +1804,7 @@ export default function Processos() {
             Accept: "application/json",
             "Content-Type": "application/json",
           },
-          body: JSON.stringify(payload),
+          body: JSON.stringify(requestPayload),
         });
 
         const text = await res.text();
@@ -1829,13 +1829,13 @@ export default function Processos() {
           throw new Error(message);
         }
 
-        const payload = (json ?? {}) as {
+        const responsePayload = (json ?? {}) as {
           tracking?: Record<string, unknown> | null;
           request?: ApiProcessoJuditRequest | null;
         };
 
-        const trackingRecord = toRecord(payload.tracking ?? null);
-        const requestMapped = mapApiJuditRequest(payload.request ?? null);
+        const trackingRecord = toRecord(responsePayload.tracking ?? null);
+        const requestMapped = mapApiJuditRequest(responsePayload.request ?? null);
 
         let trackingSummary = processoToSync.trackingSummary;
         let responseData = processoToSync.responseData;


### PR DESCRIPTION
## Summary
- rename the request payload for the manual sync handler to avoid conflicting identifiers
- rename the parsed response payload to clarify its purpose and prevent duplicate declarations
- update downstream references to use the new variable names

## Testing
- `npm --prefix frontend run build` *(fails: `vite: not found` in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d622c1747c8326b284b657ad14e457