### PR TITLE
Handle pending Judit manual sync requests

### DIFF
--- a/backend/src/controllers/juditProcessController.ts
+++ b/backend/src/controllers/juditProcessController.ts
@@ -267,6 +267,7 @@ export const triggerManualJuditSync = async (req: Request, res: Response) => {
       {
         source: 'manual',
         actorUserId: req.auth.userId,
+        skipIfPending: true,
         onDemand: onDemandFlag,
         withAttachments: withAttachmentsFlag,
       }


### PR DESCRIPTION
## Summary
- ensure the manual Judit sync controller passes the skip-if-pending flag so existing requests are reused
- add controller and service tests that verify pending manual requests are returned instead of inserting new sync records

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6c0c8a88c8326bde4063426630f0d