### PR TITLE
Fix plan payment pricing mode selection

### DIFF
--- a/frontend/src/pages/operator/MeuPlano.tsx
+++ b/frontend/src/pages/operator/MeuPlano.tsx
@@ -317,6 +317,18 @@ function hasAnualPricing(plan: PlanoDetalhe | null): boolean {
   );
 }
 
+function resolvePricingModeForPlan(current: PricingMode, plan: PlanoDetalhe): PricingMode {
+  if (current === "anual" && !hasAnualPricing(plan)) {
+    return hasMensalPricing(plan) ? "mensal" : "anual";
+  }
+
+  if (current === "mensal" && !hasMensalPricing(plan)) {
+    return hasAnualPricing(plan) ? "anual" : "mensal";
+  }
+
+  return current;
+}
+
 function getDefaultPricingMode(plan: PlanoDetalhe | null): PricingMode {
   if (hasMensalPricing(plan)) {
     return "mensal";
@@ -880,15 +892,8 @@ function MeuPlanoContent() {
     (plan: PlanoDetalhe) => {
       setPreviewPlano(plan);
       setDialogOpen(false);
-      setPricingMode((current) => {
-        if (current === "anual" && !hasAnualPricing(plan)) {
-          return hasMensalPricing(plan) ? "mensal" : "anual";
-        }
-        if (current === "mensal" && !hasMensalPricing(plan)) {
-          return hasAnualPricing(plan) ? "anual" : "mensal";
-        }
-        return current;
-      });
+      const nextPricingMode = resolvePricingModeForPlan(pricingMode, plan);
+      setPricingMode(nextPricingMode);
       toast({
         title: `Plano ${plan.nome} selecionado`,
         description: "Revise as opções de pagamento para confirmar a alteração do seu plano.",
@@ -908,7 +913,7 @@ function MeuPlanoContent() {
             economiaAnual: plan.economiaAnual,
             economiaAnualFormatada: plan.economiaAnualFormatada,
           },
-          pricingMode,
+          pricingMode: nextPricingMode,
         },
       });
     },


### PR DESCRIPTION
## Summary
- ensure Meu Plano forwards a valid pricing mode when navigating to the payment screen
- add a helper to reuse the pricing-mode resolution logic for selected plans

## Testing
- pnpm test --runInBand *(fails: vitest is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d723b7d7348326af9ddc01705dcc8e