### PR TITLE
Fix Judit tracking payload format

### DIFF
--- a/backend/src/services/juditProcessService.ts
+++ b/backend/src/services/juditProcessService.ts
@@ -1154,7 +1154,13 @@ export class JuditProcessService {
 
     return this.requestWithRetry<JuditTrackingResponse>(resolvedConfig, resolvedConfig.trackingEndpoint, {
       method: 'POST',
-      body: JSON.stringify({ process_number: processNumber, recurrence: 1 }),
+      body: JSON.stringify({
+        search: {
+          search_type: 'lawsuit_cnj',
+          search_key: processNumber,
+        },
+        recurrence: 1,
+      }),
     });
   }
 
@@ -1167,7 +1173,13 @@ export class JuditProcessService {
     const url = `${resolvedConfig.trackingEndpoint}/${encodeURIComponent(trackingId)}`;
     return this.requestWithRetry<JuditTrackingResponse>(resolvedConfig, url, {
       method: 'PUT',
-      body: JSON.stringify({ process_number: processNumber, recurrence: 1 }),
+      body: JSON.stringify({
+        search: {
+          search_type: 'lawsuit_cnj',
+          search_key: processNumber,
+        },
+        recurrence: 1,
+      }),
     });
   }
 

--- a/backend/tests/juditProcessService.test.ts
+++ b/backend/tests/juditProcessService.test.ts
@@ -464,7 +464,11 @@ test('ensureTrackingForProcess creates tracking via Judit API', async (t) => {
     assert.equal(url, 'https://tracking.prod.judit.io/tracking');
     assert.equal(init?.method, 'POST');
     const body = JSON.parse((init?.body ?? '{}') as string);
-    assert.equal(body.process_number, '0000000-00.0000.0.00.0000');
+    assert.deepStrictEqual(body.search, {
+      search_type: 'lawsuit_cnj',
+      search_key: '0000000-00.0000.0.00.0000',
+    });
+    assert.equal(body.recurrence, 1);
 
     return new Response(JSON.stringify({
       tracking_id: 'trk-123',


### PR DESCRIPTION
## Summary
- update the Judit tracking create and renew requests to send the required search payload
- adjust the Judit tracking service test to validate the new payload structure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d625081e8c8326948baaa9cf3b8bd0