### PR TITLE
Enforce JWT secret requirement outside of tests

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -37,11 +37,24 @@ Estrutura inicial do backend usando Express e TypeScript.
    npm install
    ```
 
-3. (Opcional) Execute os scripts SQL necessários para criar as tabelas usadas
+3. Defina uma chave secreta para assinar os tokens JWT antes de iniciar o
+   servidor. Durante o desenvolvimento você pode exportar uma string qualquer
+   (com pelo menos 32 caracteres aleatórios) diretamente no terminal ou criar
+   um arquivo `.env` consumido pelo `npm run dev`:
+
+   ```bash
+   export AUTH_TOKEN_SECRET="troque-por-uma-chave-segura"
+   ```
+
+   O backend também aceita as variáveis `JWT_SECRET` ou `TOKEN_SECRET`, mas em
+   qualquer ambiente diferente de `NODE_ENV=test` a aplicação será encerrada se
+   nenhuma delas estiver configurada.
+
+4. (Opcional) Execute os scripts SQL necessários para criar as tabelas usadas
    pelos módulos que deseja testar. Os arquivos estão em `sql/*.sql`. O
    projeto pode ser iniciado mesmo sem todas as tabelas, mas os endpoints que
    dependem delas retornarão erros específicos.
-4. Inicie o servidor em modo desenvolvimento. A API ficará disponível em
+5. Inicie o servidor em modo desenvolvimento. A API ficará disponível em
    `http://localhost:3001` e a documentação Swagger em
    `http://localhost:3001/api-docs`:
 

--- a/backend/dist/constants/auth.js
+++ b/backend/dist/constants/auth.js
@@ -6,7 +6,13 @@ const FALLBACK_SECRET = 'change-me-in-production';
 const FALLBACK_EXPIRATION_SECONDS = 60 * 60; // 1 hora
 const secretFromEnv = process.env.AUTH_TOKEN_SECRET || process.env.JWT_SECRET || process.env.TOKEN_SECRET;
 if (!secretFromEnv) {
-    console.warn('AUTH_TOKEN_SECRET não definido. Um valor padrão inseguro está sendo utilizado apenas para desenvolvimento.');
+    const errorMessage = 'AUTH_TOKEN_SECRET não definido. Configure uma chave segura antes de iniciar o servidor.';
+    if (process.env.NODE_ENV === 'test') {
+        console.warn(`${errorMessage} Um valor padrão inseguro está sendo utilizado apenas para o ambiente de testes.`);
+    }
+    else {
+        throw new Error(errorMessage);
+    }
 }
 exports.authConfig = {
     secret: secretFromEnv ?? FALLBACK_SECRET,

--- a/backend/src/constants/auth.ts
+++ b/backend/src/constants/auth.ts
@@ -7,9 +7,16 @@ const secretFromEnv =
   process.env.AUTH_TOKEN_SECRET || process.env.JWT_SECRET || process.env.TOKEN_SECRET;
 
 if (!secretFromEnv) {
-  console.warn(
-    'AUTH_TOKEN_SECRET não definido. Um valor padrão inseguro está sendo utilizado apenas para desenvolvimento.'
-  );
+  const errorMessage =
+    'AUTH_TOKEN_SECRET não definido. Configure uma chave segura antes de iniciar o servidor.';
+
+  if (process.env.NODE_ENV === 'test') {
+    console.warn(
+      `${errorMessage} Um valor padrão inseguro está sendo utilizado apenas para o ambiente de testes.`
+    );
+  } else {
+    throw new Error(errorMessage);
+  }
 }
 
 export const authConfig = {

--- a/backend/tests/authController.test.ts
+++ b/backend/tests/authController.test.ts
@@ -4,7 +4,7 @@ import type { Request, Response } from 'express';
 import { Pool } from 'pg';
 import { hashPassword } from '../src/utils/passwordUtils';
 
-process.env.AUTH_TOKEN_SECRET ??= 'test-secret';
+process.env.AUTH_TOKEN_SECRET = 'test-secret';
 
 let register: typeof import('../src/controllers/authController')['register'];
 let login: typeof import('../src/controllers/authController')['login'];


### PR DESCRIPTION
## Summary
- throw an error during application bootstrap when the JWT secret is missing outside the test environment
- ensure the auth controller tests provide a deterministic token secret
- document the need to configure AUTH_TOKEN_SECRET (or equivalent) before starting the backend

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6ac16c22c832684f18ae540c231a2