### PR TITLE
Support integration API keys scoped by company

### DIFF
--- a/backend/sql/integration_api_keys.sql
+++ b/backend/sql/integration_api_keys.sql
@@ -2,18 +2,25 @@
 CREATE TABLE IF NOT EXISTS integration_api_keys (
   id BIGSERIAL PRIMARY KEY,
   provider TEXT NOT NULL CHECK (provider IN ('gemini', 'openai', 'asaas', 'judit')),
-  url_api TEXT,
-  key_value TEXT NOT NULL,
   url_api TEXT NULL,
+  key_value TEXT NOT NULL,
   environment TEXT NOT NULL CHECK (environment IN ('producao', 'homologacao')),
   active BOOLEAN NOT NULL DEFAULT TRUE,
   last_used TIMESTAMPTZ NULL,
+  idempresa BIGINT REFERENCES public.empresas(id),
+  global BOOLEAN NOT NULL DEFAULT FALSE,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 ALTER TABLE integration_api_keys
   ADD COLUMN IF NOT EXISTS url_api TEXT;
+
+ALTER TABLE integration_api_keys
+  ADD COLUMN IF NOT EXISTS idempresa BIGINT REFERENCES public.empresas(id);
+
+ALTER TABLE integration_api_keys
+  ADD COLUMN IF NOT EXISTS global BOOLEAN NOT NULL DEFAULT FALSE;
 
 ALTER TABLE integration_api_keys
   DROP CONSTRAINT IF EXISTS integration_api_keys_provider_check;
@@ -28,6 +35,14 @@ CREATE INDEX IF NOT EXISTS idx_integration_api_keys_provider
 CREATE INDEX IF NOT EXISTS idx_integration_api_keys_active
   ON integration_api_keys (active)
   WHERE active IS TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_integration_api_keys_global_true
+  ON integration_api_keys (provider)
+  WHERE global IS TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_integration_api_keys_idempresa
+  ON integration_api_keys (idempresa)
+  WHERE idempresa IS NOT NULL;
 
 -- Atualiza automaticamente o campo updated_at a cada modificação
 CREATE OR REPLACE FUNCTION set_integration_api_keys_updated_at()


### PR DESCRIPTION
## Summary
- add company ownership and global flag columns and indexes to the integration_api_keys schema
- persist and expose empresaId/global fields through the integration API key service
- extend integration API key service tests to cover the new columns

## Testing
- npm test --prefix backend

------
https://chatgpt.com/codex/tasks/task_e_68d70c4183888326b8cda30756edba09