### PR TITLE
Adjust Judit response parsing for root-level metadata

### DIFF
--- a/frontend/src/pages/operator/utils/judit.test.ts
+++ b/frontend/src/pages/operator/utils/judit.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { parseResponseDataFromResult } from "./judit";
+
+describe("parseResponseDataFromResult", () => {
+  it("fallbacks to root payload metadata when response_data is missing", () => {
+    const payload = {
+      numero_processo: "123",
+      status: "Ativo",
+      fonte: "Judit",
+    };
+
+    const parsed = parseResponseDataFromResult(payload);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.raw).toEqual(payload);
+    expect(parsed?.metadata).toMatchObject({
+      numero_processo: "123",
+      status: "Ativo",
+      fonte: "Judit",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- allow parseResponseDataFromResult to interpret Judit payloads whose fields live at the root or in result
- ensure metadata includes sanitized root-level information for existing UI consumers
- add a regression test covering the root-level metadata fallback behaviour

## Testing
- npm test -- src/pages/operator/utils/judit.test.ts *(fails: vitest not found because dependencies are unavailable in the execution environment)*
- npm install *(fails: 403 Forbidden when fetching vitest from the registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d700a553588326a57eff43dd5b642f