### PR TITLE
Fix process view navigation when client id missing

### DIFF
--- a/frontend/src/pages/operator/Processos.tsx
+++ b/frontend/src/pages/operator/Processos.tsx
@@ -522,6 +522,10 @@ const createEmptyProcessForm = (): ProcessFormState => ({
 
 const mapApiProcessoToProcesso = (processo: ApiProcesso): Processo => {
   const clienteResumo = processo.cliente ?? null;
+  const clienteId =
+    parseOptionalInteger(clienteResumo?.id) ??
+    parseOptionalInteger(processo.cliente_id) ??
+    0;
   const documento = clienteResumo?.documento ?? "";
   const jurisdicao =
     processo.jurisdicao ||
@@ -622,7 +626,7 @@ const mapApiProcessoToProcesso = (processo: ApiProcesso): Processo => {
     status: statusLabel,
     tipo: processo.tipo?.trim() || "Não informado",
     cliente: {
-      id: clienteResumo?.id ?? processo.cliente_id,
+      id: clienteId,
       nome: clienteResumo?.nome ?? "Cliente não informado",
       documento: documento,
       papel: resolveClientePapel(clienteResumo?.tipo),


### PR DESCRIPTION
## Summary
- parse the client identifier from API payloads when mapping processes
- ensure process records retain a valid numeric client id so navigation to details works

## Testing
- npm run lint -- --max-warnings=0 *(fails: missing @eslint/js dependency in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d72fc05fc483268c55dfb32a0f5b31