### PR TITLE
Filter interested parties in operator views

### DIFF
--- a/frontend/src/pages/operator/Processos.tsx
+++ b/frontend/src/pages/operator/Processos.tsx
@@ -83,6 +83,7 @@ import {
   type ProcessoTrackingSummary,
 } from "./utils/judit";
 import { renderMetadataEntries } from "./components/metadata-renderer";
+import { filtrarPartesInteressadas } from "./utils/partes";
 
 interface ProcessoCliente {
   id: number;
@@ -1911,9 +1912,12 @@ export default function Processos() {
                 : `${processo.movimentacoesCount} movimentações registradas`;
             const trackingPhase = processo.trackingSummary?.phase?.trim() || null;
             const trackingTags = processo.trackingSummary?.tags ?? [];
-              const trackingLastStep = processo.trackingSummary?.lastStep ?? null;
-              const trackingLastStepLabel =
-                trackingLastStep?.label ?? trackingLastStep?.name ?? null;
+            const partesInteressadas = processo.responseData?.partes
+              ? filtrarPartesInteressadas(processo.responseData.partes)
+              : [];
+            const trackingLastStep = processo.trackingSummary?.lastStep ?? null;
+            const trackingLastStepLabel =
+              trackingLastStep?.label ?? trackingLastStep?.name ?? null;
               const trackingLastStepDescription = trackingLastStep?.description ?? null;
               const trackingLastStepUpdatedAt = trackingLastStep?.updatedAt ?? null;
               const trackingLastStepContent = trackingLastStepLabel ? (
@@ -2198,18 +2202,19 @@ export default function Processos() {
                             </dl>
                           </div>
                         ) : null}
-                        {processo.responseData.partes.length > 0 ? (
+                        {processo.responseData.partes ? (
                           <div className="rounded-lg border border-dashed border-border/60 bg-muted/40 p-4">
                             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                               Partes identificadas
                             </p>
                             <div className="mt-3 space-y-3">
-                              {processo.responseData.partes.map((parte, index) => {
-                                const parteNome =
-                                  parseOptionalString(parte.nome) ??
-                                  parseOptionalString(parte.name) ??
-                                  parseOptionalString(parte.parte) ??
-                                  `Parte ${index + 1}`;
+                              {partesInteressadas.length > 0 ? (
+                                partesInteressadas.map((parte, index) => {
+                                  const parteNome =
+                                    parseOptionalString(parte.nome) ??
+                                    parseOptionalString(parte.name) ??
+                                    parseOptionalString(parte.parte) ??
+                                    `Parte ${index + 1}`;
                                 const ignoredKeys = new Set([
                                   "nome",
                                   "name",
@@ -2260,8 +2265,13 @@ export default function Processos() {
                                         })}
                                     </dl>
                                   </div>
-                                );
-                              })}
+                                  );
+                                })
+                              ) : (
+                                <p className="text-sm text-muted-foreground">
+                                  Nenhuma parte interessada foi identificada.
+                                </p>
+                              )}
                             </div>
                           </div>
                         ) : null}

--- a/frontend/src/pages/operator/VisualizarProcesso.tsx
+++ b/frontend/src/pages/operator/VisualizarProcesso.tsx
@@ -57,6 +57,7 @@ import {
   type ProcessoResponseData,
   type ProcessoTrackingSummary,
 } from "./utils/judit";
+import { filtrarPartesInteressadas } from "./utils/partes";
 import { renderMetadataEntries } from "./components/metadata-renderer";
 
 interface ApiProcessoCliente {
@@ -1162,6 +1163,14 @@ export default function VisualizarProcesso() {
     return anexos.slice(start, end);
   }, [anexos, attachmentsPage, attachmentsPageSize, totalAttachments]);
 
+  const partesInteressadas = useMemo(() => {
+    if (!processo?.responseData?.partes) {
+      return [];
+    }
+
+    return filtrarPartesInteressadas(processo.responseData.partes);
+  }, [processo?.responseData?.partes]);
+
   const handleAttachmentsPageChange = useCallback(
     (page: number) => {
       setAttachmentsPage((current) => {
@@ -1413,70 +1422,76 @@ export default function VisualizarProcesso() {
                           </dl>
                         </div>
                       ) : null}
-                      {processo.responseData.partes.length > 0 ? (
+                      {processo.responseData.partes ? (
                         <div className="rounded-lg border border-dashed border-border/60 bg-muted/40 p-4">
                           <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                             Partes identificadas
                           </p>
                           <div className="mt-3 space-y-3">
-                            {processo.responseData.partes.map((parte, index) => {
-                              const parteNome =
-                                parseOptionalString(parte.nome) ??
-                                parseOptionalString(parte.name) ??
-                                parseOptionalString(parte.parte) ??
-                                `Parte ${index + 1}`;
-                              const ignoredKeys = new Set([
-                                "nome",
-                                "name",
-                                "parte",
-                                "id",
-                              ]);
-                              return (
-                                <div
-                                  key={`${processo.id}-parte-${index}-${parteNome}`}
-                                  className="rounded-md border border-border/40 bg-background/60 p-3"
-                                >
-                                  <p className="text-sm font-medium text-foreground">{parteNome}</p>
-                                  <dl className="mt-2 grid gap-2 sm:grid-cols-2">
-                                    {Object.entries(parte)
-                                      .filter(([key]) => !ignoredKeys.has(key))
-                                      .map(([key, value]) => {
-                                        const formattedValue = formatResponseValue(value);
-                                        const isStructured = isMetadataEntryList(formattedValue);
-                                        const entryKey = `${processo.id}-parte-${index}-${key}`;
+                            {partesInteressadas.length > 0 ? (
+                              partesInteressadas.map((parte, index) => {
+                                const parteNome =
+                                  parseOptionalString(parte.nome) ??
+                                  parseOptionalString(parte.name) ??
+                                  parseOptionalString(parte.parte) ??
+                                  `Parte ${index + 1}`;
+                                const ignoredKeys = new Set([
+                                  "nome",
+                                  "name",
+                                  "parte",
+                                  "id",
+                                ]);
+                                return (
+                                  <div
+                                    key={`${processo.id}-parte-${index}-${parteNome}`}
+                                    className="rounded-md border border-border/40 bg-background/60 p-3"
+                                  >
+                                    <p className="text-sm font-medium text-foreground">{parteNome}</p>
+                                    <dl className="mt-2 grid gap-2 sm:grid-cols-2">
+                                      {Object.entries(parte)
+                                        .filter(([key]) => !ignoredKeys.has(key))
+                                        .map(([key, value]) => {
+                                          const formattedValue = formatResponseValue(value);
+                                          const isStructured = isMetadataEntryList(formattedValue);
+                                          const entryKey = `${processo.id}-parte-${index}-${key}`;
 
-                                        return (
-                                          <div key={entryKey} className="space-y-1">
-                                            <dt className="text-[11px] uppercase tracking-wide text-muted-foreground">
-                                              {formatResponseKey(key)}
-                                            </dt>
-                                            <dd
-                                              className={cn(
-                                                "break-words",
-                                                isStructured
-                                                  ? "text-foreground"
-                                                  : "text-xs text-foreground",
-                                              )}
-                                            >
-                                              {isStructured
-                                                ? renderMetadataEntries(formattedValue, {
-                                                    keyPrefix: entryKey,
-                                                    containerClassName: "space-y-2",
-                                                    nestedContainerClassName: "space-y-2",
-                                                    valueClassName:
-                                                      "text-xs text-foreground break-words",
-                                                    nestedValueClassName:
-                                                      "text-[11px] text-foreground/90 break-words",
-                                                  })
-                                                : formattedValue}
-                                            </dd>
-                                          </div>
-                                        );
-                                      })}
-                                  </dl>
-                                </div>
-                              );
-                            })}
+                                          return (
+                                            <div key={entryKey} className="space-y-1">
+                                              <dt className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                                                {formatResponseKey(key)}
+                                              </dt>
+                                              <dd
+                                                className={cn(
+                                                  "break-words",
+                                                  isStructured
+                                                    ? "text-foreground"
+                                                    : "text-xs text-foreground",
+                                                )}
+                                              >
+                                                {isStructured
+                                                  ? renderMetadataEntries(formattedValue, {
+                                                      keyPrefix: entryKey,
+                                                      containerClassName: "space-y-2",
+                                                      nestedContainerClassName: "space-y-2",
+                                                      valueClassName:
+                                                        "text-xs text-foreground break-words",
+                                                      nestedValueClassName:
+                                                        "text-[11px] text-foreground/90 break-words",
+                                                    })
+                                                  : formattedValue}
+                                              </dd>
+                                            </div>
+                                          );
+                                        })}
+                                    </dl>
+                                  </div>
+                                );
+                              })
+                            ) : (
+                              <p className="text-sm text-muted-foreground">
+                                Nenhuma parte interessada foi identificada.
+                              </p>
+                            )}
                           </div>
                         </div>
                       ) : null}

--- a/frontend/src/pages/operator/utils/partes.test.ts
+++ b/frontend/src/pages/operator/utils/partes.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { isParteInteressada, filtrarPartesInteressadas } from "./partes";
+
+describe("isParteInteressada", () => {
+  it("identifica partes interessadas com base no campo role", () => {
+    const parte = { nome: "Maria", role: "Parte Interessada" };
+
+    expect(isParteInteressada(parte)).toBe(true);
+  });
+
+  it("identifica partes interessadas com base em campos aninhados", () => {
+    const parte = {
+      nome: "Empresa X",
+      detalhes: {
+        participacao: "Interessada Principal",
+      },
+    };
+
+    expect(isParteInteressada(parte)).toBe(true);
+  });
+
+  it("reconhece indicadores booleanos fornecidos pelo backend", () => {
+    const parte = { nome: "Carlos", is_interested: true };
+
+    expect(isParteInteressada(parte)).toBe(true);
+  });
+
+  it("considera arrays com descrições de interesse", () => {
+    const parte = {
+      nome: "Fulano",
+      labels: ["Testemunha", "Parte Interessada"],
+    };
+
+    expect(isParteInteressada(parte)).toBe(true);
+  });
+
+  it("retorna falso quando nenhum indicador é encontrado", () => {
+    const parte = { nome: "Beltrano", role: "Autor" };
+
+    expect(isParteInteressada(parte)).toBe(false);
+  });
+});
+
+describe("filtrarPartesInteressadas", () => {
+  it("filtra apenas as partes interessadas", () => {
+    const partes = [
+      { nome: "Maria", role: "Parte Interessada" },
+      { nome: "João", role: "Réu" },
+      { nome: "Empresa X", detalhes: { participacao: "Interessada" } },
+    ];
+
+    expect(filtrarPartesInteressadas(partes)).toEqual([
+      { nome: "Maria", role: "Parte Interessada" },
+      { nome: "Empresa X", detalhes: { participacao: "Interessada" } },
+    ]);
+  });
+});
+

--- a/frontend/src/pages/operator/utils/partes.ts
+++ b/frontend/src/pages/operator/utils/partes.ts
@@ -1,0 +1,116 @@
+const INTERESTED_KEY_INDICATOR_SUBSTRINGS = ["interess", "interest"];
+
+const INTERESTED_KEY_CANDIDATES = [
+  "role",
+  "papel",
+  "tipo",
+  "type",
+  "participacao",
+  "participation",
+  "funcao",
+  "side",
+  "categoria",
+  "category",
+  "qualificacao",
+  "classification",
+  "identificador",
+  "identifier",
+  "descricao",
+  "description",
+  "etiqueta",
+  "label",
+];
+
+const INTERESTED_VALUE_IDENTIFIERS = ["interess", "interest"];
+
+const BOOLEAN_TRUE_VALUES = new Set(["true", "1", "sim", "yes"]);
+
+const isInterestedKey = (key: string): boolean => {
+  const normalizedKey = key.toLowerCase();
+
+  if (
+    INTERESTED_KEY_INDICATOR_SUBSTRINGS.some((substring) =>
+      normalizedKey.includes(substring),
+    )
+  ) {
+    return true;
+  }
+
+  return INTERESTED_KEY_CANDIDATES.some((candidate) =>
+    normalizedKey === candidate ||
+    normalizedKey.endsWith(`_${candidate}`) ||
+    normalizedKey.includes(candidate),
+  );
+};
+
+const stringMatchesInterested = (value: string): boolean => {
+  const normalizedValue = value.toLowerCase();
+
+  return INTERESTED_VALUE_IDENTIFIERS.some((identifier) =>
+    normalizedValue.includes(identifier),
+  );
+};
+
+const coerceBoolean = (value: unknown): boolean => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return value === 1;
+  }
+
+  if (typeof value === "string") {
+    return BOOLEAN_TRUE_VALUES.has(value.trim().toLowerCase());
+  }
+
+  return false;
+};
+
+const valueContainsInterested = (
+  value: unknown,
+  allowBooleanMatches: boolean,
+): boolean => {
+  if (typeof value === "string") {
+    return stringMatchesInterested(value) ||
+      (allowBooleanMatches && coerceBoolean(value));
+  }
+
+  if (typeof value === "boolean" || typeof value === "number") {
+    return allowBooleanMatches && coerceBoolean(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => valueContainsInterested(item, allowBooleanMatches));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).some(
+      ([nestedKey, nestedValue]) =>
+        valueContainsInterested(
+          nestedValue,
+          allowBooleanMatches || isInterestedKey(nestedKey),
+        ),
+    );
+  }
+
+  return false;
+};
+
+export const isParteInteressada = (parte: unknown): boolean => {
+  if (!parte || typeof parte !== "object") {
+    return false;
+  }
+
+  return Object.entries(parte as Record<string, unknown>).some(
+    ([key, value]) =>
+      valueContainsInterested(value, isInterestedKey(key)) ||
+      (typeof value === "string" && stringMatchesInterested(value)),
+  );
+};
+
+export const filtrarPartesInteressadas = <T extends unknown>(
+  partes: T[],
+): T[] =>
+  partes.filter((parte) => isParteInteressada(parte));
+


### PR DESCRIPTION
## Summary
- add a shared helper to detect partes interessadas from varying API payloads and cover it with unit tests
- filter Judit party data in operator process detail and list views before rendering, surfacing a fallback message when none are found

## Testing
- pnpm test *(fails: vitest binary missing because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d712257dc88326bc471223c86033a8