### PR TITLE
Fix attachment title fallback for Judit documents

### DIFF
--- a/frontend/src/pages/operator/VisualizarProcesso.tsx
+++ b/frontend/src/pages/operator/VisualizarProcesso.tsx
@@ -876,6 +876,7 @@ export function ProcessoAttachmentsSection({
                   parseOptionalString(anexo.titulo) ??
                   parseOptionalString(anexo.title) ??
                   parseOptionalString(anexo.nome) ??
+                  parseOptionalString(anexo.attachment_name ?? anexo.attachmentName) ??
                   `Anexo ${index + 1 + (currentPage - 1) * pageSize}`;
                 const links = normalizeDocumentoLinks(
                   buildDocumentoLinksMap(


### PR DESCRIPTION
## Summary
- ensure ProcessoAttachmentsSection resolves Judit attachment names before falling back to generic labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7120a27a08326a4f0f0672d5e127a