### PR TITLE
Fix plan payment account UUID handling

### DIFF
--- a/backend/tests/planPaymentController.test.ts
+++ b/backend/tests/planPaymentController.test.ts
@@ -73,6 +73,7 @@ test('createPlanPayment creates Asaas customer and stores identifier when missin
     vencimento: '2024-05-10',
     status: 'pendente',
   };
+  const defaultAccountId = '123e4567-e89b-12d3-a456-426614174000';
 
   const empresaStateRow = {
     id: 45,
@@ -130,7 +131,7 @@ test('createPlanPayment creates Asaas customer and stores identifier when missin
     { rows: [{ asaas_customer_id: null }], rowCount: 1 },
     { rows: [], rowCount: 1 },
     { rows: [], rowCount: 1 },
-    { rows: [{ id: 321 }], rowCount: 1 },
+    { rows: [{ id: defaultAccountId }], rowCount: 1 },
     { rows: [financialFlowRow], rowCount: 1 },
   ]);
 
@@ -201,7 +202,7 @@ test('createPlanPayment creates Asaas customer and stores identifier when missin
   assert.match(calls[5]?.text ?? '', /UPDATE public\.empresas SET asaas_customer_id/);
   assert.deepEqual(calls[5]?.values, ['cus_new_123', 45]);
   assert.match(calls[6]?.text ?? '', /UPDATE public\.empresas/);
-  assert.match(calls[7]?.text ?? '', /SELECT id FROM public\.accounts/);
+  assert.match(calls[7]?.text ?? '', /SELECT id::text AS id FROM public\.accounts/);
   assert.deepEqual(calls[7]?.values, undefined);
   assert.match(calls[8]?.text ?? '', /INSERT INTO financial_flows/);
   assert.ok(Array.isArray(calls[8]?.values));
@@ -211,7 +212,7 @@ test('createPlanPayment creates Asaas customer and stores identifier when missin
   assert.equal(typeof insertValues[1], 'string');
   assert.match(String(insertValues[1]), /^\d{4}-\d{2}-\d{2}$/);
   assert.equal(insertValues[2], 199.9);
-  assert.equal(insertValues[3], 321);
+  assert.equal(insertValues[3], defaultAccountId);
 
   const payload = res.body as { plan?: { id?: number }; charge?: { id?: string } };
   assert.equal(payload.plan?.id, 9);
@@ -226,6 +227,7 @@ test('createPlanPayment reuses existing Asaas customer and updates information',
     vencimento: '2024-06-15',
     status: 'pendente',
   };
+  const defaultAccountId = '123e4567-e89b-12d3-a456-426614174000';
 
   const empresaStateRow = {
     id: 88,
@@ -283,7 +285,7 @@ test('createPlanPayment reuses existing Asaas customer and updates information',
     { rows: [{ asaas_customer_id: '  cus_existing_999  ' }], rowCount: 1 },
     { rows: [], rowCount: 1 },
     { rows: [], rowCount: 1 },
-    { rows: [{ id: 654 }], rowCount: 1 },
+    { rows: [{ id: defaultAccountId }], rowCount: 1 },
     { rows: [financialFlowRow], rowCount: 1 },
   ]);
 
@@ -352,7 +354,7 @@ test('createPlanPayment reuses existing Asaas customer and updates information',
   assert.match(calls[5]?.text ?? '', /UPDATE public\.empresas SET asaas_customer_id/);
   assert.deepEqual(calls[5]?.values, ['cus_existing_999', 88]);
   assert.match(calls[6]?.text ?? '', /UPDATE public\.empresas/);
-  assert.match(calls[7]?.text ?? '', /SELECT id FROM public\.accounts/);
+  assert.match(calls[7]?.text ?? '', /SELECT id::text AS id FROM public\.accounts/);
   assert.deepEqual(calls[7]?.values, undefined);
   assert.match(calls[8]?.text ?? '', /INSERT INTO financial_flows/);
   assert.ok(Array.isArray(calls[8]?.values));
@@ -362,7 +364,7 @@ test('createPlanPayment reuses existing Asaas customer and updates information',
   assert.equal(typeof insertValues[1], 'string');
   assert.match(String(insertValues[1]), /^\d{4}-\d{2}-\d{2}$/);
   assert.equal(insertValues[2], 299.9);
-  assert.equal(insertValues[3], 654);
+  assert.equal(insertValues[3], defaultAccountId);
 
   const payload = res.body as { charge?: { id?: string }; plan?: { id?: number } };
   assert.equal(payload.plan?.id, 5);
@@ -377,6 +379,7 @@ test('createPlanPayment forwards debit card method to AsaasChargeService', async
     vencimento: '2024-07-05',
     status: 'pendente',
   };
+  const defaultAccountId = '123e4567-e89b-12d3-a456-426614174000';
 
   const empresaStateRow = {
     id: 55,
@@ -434,7 +437,7 @@ test('createPlanPayment forwards debit card method to AsaasChargeService', async
     { rows: [{ asaas_customer_id: 'cus_linked_123' }], rowCount: 1 },
     { rows: [], rowCount: 1 },
     { rows: [], rowCount: 1 },
-    { rows: [{ id: 987 }], rowCount: 1 },
+    { rows: [{ id: defaultAccountId }], rowCount: 1 },
     { rows: [financialFlowRow], rowCount: 1 },
   ]);
 
@@ -492,7 +495,7 @@ test('createPlanPayment forwards debit card method to AsaasChargeService', async
   assert.equal(calls.length, 9);
   assert.match(calls[4]?.text ?? '', /SELECT asaas_customer_id FROM public\.empresas/);
   assert.match(calls[5]?.text ?? '', /UPDATE public\.empresas SET asaas_customer_id/);
-  assert.match(calls[7]?.text ?? '', /SELECT id FROM public\.accounts/);
+  assert.match(calls[7]?.text ?? '', /SELECT id::text AS id FROM public\.accounts/);
   assert.deepEqual(calls[7]?.values, undefined);
   assert.match(calls[8]?.text ?? '', /INSERT INTO financial_flows/);
   assert.ok(Array.isArray(calls[8]?.values));
@@ -502,6 +505,6 @@ test('createPlanPayment forwards debit card method to AsaasChargeService', async
   assert.equal(typeof insertValues[1], 'string');
   assert.match(String(insertValues[1]), /^\d{4}-\d{2}-\d{2}$/);
   assert.equal(insertValues[2], 249.9);
-  assert.equal(insertValues[3], 987);
+  assert.equal(insertValues[3], defaultAccountId);
 });
 


### PR DESCRIPTION
## Summary
- ensure the plan payment account ID is treated as a UUID by validating environment input and querying the database as text
- adjust plan payment controller tests to use UUID account IDs and match the updated query

## Testing
- npm run test *(fails: tests/asaasIntegrationResolver.test.ts expectations require legacy fallback configuration that is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7214e592c8326a30190975b66c355