### PR TITLE
Fix external reference handling for plan payments

### DIFF
--- a/backend/src/controllers/planPaymentController.ts
+++ b/backend/src/controllers/planPaymentController.ts
@@ -292,13 +292,11 @@ async function createFinancialFlow({
   description,
   value,
   dueDate,
-  externalReference,
   accountId,
 }: {
   description: string;
   value: number;
   dueDate: string;
-  externalReference: string;
   accountId: number | null;
 }): Promise<{ id: number; descricao: string; valor: string; vencimento: string; status: string } | null> {
   const result = await pool.query(
@@ -314,9 +312,9 @@ async function createFinancialFlow({
         external_provider,
         external_reference_id
       )
-      VALUES ('receita', $1, $2, $3, 'pendente', $4, NULL, NULL, 'asaas', $5)
+      VALUES ('receita', $1, $2, $3, 'pendente', $4, NULL, NULL, 'asaas', NULL)
       RETURNING id, descricao, valor::text AS valor, vencimento::text AS vencimento, status`,
-    [description, dueDate, value, accountId, externalReference],
+    [description, dueDate, value, accountId],
   );
 
   if (result.rowCount === 0) {
@@ -632,7 +630,6 @@ export const createPlanPayment = async (req: Request, res: Response) => {
     description,
     value: price,
     dueDate: nextDueDate,
-    externalReference,
     accountId,
   });
 

--- a/backend/tests/planPaymentController.test.ts
+++ b/backend/tests/planPaymentController.test.ts
@@ -206,12 +206,12 @@ test('createPlanPayment creates Asaas customer and stores identifier when missin
   assert.match(calls[8]?.text ?? '', /INSERT INTO financial_flows/);
   assert.ok(Array.isArray(calls[8]?.values));
   const insertValues = calls[8]?.values as unknown[];
+  assert.equal(insertValues.length, 4);
   assert.equal(insertValues[0], 'Assinatura Plano Jurídico (mensal)');
   assert.equal(typeof insertValues[1], 'string');
   assert.match(String(insertValues[1]), /^\d{4}-\d{2}-\d{2}$/);
   assert.equal(insertValues[2], 199.9);
   assert.equal(insertValues[3], 321);
-  assert.equal(typeof insertValues[4], 'string');
 
   const payload = res.body as { plan?: { id?: number }; charge?: { id?: string } };
   assert.equal(payload.plan?.id, 9);
@@ -357,12 +357,12 @@ test('createPlanPayment reuses existing Asaas customer and updates information',
   assert.match(calls[8]?.text ?? '', /INSERT INTO financial_flows/);
   assert.ok(Array.isArray(calls[8]?.values));
   const insertValues = calls[8]?.values as unknown[];
+  assert.equal(insertValues.length, 4);
   assert.equal(insertValues[0], 'Assinatura Plano Premium (mensal)');
   assert.equal(typeof insertValues[1], 'string');
   assert.match(String(insertValues[1]), /^\d{4}-\d{2}-\d{2}$/);
   assert.equal(insertValues[2], 299.9);
   assert.equal(insertValues[3], 654);
-  assert.equal(typeof insertValues[4], 'string');
 
   const payload = res.body as { charge?: { id?: string }; plan?: { id?: number } };
   assert.equal(payload.plan?.id, 5);
@@ -497,11 +497,11 @@ test('createPlanPayment forwards debit card method to AsaasChargeService', async
   assert.match(calls[8]?.text ?? '', /INSERT INTO financial_flows/);
   assert.ok(Array.isArray(calls[8]?.values));
   const insertValues = calls[8]?.values as unknown[];
+  assert.equal(insertValues.length, 4);
   assert.equal(insertValues[0], 'Assinatura Plano Plus (mensal)');
   assert.equal(typeof insertValues[1], 'string');
   assert.match(String(insertValues[1]), /^\d{4}-\d{2}-\d{2}$/);
   assert.equal(insertValues[2], 249.9);
   assert.equal(insertValues[3], 987);
-  assert.equal(typeof insertValues[4], 'string');
 });
 


### PR DESCRIPTION
## Summary
- avoid persisting the generated plan reference in the financial_flows.external_reference_id column so it stays compatible with UUID databases
- adjust plan payment controller tests to expect the reduced insert parameter list

## Testing
- npm test -- planPaymentController.test.ts *(fails: resolveAsaasIntegration fallback tests rely on legacy credential setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d71cb001b483268788eec7fde48635