### PR TITLE
feat: refine partes interessadas detection

### DIFF
--- a/frontend/src/pages/operator/Processos.tsx
+++ b/frontend/src/pages/operator/Processos.tsx
@@ -1912,9 +1912,9 @@ export default function Processos() {
                 : `${processo.movimentacoesCount} movimentações registradas`;
             const trackingPhase = processo.trackingSummary?.phase?.trim() || null;
             const trackingTags = processo.trackingSummary?.tags ?? [];
-            const partesInteressadas = processo.responseData?.partes
-              ? filtrarPartesInteressadas(processo.responseData.partes)
-              : [];
+            const partesBrutas = processo.responseData?.partes;
+            const partesInteressadas = filtrarPartesInteressadas(partesBrutas);
+            const hasPartesData = partesBrutas !== undefined && partesBrutas !== null;
             const trackingLastStep = processo.trackingSummary?.lastStep ?? null;
             const trackingLastStepLabel =
               trackingLastStep?.label ?? trackingLastStep?.name ?? null;
@@ -2202,7 +2202,7 @@ export default function Processos() {
                             </dl>
                           </div>
                         ) : null}
-                        {processo.responseData.partes ? (
+                        {hasPartesData || partesInteressadas.length > 0 ? (
                           <div className="rounded-lg border border-dashed border-border/60 bg-muted/40 p-4">
                             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                               Partes identificadas

--- a/frontend/src/pages/operator/VisualizarProcesso.tsx
+++ b/frontend/src/pages/operator/VisualizarProcesso.tsx
@@ -1176,13 +1176,12 @@ export default function VisualizarProcesso() {
     return anexos.slice(start, end);
   }, [anexos, attachmentsPage, attachmentsPageSize, totalAttachments]);
 
-  const partesInteressadas = useMemo(() => {
-    if (!processo?.responseData?.partes) {
-      return [];
-    }
-
-    return filtrarPartesInteressadas(processo.responseData.partes);
-  }, [processo?.responseData?.partes]);
+  const partesBrutas = processo?.responseData?.partes;
+  const partesInteressadas = useMemo(
+    () => filtrarPartesInteressadas(partesBrutas),
+    [partesBrutas],
+  );
+  const hasPartesData = partesBrutas !== undefined && partesBrutas !== null;
 
   const handleAttachmentsPageChange = useCallback(
     (page: number) => {
@@ -1435,7 +1434,7 @@ export default function VisualizarProcesso() {
                           </dl>
                         </div>
                       ) : null}
-                      {processo.responseData.partes ? (
+                      {hasPartesData || partesInteressadas.length > 0 ? (
                         <div className="rounded-lg border border-dashed border-border/60 bg-muted/40 p-4">
                           <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                             Partes identificadas


### PR DESCRIPTION
## Summary
- enhance the partes helper to normalize varied API payloads and detect interested parties across textual, boolean, and nested indicators
- apply the shared filtering in VisualizarProcesso and Processos, ensuring the empty state message appears when no interested parties are found
- expand the unit tests covering multiple payload formats returned by the backend

## Testing
- pnpm test *(fails: vitest not available because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d714a5b58c832686546daf33652116