### PR TITLE
Restrict systemic integrations to global credentials with fallbacks

### DIFF
--- a/backend/src/services/asaas/integrationResolver.ts
+++ b/backend/src/services/asaas/integrationResolver.ts
@@ -33,6 +33,23 @@ interface IntegrationRow {
   active: boolean;
 }
 
+function resolveBooleanEnv(name: string, fallback: boolean): boolean {
+  const raw = process.env[name];
+  if (typeof raw !== 'string') {
+    return fallback;
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on', 'habilitado', 'enabled'].includes(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'off', 'desabilitado', 'disabled'].includes(normalized)) {
+    return false;
+  }
+
+  return fallback;
+}
+
 function normalizeToken(token: string | null): string {
   if (!token) {
     throw new AsaasIntegrationNotConfiguredError('Active Asaas credential is missing access token');
@@ -45,20 +62,49 @@ function normalizeToken(token: string | null): string {
 }
 
 export async function resolveAsaasIntegration(db: Queryable = pool): Promise<AsaasIntegration> {
-  const result = await db.query(
+  const allowLegacyFallback = resolveBooleanEnv('ASAAS_ALLOW_LEGACY_CREDENTIAL_FALLBACK', true);
+
+  const globalResult = await db.query(
     `SELECT id, provider, url_api, key_value, environment, active
      FROM integration_api_keys
-     WHERE provider = $1 AND active = TRUE
+     WHERE provider = $1 AND active = TRUE AND global IS TRUE
      ORDER BY updated_at DESC
      LIMIT 1`,
     ['asaas'],
   );
 
-  if (!result.rowCount) {
-    throw new AsaasIntegrationNotConfiguredError();
+  let row: IntegrationRow | null = null;
+
+  if (globalResult.rowCount > 0) {
+    row = globalResult.rows[0] as IntegrationRow;
+  } else {
+    if (!allowLegacyFallback) {
+      console.warn('[Asaas] Nenhuma credencial global encontrada e fallback legado está desabilitado.');
+      throw new AsaasIntegrationNotConfiguredError();
+    }
+
+    console.warn('[Asaas] Nenhuma credencial global encontrada. Aplicando fallback legado.');
+
+    const legacyResult = await db.query(
+      `SELECT id, provider, url_api, key_value, environment, active
+       FROM integration_api_keys
+       WHERE provider = $1 AND active = TRUE
+       ORDER BY updated_at DESC
+       LIMIT 1`,
+      ['asaas'],
+    );
+
+    if (!legacyResult.rowCount) {
+      console.warn('[Asaas] Fallback legado não encontrou credenciais ativas para o Asaas.');
+      throw new AsaasIntegrationNotConfiguredError();
+    }
+
+    row = legacyResult.rows[0] as IntegrationRow;
   }
 
-  const row = result.rows[0] as IntegrationRow;
+  if (!row) {
+    throw new AsaasIntegrationNotConfiguredError();
+  }
 
   const environment = normalizeAsaasEnvironment(row.environment);
   const baseUrl = normalizeAsaasBaseUrl(environment, row.url_api);


### PR DESCRIPTION
## Summary
- require systemic integrations (Judit and Asaas) to fetch only global credentials and add configurable legacy fallbacks with warnings
- add boolean env parsing helper and configuration cache handling to support the fallback logic
- update service tests to assert the global filter and fallback behaviours

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d712c8e9b48326b852024823b7a6e9