### PR TITLE
Add empresa reference column to financial flows

### DIFF
--- a/backend/dist/sql/financial_flows.sql
+++ b/backend/dist/sql/financial_flows.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS financial_flows (
   categoria_id INTEGER,
   cliente_id INTEGER,
   fornecedor_id INTEGER,
+  idempresa INTEGER REFERENCES public.empresas(id),
   descricao TEXT NOT NULL,
   vencimento DATE NOT NULL,
   pagamento DATE,
@@ -18,3 +19,26 @@ ALTER TABLE financial_flows ADD COLUMN IF NOT EXISTS external_provider TEXT;
 ALTER TABLE financial_flows ADD COLUMN IF NOT EXISTS external_reference_id TEXT;
 ALTER TABLE financial_flows ADD COLUMN IF NOT EXISTS cliente_id INTEGER;
 ALTER TABLE financial_flows ADD COLUMN IF NOT EXISTS fornecedor_id INTEGER;
+ALTER TABLE financial_flows ADD COLUMN IF NOT EXISTS idempresa INTEGER REFERENCES public.empresas(id);
+
+DO $$
+DECLARE
+  column_name TEXT;
+BEGIN
+  FOR column_name IN
+    SELECT column_name
+      FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'financial_flows'
+       AND column_name IN ('empresa_id', 'empresa')
+  LOOP
+    EXECUTE format(
+      'UPDATE public.financial_flows
+          SET idempresa = TRIM(%1$I::text)::INTEGER
+        WHERE idempresa IS NULL
+          AND %1$I IS NOT NULL
+          AND TRIM(%1$I::text) ~ ''^[0-9]+$''',
+      column_name
+    );
+  END LOOP;
+END $$;

--- a/backend/sql/financial_flows.sql
+++ b/backend/sql/financial_flows.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS financial_flows (
   categoria_id INTEGER,
   cliente_id INTEGER,
   fornecedor_id INTEGER,
+  idempresa INTEGER REFERENCES public.empresas(id),
   descricao TEXT NOT NULL,
   vencimento DATE NOT NULL,
   pagamento DATE,
@@ -18,3 +19,26 @@ ALTER TABLE financial_flows ADD COLUMN IF NOT EXISTS external_provider TEXT;
 ALTER TABLE financial_flows ADD COLUMN IF NOT EXISTS external_reference_id TEXT;
 ALTER TABLE financial_flows ADD COLUMN IF NOT EXISTS cliente_id INTEGER;
 ALTER TABLE financial_flows ADD COLUMN IF NOT EXISTS fornecedor_id INTEGER;
+ALTER TABLE financial_flows ADD COLUMN IF NOT EXISTS idempresa INTEGER REFERENCES public.empresas(id);
+
+DO $$
+DECLARE
+  column_name TEXT;
+BEGIN
+  FOR column_name IN
+    SELECT column_name
+      FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = 'financial_flows'
+       AND column_name IN ('empresa_id', 'empresa')
+  LOOP
+    EXECUTE format(
+      'UPDATE public.financial_flows
+          SET idempresa = TRIM(%1$I::text)::INTEGER
+        WHERE idempresa IS NULL
+          AND %1$I IS NOT NULL
+          AND TRIM(%1$I::text) ~ ''^[0-9]+$''',
+      column_name
+    );
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Summary
- add an idempresa column to the financial_flows table definition with a foreign key to public.empresas
- include an idempotent ALTER/DO block that backfills idempresa from existing empresa_id or empresa columns when present

## Testing
- not run (SQL-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d72d2430d483268e069314460505a0