### PR TITLE
Secure database configuration handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,8 @@
 /index.html
 
 /.env
-/.env
 /backend/appsettings.json
 *.json
 /frontend/.env.development
-/backend/appsettings.json
-/frontend/.env.development
-/.env
+
+!backend/appsettings.example.json

--- a/backend/README.md
+++ b/backend/README.md
@@ -15,21 +15,30 @@ Estrutura inicial do backend usando Express e TypeScript.
 ### Ambiente de desenvolvimento local
 
 1. Certifique-se de ter o **Node.js 20** (ou superior) e um banco de dados
-   **PostgreSQL** acessível. O projeto já inclui um `appsettings.json`
-   configurado para a stack de desenvolvimento utilizada no Docker Compose da
-   Quantum. Ao executar o backend fora de containers, a aplicação substitui
-   automaticamente o host `base-de-dados_postgres` por `localhost`.
-   Caso precise utilizar outro hostname local, defina `LOCAL_DB_HOST` antes de
+   **PostgreSQL** acessível. Antes de iniciar o servidor, informe uma
+   connection string utilizando **uma** das opções abaixo:
+
+   - Defina a variável de ambiente `DATABASE_URL` apontando para a sua base
+     local ou remota.
+   - Crie um arquivo `backend/appsettings.local.json` (ou `backend/appsettings.json`)
+     com o seguinte formato e ajuste os valores conforme a sua infraestrutura:
+
+     ```json
+     {
+       "ConnectionStrings": {
+         "DefaultConnection": "postgres://usuario:senha@localhost:5432/nomedobanco"
+       }
+     }
+     ```
+
+     Utilize o arquivo `backend/appsettings.example.json` como referência. Ele
+     é ignorado pelo Git para evitar que credenciais reais sejam versionadas.
+
+   Ao executar o backend fora de containers, a aplicação substitui
+   automaticamente o host `base-de-dados_postgres` por `localhost`. Caso
+   precise utilizar outro hostname local, defina `LOCAL_DB_HOST` antes de
    iniciar o servidor. Você também pode sobrescrever toda a conexão usando a
-   variável `DATABASE_URL`. Para o ambiente de testes/homologação padrão
-   utilize:
-
-   ```bash
-   export DATABASE_URL="postgres://postgres:C@104rm0nd1994@easypanel02.quantumtecnologia.com.br:5438/quantumtecnologia?sslmode=disable"
-   ```
-
-   Caso prefira outra instância local, substitua a string acima pela conexão
-   desejada.
+   variável `DATABASE_URL`.
 
 2. Instale as dependências do backend:
 

--- a/backend/appsettings.example.json
+++ b/backend/appsettings.example.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "postgres://postgres:postgres@localhost:5432/quantumjus"
+  }
+}

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -1,5 +1,0 @@
-{
-  "ConnectionStrings": {
-    "DefaultConnection": "postgres://postgres:C@104rm0nd1994@easypanel02.quantumtecnologia.com.br:5438/QuantumJus?sslmode=disable"
-  }
-}

--- a/backend/src/services/db.ts
+++ b/backend/src/services/db.ts
@@ -6,6 +6,8 @@ let connectionString = process.env.DATABASE_URL;
 
 if (!connectionString) {
   const configPaths = [
+    path.resolve(__dirname, '../../appsettings.local.json'),
+    path.resolve(process.cwd(), 'appsettings.local.json'),
     path.resolve(__dirname, '../../appsettings.json'),
     path.resolve(process.cwd(), 'appsettings.json'),
   ];
@@ -45,7 +47,7 @@ if (
 
 if (!connectionString) {
   throw new Error(
-    'Database connection string not provided. Set DATABASE_URL or add appsettings.json.'
+    'Database connection string not provided. Set DATABASE_URL or create appsettings.json (see appsettings.example.json).'
   );
 }
 

--- a/backend/tests/dbConfig.test.ts
+++ b/backend/tests/dbConfig.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+
+test('db service requires a local connection string', async (t) => {
+  const originalDatabaseUrl = process.env.DATABASE_URL;
+  delete process.env.DATABASE_URL;
+
+  const modulePath = require.resolve('../src/services/db');
+  delete require.cache[modulePath];
+
+  t.after(() => {
+    if (originalDatabaseUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = originalDatabaseUrl;
+    }
+
+    delete require.cache[modulePath];
+  });
+
+  await assert.rejects(async () => import('../src/services/db'), (error) => {
+    assert.match(
+      (error as Error).message,
+      /Database connection string not provided/i
+    );
+    return true;
+  });
+});


### PR DESCRIPTION
## Summary
- replace the committed appsettings.json with a safe example and ensure local copies stay untracked
- update the database service to search for local appsettings files and fail with an explicit error when no connection string is configured
- document how to configure DATABASE_URL or a local appsettings file and add a regression test that enforces the error behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6ac1a611c8326bd39b46a38fef638