### PR TITLE
Handle financial flow UUID identifiers

### DIFF
--- a/backend/src/services/subscriptionService.ts
+++ b/backend/src/services/subscriptionService.ts
@@ -1,4 +1,5 @@
 import pool from './db';
+import { normalizeFinancialFlowIdentifier } from '../utils/financialFlowIdentifier';
 
 export const TRIAL_DURATION_DAYS = 14;
 const CADENCE_MONTHLY = 'monthly' as const;
@@ -226,8 +227,12 @@ const ensureClienteEmpresaColumn = async (): Promise<string | null> => {
   return cachedClienteEmpresaColumn;
 };
 
-export const findCompanyIdForFinancialFlow = async (financialFlowId: number): Promise<number | null> => {
-  if (!Number.isInteger(financialFlowId) || financialFlowId <= 0) {
+export const findCompanyIdForFinancialFlow = async (
+  financialFlowId: number | string,
+): Promise<number | null> => {
+  const normalizedFinancialFlowId = normalizeFinancialFlowIdentifier(financialFlowId);
+
+  if (normalizedFinancialFlowId === null) {
     return null;
   }
 
@@ -241,7 +246,7 @@ export const findCompanyIdForFinancialFlow = async (financialFlowId: number): Pr
        FROM financial_flows
       WHERE id = $1
       LIMIT 1`,
-    [financialFlowId],
+    [normalizedFinancialFlowId],
   );
 
   if (result.rowCount === 0) {

--- a/backend/src/utils/financialFlowIdentifier.ts
+++ b/backend/src/utils/financialFlowIdentifier.ts
@@ -1,0 +1,49 @@
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const DIGITS_REGEX = /^\d+$/;
+
+export function normalizeFinancialFlowIdentifier(value: unknown): number | string | null {
+  if (typeof value === 'number') {
+    return Number.isInteger(value) && value > 0 ? value : null;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    if (DIGITS_REGEX.test(trimmed)) {
+      const parsed = Number.parseInt(trimmed, 10);
+      return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+    }
+
+    if (UUID_REGEX.test(trimmed)) {
+      return trimmed;
+    }
+
+    return null;
+  }
+
+  return null;
+}
+
+export function requireFinancialFlowIdentifier(value: unknown, errorFactory?: () => Error): number | string {
+  const normalized = normalizeFinancialFlowIdentifier(value);
+  if (normalized === null) {
+    if (errorFactory) {
+      throw errorFactory();
+    }
+    throw new Error('Identificador do fluxo financeiro inválido');
+  }
+
+  return normalized;
+}
+
+export function normalizeFinancialFlowIdentifierFromRow(value: unknown): number | string {
+  const normalized = normalizeFinancialFlowIdentifier(value);
+  if (normalized === null) {
+    throw new Error('Identificador do fluxo financeiro inválido');
+  }
+
+  return normalized;
+}


### PR DESCRIPTION
## Summary
- add helpers to normalize numeric or UUID financial flow identifiers
- update charge creation, syncing, and webhook flows to validate normalized identifiers
- ensure plan payment creation and subscription lookups accept UUID financial flow IDs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7295a98a48326980c2c425aebe829