### PR TITLE
Restrict Asaas integrations to company scope

### DIFF
--- a/backend/src/controllers/asaasCustomerController.ts
+++ b/backend/src/controllers/asaasCustomerController.ts
@@ -49,7 +49,7 @@ export const getAsaasCustomerStatus = async (req: Request, res: Response) => {
       return res.status(404).json({ error: 'Cliente não encontrado' });
     }
 
-    const status = await asaasCustomerService.ensureCustomer(clienteId);
+    const status = await asaasCustomerService.ensureCustomer(clienteId, empresaId);
     return res.json(status);
   } catch (error) {
     console.error('Falha ao recuperar status do cliente Asaas:', error);

--- a/backend/src/controllers/clienteController.ts
+++ b/backend/src/controllers/clienteController.ts
@@ -20,11 +20,12 @@ const DEFAULT_ASAAS_STATE: AsaasCustomerState = {
 
 const triggerAsaasSync = (
   clienteId: number,
+  empresaId: number,
   payload: ClienteLocalData
 ) => {
   const runSync = async () => {
     try {
-      await asaasCustomerService.updateFromLocal(clienteId, payload);
+      await asaasCustomerService.updateFromLocal(clienteId, empresaId, payload);
     } catch (error) {
       console.error('Falha ao sincronizar cliente no Asaas:', error);
     }
@@ -204,11 +205,12 @@ export const createCliente = async (req: Request, res: Response) => {
 
     try {
       asaasIntegration = await asaasCustomerService.ensureCustomer(
-        createdCliente.id
+        createdCliente.id,
+        empresaId,
       );
 
       if (asaasIntegration.integrationActive) {
-        triggerAsaasSync(createdCliente.id, syncPayload);
+        triggerAsaasSync(createdCliente.id, empresaId, syncPayload);
       }
     } catch (syncError) {
       console.error('Falha ao preparar sincronização com Asaas:', syncError);
@@ -306,10 +308,10 @@ export const updateCliente = async (req: Request, res: Response) => {
     let asaasIntegration: AsaasCustomerState = { ...DEFAULT_ASAAS_STATE };
 
     try {
-      asaasIntegration = await asaasCustomerService.ensureCustomer(updatedCliente.id);
+      asaasIntegration = await asaasCustomerService.ensureCustomer(updatedCliente.id, empresaId);
 
       if (asaasIntegration.integrationActive) {
-        triggerAsaasSync(updatedCliente.id, syncPayload);
+        triggerAsaasSync(updatedCliente.id, empresaId, syncPayload);
       }
     } catch (syncError) {
       console.error('Falha ao preparar sincronização com Asaas:', syncError);

--- a/backend/src/controllers/planPaymentController.ts
+++ b/backend/src/controllers/planPaymentController.ts
@@ -401,7 +401,7 @@ export const createPlanPayment = async (req: Request, res: Response) => {
 
   let integration;
   try {
-    integration = await resolveAsaasIntegration();
+    integration = await resolveAsaasIntegration(empresaId);
   } catch (error) {
     if (error instanceof AsaasIntegrationNotConfiguredError) {
       res.status(503).json({ error: 'Integração com o Asaas não está configurada.' });

--- a/backend/tests/asaasCustomerService.test.ts
+++ b/backend/tests/asaasCustomerService.test.ts
@@ -13,6 +13,8 @@ test.before(async () => {
   AsaasApiError = module.AsaasApiError;
 });
 
+const EMPRESA_ID = 77;
+
 type QueryResponse = { rows: any[]; rowCount: number };
 
 type QueryCall = { text: string; values?: unknown[] };
@@ -40,7 +42,7 @@ test('ensureCustomer returns inactive state when Asaas integration is disabled',
     throw new Error('HTTP client should not be instantiated');
   });
 
-  const state = await service.ensureCustomer(10);
+  const state = await service.ensureCustomer(10, EMPRESA_ID);
   assert.deepEqual(state, {
     integrationActive: false,
     integrationApiKeyId: null,
@@ -52,6 +54,7 @@ test('ensureCustomer returns inactive state when Asaas integration is disabled',
   });
   assert.equal(pool.calls.length, 1);
   assert.match(pool.calls[0]?.text ?? '', /FROM public\.integration_api_keys/);
+  assert.deepEqual(pool.calls[0]?.values, ['asaas', EMPRESA_ID]);
 });
 
 test('updateFromLocal creates remote customer when mapping does not exist', async () => {
@@ -120,7 +123,7 @@ test('updateFromLocal creates remote customer when mapping does not exist', asyn
     uf: 'SP',
   };
 
-  const state = await service.updateFromLocal(25, localData);
+  const state = await service.updateFromLocal(25, EMPRESA_ID, localData);
 
   assert.ok(createCalled);
   assert.equal(state.integrationActive, true);
@@ -199,7 +202,7 @@ test('updateFromLocal updates existing remote customer and records responses', a
     uf: 'RJ',
   };
 
-  const state = await service.updateFromLocal(40, localData);
+  const state = await service.updateFromLocal(40, EMPRESA_ID, localData);
 
   assert.ok(updateCalled);
   assert.equal(state.status, 'synced');
@@ -270,7 +273,7 @@ test('updateFromLocal stores error information when Asaas API rejects request', 
     uf: null,
   };
 
-  const state = await service.updateFromLocal(55, localData);
+  const state = await service.updateFromLocal(55, EMPRESA_ID, localData);
 
   assert.equal(state.status, 'error');
   assert.equal(state.integrationApiKeyId, 5);

--- a/backend/tests/asaasIntegrationResolver.test.ts
+++ b/backend/tests/asaasIntegrationResolver.test.ts
@@ -22,6 +22,8 @@ class FakePool {
   }
 }
 
+const EMPRESA_ID = 42;
+
 test('resolveAsaasIntegration returns sandbox base URL when environment is homologacao', async () => {
   const pool = new FakePool([
     {
@@ -39,13 +41,13 @@ test('resolveAsaasIntegration returns sandbox base URL when environment is homol
     },
   ]);
 
-  const integration = await resolveAsaasIntegration(pool as any);
+  const integration = await resolveAsaasIntegration(EMPRESA_ID, pool as any);
 
   assert.equal(integration.accessToken, 'sandbox-token');
   assert.equal(integration.baseUrl, ASAAS_DEFAULT_BASE_URLS.homologacao);
   assert.equal(integration.environment, 'homologacao');
   assert.match(pool.calls[0].text, /FROM integration_api_keys/);
-  assert.deepEqual(pool.calls[0].params, ['asaas']);
+  assert.deepEqual(pool.calls[0].params, ['asaas', EMPRESA_ID]);
 });
 
 test('resolveAsaasIntegration prioritizes custom API URL for production', async () => {
@@ -65,7 +67,7 @@ test('resolveAsaasIntegration prioritizes custom API URL for production', async 
     },
   ]);
 
-  const integration = await resolveAsaasIntegration(pool as any);
+  const integration = await resolveAsaasIntegration(EMPRESA_ID, pool as any);
 
   assert.equal(integration.accessToken, 'live-token');
   assert.equal(integration.baseUrl, 'https://custom.asaas.com/api/v3');
@@ -89,7 +91,7 @@ test('resolveAsaasIntegration appends API path when missing for known Asaas host
     },
   ]);
 
-  const integration = await resolveAsaasIntegration(pool as any);
+  const integration = await resolveAsaasIntegration(EMPRESA_ID, pool as any);
 
   assert.equal(integration.baseUrl, 'https://sandbox.asaas.com/api/v3');
 });
@@ -111,7 +113,7 @@ test('resolveAsaasIntegration completes API version when only /api is provided',
     },
   ]);
 
-  const integration = await resolveAsaasIntegration(pool as any);
+  const integration = await resolveAsaasIntegration(EMPRESA_ID, pool as any);
 
   assert.equal(integration.baseUrl, 'https://sandbox.asaas.com/api/v3');
 });
@@ -124,7 +126,10 @@ test('resolveAsaasIntegration throws a specific error when no active credential 
     },
   ]);
 
-  await assert.rejects(() => resolveAsaasIntegration(pool as any), AsaasIntegrationNotConfiguredError);
+  await assert.rejects(
+    () => resolveAsaasIntegration(EMPRESA_ID, pool as any),
+    AsaasIntegrationNotConfiguredError,
+  );
 });
 
 test('createAsaasClient builds client instance with resolved credentials', async () => {
@@ -144,7 +149,9 @@ test('createAsaasClient builds client instance with resolved credentials', async
     },
   ]);
 
-  const client = await createAsaasClient(pool as any, { fetchImpl: async () => new Response(null, { status: 204 }) });
+  const client = await createAsaasClient(EMPRESA_ID, pool as any, {
+    fetchImpl: async () => new Response(null, { status: 204 }),
+  });
   assert.equal(typeof client, 'object');
   assert.equal(pool.calls.length, 1);
 });


### PR DESCRIPTION
## Summary
- scope Asaas integration resolution and customer sync operations by empresa
- validate Asaas charge credentials against the financial flow company and add coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d712c3d94c8326b144d4a6d65c1faf