### PR TITLE
Allow viewing processes without client context

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -160,7 +160,11 @@ const App = () => (
                 <Route path="/clientes/:id/novo-processo" element={withModule("clientes", <NovoProcesso />)} />
                 <Route
                   path="/clientes/:id/processos/:processoId"
-                  element={withModule("clientes", <VisualizarProcesso />)}
+                  element={withModule(["clientes", "processos"], <VisualizarProcesso />)}
+                />
+                <Route
+                  path="/processos/:processoId"
+                  element={withModule(["clientes", "processos"], <VisualizarProcesso />)}
                 />
                 <Route
                   path="/clientes/:id/processos/:processoId/contrato"

--- a/frontend/src/pages/operator/Processos.tsx
+++ b/frontend/src/pages/operator/Processos.tsx
@@ -522,6 +522,10 @@ const createEmptyProcessForm = (): ProcessFormState => ({
 
 const mapApiProcessoToProcesso = (processo: ApiProcesso): Processo => {
   const clienteResumo = processo.cliente ?? null;
+  const clienteId =
+    parseOptionalInteger(clienteResumo?.id) ??
+    parseOptionalInteger(processo.cliente_id) ??
+    0;
   const documento = clienteResumo?.documento ?? "";
   const jurisdicao =
     processo.jurisdicao ||
@@ -622,7 +626,7 @@ const mapApiProcessoToProcesso = (processo: ApiProcesso): Processo => {
     status: statusLabel,
     tipo: processo.tipo?.trim() || "Não informado",
     cliente: {
-      id: clienteResumo?.id ?? processo.cliente_id,
+      id: clienteId,
       nome: clienteResumo?.nome ?? "Cliente não informado",
       documento: documento,
       papel: resolveClientePapel(clienteResumo?.tipo),
@@ -1628,21 +1632,21 @@ export default function Processos() {
       processoToView: Processo,
       options?: { initialTab?: "resumo" | "historico" | "anexos" },
     ) => {
-      const clienteId = processoToView.cliente?.id ?? null;
-
-      if (!clienteId || clienteId <= 0) {
-        toast({
-          title: "Não foi possível abrir o processo",
-          description: "Cliente relacionado ao processo não identificado.",
-          variant: "destructive",
-        });
-        return;
-      }
-
       const state = options?.initialTab ? { initialTab: options.initialTab } : undefined;
       const navigateOptions = state ? { state } : undefined;
 
-      navigate(`/clientes/${clienteId}/processos/${processoToView.id}`, navigateOptions);
+      const clienteId = processoToView.cliente?.id ?? null;
+
+      if (clienteId && clienteId > 0) {
+        navigate(`/clientes/${clienteId}/processos/${processoToView.id}`, navigateOptions);
+        return;
+      }
+
+      toast({
+        title: "Cliente do processo não identificado",
+        description: "Abrindo detalhes do processo diretamente.",
+      });
+      navigate(`/processos/${processoToView.id}`, navigateOptions);
     },
     [navigate, toast],
   );


### PR DESCRIPTION
## Summary
- fall back to a direct /processos/:id route when the related client is missing
- expose a standalone process details route guarded by either the clientes or processos module
- inform the operator that the client could not be resolved while still opening the process details screen

## Testing
- npm run lint -- --max-warnings=0 *(fails: repository root has no package.json in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d72fc05fc483268c55dfb32a0f5b31