### PR TITLE
feat: alinhar VisualizarProcesso ao modelo da JUDIT

### DIFF
--- a/frontend/src/pages/operator/VisualizarProcesso.test.ts
+++ b/frontend/src/pages/operator/VisualizarProcesso.test.ts
@@ -1,91 +1,104 @@
-import { describe, expect, it } from "vitest";
+import { renderToString } from "react-dom/server";
+import { afterAll, describe, expect, it, vi } from "vitest";
 
 import {
+  InformacoesProcesso as InformacoesProcessoComponent,
+  mapApiProcessoToViewModel,
   type ApiProcessoResponse,
-  mapApiProcessoToDetalhes,
 } from "./VisualizarProcesso";
+import {
+  agruparPorMes,
+  deduplicarMovimentacoes,
+  diasDesde,
+  type MovimentoComIdEData,
+} from "./utils/processo-ui";
 
-const createMockResponse = (): ApiProcessoResponse => ({
-  id: 42,
-  numero: "0001234-56.2024.1.00.0000",
-  status: "Ativo",
-  tipo: "Cível",
-  classe_judicial: "Ação de Teste",
-  assunto: "Cobrança",
-  jurisdicao: "São Paulo - SP",
-  orgao_julgador: "1ª Vara Cível",
-  advogado_responsavel: "Dra. Teste",
-  data_distribuicao: "2024-01-15T12:30:00Z",
-  criado_em: "2024-01-16T09:00:00Z",
-  atualizado_em: "2024-01-20T10:15:00Z",
-  cliente: {
-    id: 10,
-    nome: "Cliente Exemplo",
-    documento: "123.456.789-00",
-    tipo: "PF",
-  },
-  movimentacoes: [],
-  movimentacoes_count: 0,
-  consultas_api_count: 0,
-  judit_last_request: {
-    request_id: "req-123",
-    status: "completed",
-    source: "automatic",
-    criado_em: "2024-01-21T11:00:00Z",
-    atualizado_em: "2024-01-21T11:30:00Z",
-    result: {
-      status: "completed",
-      response_data: {
-        cover: {
-          numero: "0001234-56.2024.1.00.0000",
-          classe: "Ação de Teste",
-        },
-        partes: [
-          {
-            nome: "Autor Exemplo",
-            documento: "12345678900",
-            tipo: "Autor",
-          },
-        ],
-        movimentacoes: [
-          {
-            titulo: "Distribuição",
-            data: "2024-01-15",
-            conteudo: "Processo distribuído",
-          },
-        ],
-        anexos: [
-          {
-            titulo: "Petição Inicial",
-            url: "https://exemplo.com/peticao.pdf",
-          },
-        ],
-        metadata: {
-          tribunal: "TJSP",
-          grau: "1º Grau",
-        },
-      },
-    },
-  },
+vi.useFakeTimers();
+
+afterAll(() => {
+  vi.useRealTimers();
 });
 
-describe("mapApiProcessoToDetalhes", () => {
-  it("normaliza dados da Judit quando a resposta foi concluída", () => {
-    const detalhes = mapApiProcessoToDetalhes(createMockResponse(), "42");
+describe("processo-ui utils", () => {
+  it("agruparPorMes organiza por ordem decrescente e separa desconhecidos", () => {
+    const itens: MovimentoComIdEData[] = [
+      { id: "1", data: new Date("2024-09-15") },
+      { id: "2", data: new Date("2024-09-01") },
+      { id: "3", data: new Date("2023-12-20") },
+      { id: "4", data: null },
+    ];
 
-    expect(detalhes.juditLastRequest).not.toBeNull();
-    expect(detalhes.juditLastRequest?.status).toBe("completed");
-    expect(detalhes.responseData).not.toBeNull();
-    expect(detalhes.responseData?.cover).toMatchObject({
-      numero: "0001234-56.2024.1.00.0000",
-      classe: "Ação de Teste",
-    });
-    expect(detalhes.responseData?.partes).toHaveLength(1);
-    expect(detalhes.responseData?.movimentacoes).toHaveLength(1);
-    expect(detalhes.responseData?.anexos).toHaveLength(1);
-    expect(detalhes.responseData?.metadata).toMatchObject({
-      tribunal: "TJSP",
-      grau: "1º Grau",
-    });
+    const grupos = agruparPorMes(itens);
+
+    expect(grupos).toHaveLength(3);
+    expect(grupos[0].rotulo).toBe("Setembro de 2024");
+    expect(grupos[0].itens.map((item) => item.id)).toEqual(["1", "2"]);
+    expect(grupos[1].rotulo).toBe("Dezembro de 2023");
+    expect(grupos[2].rotulo).toBe("Data desconhecida");
+    expect(grupos[2].itens[0].id).toBe("4");
+  });
+
+  it("diasDesde calcula diferença em dias corridos", () => {
+    vi.setSystemTime(new Date("2024-05-20T12:00:00Z"));
+
+    expect(diasDesde(new Date("2024-05-18T03:00:00Z"))).toBe(2);
+    expect(diasDesde("2024-05-19")).toBe(1);
+    expect(diasDesde(null)).toBeNull();
+  });
+
+  it("deduplicarMovimentacoes remove itens com mesmo id ou mesmo conteúdo", () => {
+    const lista = [
+      { id: 1, data: "2024-05-01", tipo: "Despacho", conteudo: "Texto" },
+      { id: 1, data: "2024-05-01", tipo: "Despacho", conteudo: "Texto" },
+      { id: null, data: "2024-05-02", tipo: "Decisão", conteudo: "Outro" },
+      { id: undefined, data: "2024-05-02", tipo: "Decisão", conteudo: "Outro" },
+    ];
+
+    const resultado = deduplicarMovimentacoes(lista);
+
+    expect(resultado).toHaveLength(2);
+    expect(resultado[0].id).toBe(1);
+    expect(resultado[1].tipo).toBe("Decisão");
+  });
+});
+
+describe("mapApiProcessoToViewModel", () => {
+  it("fornece dados com fallbacks e partes vazias", () => {
+    const resposta: ApiProcessoResponse = {
+      numero: null,
+      status: null,
+      tipo: null,
+      movimentacoes: [
+        { id: 10, data: "2024-03-10", tipo: "Despacho" },
+        { id: 10, data: "2024-03-10", tipo: "Despacho" },
+      ],
+      partes: [],
+    };
+
+    const viewModel = mapApiProcessoToViewModel(resposta);
+
+    expect(viewModel.cabecalho.numero).toBe("Não informado");
+    expect(viewModel.cabecalho.grau).toBe("Não informado");
+    expect(viewModel.partes.total).toBe(0);
+    expect(viewModel.dados.valorDaCausa).toBe("Não informado");
+    expect(viewModel.movimentacoes).toHaveLength(1);
+  });
+
+  it("renderiza Informações e Partes com dados faltantes", () => {
+    const resposta: ApiProcessoResponse = {
+      numero: "0001111-22.2024.1.00.0000",
+      movimentacoes: [],
+      partes: [],
+    };
+
+    const viewModel = mapApiProcessoToViewModel(resposta);
+
+    const html = renderToString(
+      <InformacoesProcessoComponent dados={viewModel.dados} partes={viewModel.partes} />,
+    );
+
+    expect(html).toContain("Dados do processo");
+    expect(html).toContain("Nenhum registro informado.");
+    expect(html).toContain("Partes do processo");
   });
 });

--- a/frontend/src/pages/operator/VisualizarProcesso.tsx
+++ b/frontend/src/pages/operator/VisualizarProcesso.tsx
@@ -1,60 +1,72 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type UIEventHandler,
+} from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
-import { AlertCircle, ArrowLeft, Clock, Newspaper } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ChevronDown,
+  ChevronUp,
+  Info,
+} from "lucide-react";
 
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/ui/pagination";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { ScrollArea } from "@/components/ui/scroll-area";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
 import { getApiUrl } from "@/lib/api";
 import { cn } from "@/lib/utils";
+
 import {
-  formatResponseKey,
+  agruparPorMes,
+  deduplicarMovimentacoes,
+  diasDesde,
+  normalizarTexto,
+} from "./utils/processo-ui";
+import {
   mapApiJuditRequest,
-  parseOptionalString,
   parseResponseDataFromResult,
-  parseTrackingSummaryFromResult,
-  type ApiProcessoJuditRequest,
   type ProcessoJuditRequest,
   type ProcessoResponseData,
-  type ProcessoTrackingSummary,
 } from "./utils/judit";
 
+const NAO_INFORMADO = "Não informado";
+const MOVIMENTACOES_POR_LAJE = 25;
+const MESES_INICIAIS = 3;
+const ALTURA_ESTIMADA_ITEM = 160;
+
 interface ApiProcessoCliente {
-  id?: number | null;
+  id?: number | string | null;
   nome?: string | null;
   documento?: string | null;
   tipo?: string | null;
@@ -65,2143 +77,1442 @@ interface ApiProcessoMovimentacao {
   data?: string | null;
   tipo?: string | null;
   tipo_publicacao?: string | null;
-  classificacao_predita?: Record<string, unknown> | null;
   conteudo?: string | null;
   texto_categoria?: string | null;
-  fonte?: Record<string, unknown> | null;
-  criado_em?: string | null;
   atualizado_em?: string | null;
+  criado_em?: string | null;
 }
 
-interface ApiProcessoOportunidade {
+interface ApiProcessoParte {
   id?: number | string | null;
-  sequencial_empresa?: number | string | null;
-  data_criacao?: string | null;
-  numero_processo_cnj?: string | null;
-  numero_protocolo?: string | null;
-  solicitante_id?: number | string | null;
-  solicitante_nome?: string | null;
+  nome?: string | null;
+  documento?: string | null;
+  cpf?: string | null;
+  cnpj?: string | null;
+  tipo?: string | null;
+  papel?: string | null;
+  polo?: string | null;
+  categoria?: string | null;
+  advogado?: string | null;
+  advogado_nome?: string | null;
+  advogados?: Array<{ nome?: string | null }> | null;
+}
+
+interface ApiProcessoRelacionado {
+  id?: number | string | null;
+  numero?: string | null;
+  grau?: string | null;
+  classe?: string | null;
 }
 
 export interface ApiProcessoResponse {
-  id?: number | null;
-  cliente_id?: number | null;
+  id?: number | string | null;
   numero?: string | null;
-  uf?: string | null;
-  municipio?: string | null;
-  orgao_julgador?: string | null;
-  tipo?: string | null;
   status?: string | null;
+  tipo?: string | null;
   classe_judicial?: string | null;
   assunto?: string | null;
+  orgao_julgador?: string | null;
   jurisdicao?: string | null;
   advogado_responsavel?: string | null;
   data_distribuicao?: string | null;
-  criado_em?: string | null;
-  atualizado_em?: string | null;
-  cliente?: ApiProcessoCliente | null;
-  oportunidade_id?: number | string | null;
-  oportunidade?: ApiProcessoOportunidade | null;
   movimentacoes?: ApiProcessoMovimentacao[] | null;
-  movimentacoes_count?: number | string | null;
+  partes?: ApiProcessoParte[] | null;
+  relacionados?: ApiProcessoRelacionado[] | null;
   consultas_api_count?: number | string | null;
   ultima_sincronizacao?: string | null;
   judit_tracking_id?: string | null;
   judit_tracking_hour_range?: string | null;
-  judit_last_request?: ApiProcessoJuditRequest | null;
+  judit_last_request?: ProcessoJuditRequest | null;
+  uf?: string | null;
+  municipio?: string | null;
+  orgao_julgador_nome?: string | null;
+  classe?: string | null;
+  cliente?: ApiProcessoCliente | null;
+  status_processo?: string | null;
+  fase?: string | null;
+  metadata?: Record<string, unknown> | null;
 }
 
-interface ProcessoPropostaDetalhe {
-  id: number;
-  label: string;
-  solicitante?: string | null;
-  dataCriacao?: string | null;
-  sequencial?: number | null;
+interface MovimentoLinha {
+  texto: string;
+  negrito?: boolean;
 }
 
-export interface ProcessoDetalhes {
-  id: number;
-  numero: string;
-  status: string;
-  tipo: string;
-  classeJudicial: string;
-  assunto: string;
-  jurisdicao: string;
+interface MovimentoNormalizado {
+  id: string;
+  data: Date | null;
+  dataCurta: string | null;
+  dataLonga: string | null;
+  dias: number | null;
+  linhas: MovimentoLinha[];
+  observacao?: string | null;
+}
+
+interface GrupoMovimentacao {
+  chave: string;
+  rotulo: string;
+  ano: number | null;
+  mes: number | null;
+  itens: MovimentoNormalizado[];
+}
+
+interface ParteNormalizada {
+  nome: string;
+  documento?: string | null;
+  advogado?: string | null;
+}
+
+interface PartesAgrupadas {
+  ativo: ParteNormalizada[];
+  passivo: ParteNormalizada[];
+  outros: Array<ParteNormalizada & { rotulo: string }>;
+  total: number;
+}
+
+interface DadosProcesso {
+  tribunalDeOrigem: string;
+  comarca: string;
+  cidade: string;
+  estado: string;
+  segmento: string;
+  fase: string;
+  distribuidoEm: string;
+  valorDaCausa: string;
+  classeProcessual: string;
+  juizRelator: string;
+  grau: string;
   orgaoJulgador: string;
-  advogadoResponsavel: string;
-  dataDistribuicao: string | null;
-  dataDistribuicaoFormatada: string;
-  criadoEm: string | null;
+  assuntos: string;
+}
+
+interface CabecalhoProcesso {
+  numero: string;
+  grau: string;
+  ultimaMovimentacao: string | null;
+  chips: string[];
+  tribunal: string;
+  valorDaCausa: string;
+  distribuidoEm: string;
+  partesResumo: ParteNormalizada[];
+  classeProcessual: string;
+}
+
+interface ProcessoRelacionadoView {
+  id: string;
+  numero: string;
+  grau: string;
+  classe: string;
+}
+
+interface JuditResumo {
+  requestId: string | null;
+  status: string | null;
   atualizadoEm: string | null;
-  uf: string | null;
-  municipio: string | null;
-  cliente: {
-    id: number | null;
-    nome: string;
-    documento: string | null;
-    papel: string;
-  } | null;
-  proposta: ProcessoPropostaDetalhe | null;
-  consultasApiCount: number;
+  origem: string | null;
+  consultas: number;
   ultimaSincronizacao: string | null;
-  movimentacoesCount: number;
-  movimentacoes: ProcessoMovimentacaoDetalhe[];
-  juditTrackingId: string | null;
-  juditTrackingHourRange: string | null;
-  juditLastRequest: ProcessoJuditRequest | null;
-  trackingSummary: ProcessoTrackingSummary | null;
+  trackingId: string | null;
+  janela: string | null;
+  anexos: Array<{ titulo: string; data: string | null; url: string | null }>;
+}
+
+export interface ProcessoViewModel {
+  cabecalho: CabecalhoProcesso;
+  dados: DadosProcesso;
+  partes: PartesAgrupadas;
+  movimentacoes: MovimentoNormalizado[];
+  grupos: GrupoMovimentacao[];
+  relacionados: ProcessoRelacionadoView[];
+  judit: JuditResumo;
   responseData: ProcessoResponseData | null;
 }
 
-interface ProcessoMovimentacaoDetalhe {
-  id: string;
-  data: string | null;
-  dataFormatada: string | null;
-  tipo: string;
-  tipoPublicacao: string | null;
-  conteudo: string | null;
-  textoCategoria: string | null;
-  classificacao: {
-    nome: string;
-    descricao: string | null;
-    hierarquia: string | null;
-  } | null;
-  fonte: {
-    nome: string | null;
-    sigla: string | null;
-    tipo: string | null;
-    caderno: string | null;
-    grau: string | null;
-    grauFormatado: string | null;
-  } | null;
-  criadoEm: string | null;
-  atualizadoEm: string | null;
+const TEXTO_DICA =
+  "Use filtros avançados para identificar rapidamente decisões, despachos e publicações relevantes para o seu cliente.";
+
+const KEYWORDS_ATIVO = [
+  "ATIVO",
+  "AUTOR",
+  "REQUERENTE",
+  "EXEQUENTE",
+  "IMPETRANTE",
+  "RECORRENTE",
+  "AGRAVANTE",
+];
+
+const KEYWORDS_PASSIVO = [
+  "PASSIVO",
+  "RÉU",
+  "REU",
+  "REQUERIDO",
+  "EXECUTADO",
+  "IMPUGNADO",
+  "RECORRIDO",
+  "AGRAVADO",
+];
+
+const DATA_LONGA_OPCOES: Intl.DateTimeFormatOptions = {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+};
+
+const DATA_CURTA_OPCOES: Intl.DateTimeFormatOptions = {
+  day: "2-digit",
+  month: "2-digit",
+  year: "2-digit",
+};
+
+const DATA_HORA_OPCOES: Intl.DateTimeFormatOptions = {
+  ...DATA_LONGA_OPCOES,
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
+const formatadorMoeda = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+  minimumFractionDigits: 2,
+});
+
+function primeiroTextoValido(...valores: Array<string | null | undefined>): string {
+  for (const valor of valores) {
+    if (typeof valor === "string") {
+      const texto = normalizarTexto(valor);
+      if (texto) {
+        return texto;
+      }
+    }
+  }
+
+  return "";
 }
 
-const formatDateToPtBR = (value: string | null | undefined): string | null => {
+function formatarData(
+  value: string | Date | null | undefined,
+  tipo: "curta" | "longa" | "hora" = "longa",
+): string | null {
   if (!value) {
     return null;
   }
 
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
+  const data = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(data.getTime())) {
     return null;
   }
 
-  return date.toLocaleDateString("pt-BR");
-};
+  const opcoes =
+    tipo === "curta" ? DATA_CURTA_OPCOES : tipo === "hora" ? DATA_HORA_OPCOES : DATA_LONGA_OPCOES;
 
-const formatDateTimeToPtBR = (value: string | null | undefined): string => {
-  if (!value) {
-    return "Date not available";
+  return data.toLocaleDateString("pt-BR", opcoes);
+}
+
+function formatarMoeda(valor?: string | number | null): string {
+  if (typeof valor === "number") {
+    return formatadorMoeda.format(valor);
   }
 
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return "Date not available";
-  }
-
-  return date.toLocaleString("pt-BR", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-};
-
-const formatDateTimeOrNull = (value: string | null | undefined): string | null => {
-  if (!value) {
-    return null;
-  }
-
-  const formatted = formatDateTimeToPtBR(value);
-  return formatted === "Date not available" ? null : formatted;
-};
-
-const normalizeString = (value: unknown): string => {
-  if (typeof value !== "string") {
-    return "";
-  }
-
-  const trimmed = value.trim();
-  return trimmed || "";
-};
-
-const normalizeClienteTipo = (value: string | null | undefined): string => {
-  if (!value) {
-    return "";
-  }
-
-  return value
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toUpperCase()
-    .trim();
-};
-
-const resolveClientePapel = (tipo: string | null | undefined): string => {
-  const normalized = normalizeClienteTipo(tipo);
-
-  if (
-    normalized.includes("JURIDICA") ||
-    ["2", "J", "PJ"].includes(normalized)
-  ) {
-    return "Corporate entity";
-  }
-
-  if (
-    normalized.includes("FISICA") ||
-    ["1", "F", "PF"].includes(normalized)
-  ) {
-    return "Individual";
-  }
-
-  return "Party";
-};
-
-const parseOptionalInteger = (value: unknown): number | null => {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return Math.trunc(value);
-  }
-
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return null;
+  if (typeof valor === "string") {
+    const numero = Number.parseFloat(valor.replace(/[^\d,-]/g, "").replace(",", "."));
+    if (Number.isFinite(numero)) {
+      return formatadorMoeda.format(numero);
     }
+  }
 
-    const parsed = Number.parseInt(trimmed, 10);
-    if (Number.isFinite(parsed)) {
-      return parsed;
+  return NAO_INFORMADO;
+}
+
+function mascararDocumento(documento?: string | null): string | null {
+  if (!documento) {
+    return null;
+  }
+
+  const numeros = documento.replace(/\D+/g, "");
+
+  if (numeros.length === 11) {
+    return numeros.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, "$1.$2.$3-$4");
+  }
+
+  if (numeros.length === 14) {
+    return numeros.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, "$1.$2.$3/$4-$5");
+  }
+
+  return documento;
+}
+
+function normalizarGrau(valor?: string | null): string {
+  if (!valor) {
+    return NAO_INFORMADO;
+  }
+
+  const texto = normalizarTexto(valor).toUpperCase();
+
+  if (!texto) {
+    return NAO_INFORMADO;
+  }
+
+  if (/1/.test(texto) || texto.includes("PRIMEIRO")) {
+    return "1º Grau";
+  }
+
+  if (/2/.test(texto) || texto.includes("SEGUNDO")) {
+    return "2º Grau";
+  }
+
+  return valor;
+}
+
+function resolverChips(
+  status?: string | null,
+  fase?: string | null,
+  etiquetas?: unknown,
+): string[] {
+  const chips = new Set<string>();
+  const statusTexto = normalizarTexto(status ?? "");
+  const faseTexto = normalizarTexto(fase ?? "");
+
+  if (statusTexto) {
+    chips.add(statusTexto);
+  }
+
+  if (faseTexto) {
+    chips.add(faseTexto);
+  }
+
+  const statusFinal = `${statusTexto} ${faseTexto}`.toLowerCase();
+
+  if (
+    statusFinal.includes("final") ||
+    statusFinal.includes("encerr") ||
+    faseTexto.toLowerCase() === "arquivado"
+  ) {
+    chips.add("Finalizado");
+  }
+
+  if (Array.isArray(etiquetas)) {
+    etiquetas.forEach((etiqueta) => {
+      if (typeof etiqueta === "string" && etiqueta.trim()) {
+        chips.add(etiqueta.trim());
+      }
+    });
+  }
+
+  return Array.from(chips);
+}
+
+function extrairAdvogado(parte: ApiProcessoParte): string | null {
+  if (parte.advogado_nome) {
+    const texto = normalizarTexto(parte.advogado_nome);
+    if (texto) {
+      return texto;
+    }
+  }
+
+  if (parte.advogado) {
+    const texto = normalizarTexto(parte.advogado);
+    if (texto) {
+      return texto;
+    }
+  }
+
+  if (Array.isArray(parte.advogados) && parte.advogados.length > 0) {
+    const primeiro = parte.advogados.find((adv) => normalizarTexto(adv?.nome));
+    if (primeiro?.nome) {
+      return normalizarTexto(primeiro.nome);
     }
   }
 
   return null;
-};
+}
 
-const formatPropostaLabel = (
-  id: number,
-  sequencial: number | null,
-  dataCriacao: string | null,
-  solicitante?: string | null,
-): string => {
-  const numero = sequencial && sequencial > 0 ? sequencial : id;
-  let ano = new Date().getFullYear();
+function classificarParte(parte: ApiProcessoParte): "ativo" | "passivo" | "outros" {
+  const polo = normalizarTexto(parte.polo ?? parte.tipo ?? parte.papel ?? parte.categoria).toUpperCase();
 
-  if (dataCriacao) {
-    const parsed = new Date(dataCriacao);
-    if (!Number.isNaN(parsed.getTime())) {
-      ano = parsed.getFullYear();
-    }
+  if (KEYWORDS_ATIVO.some((palavra) => polo.includes(palavra))) {
+    return "ativo";
   }
 
-  const solicitanteNome =
-    typeof solicitante === "string" && solicitante.trim().length > 0
-      ? solicitante.trim()
-      : "";
-
-  return `Proposal #${numero}/${ano}${solicitanteNome ? ` - ${solicitanteNome}` : ""}`;
-};
-
-const parseInteger = (value: unknown): number => {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return Math.trunc(value);
+  if (KEYWORDS_PASSIVO.some((palavra) => polo.includes(palavra))) {
+    return "passivo";
   }
 
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return 0;
-    }
+  return "outros";
+}
 
-    const parsed = Number.parseInt(trimmed, 10);
-    if (Number.isFinite(parsed)) {
-      return parsed;
-    }
+function formatarListaAssuntos(valor?: unknown): string {
+  if (Array.isArray(valor)) {
+    const itens = valor
+      .map((item) => (typeof item === "string" ? normalizarTexto(item) : ""))
+      .filter(Boolean);
+
+    return itens.length > 0 ? itens.join(", ") : NAO_INFORMADO;
   }
 
-  return 0;
-};
-
-const decodeHtmlEntities = (value: string): string =>
-  value
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&#x27;/g, "'")
-    .replace(/&#x2F;/g, "/");
-
-const normalizeMovimentacaoText = (
-  value: string | null | undefined,
-): string | null => {
-  if (typeof value !== "string") {
-    return null;
+  if (typeof valor === "string") {
+    const texto = normalizarTexto(valor);
+    return texto || NAO_INFORMADO;
   }
 
-  const decoded = decodeHtmlEntities(value)
-    .replace(/\r\n/g, "\n")
-    .replace(/\u00a0/g, " ");
+  return NAO_INFORMADO;
+}
 
-  const trimmed = decoded.trim();
-  return trimmed ? trimmed : null;
-};
+function mapearPartes(partes: ApiProcessoParte[] | null | undefined): PartesAgrupadas {
+  if (!Array.isArray(partes) || partes.length === 0) {
+    return { ativo: [], passivo: [], outros: [], total: 0 };
+  }
 
-const mapApiMovimentacoes = (
-  value: unknown,
-): ProcessoMovimentacaoDetalhe[] => {
-  const movimentacoes: ProcessoMovimentacaoDetalhe[] = [];
+  const agrupado: PartesAgrupadas = { ativo: [], passivo: [], outros: [], total: 0 };
 
-  const processItem = (item: unknown) => {
-    if (!item || typeof item !== "object") {
+  partes.forEach((parte) => {
+    const nome = normalizarTexto(parte.nome ?? "");
+    if (!nome) {
       return;
     }
 
-    const raw = item as ApiProcessoMovimentacao;
-    const idCandidate = raw.id ?? null;
-    let id: string | null = null;
+    const documento = mascararDocumento(parte.documento ?? parte.cpf ?? parte.cnpj ?? null);
+    const advogado = extrairAdvogado(parte);
+    const categoria = classificarParte(parte);
 
-    if (typeof idCandidate === "number" && Number.isFinite(idCandidate)) {
-      id = String(Math.trunc(idCandidate));
-    } else if (typeof idCandidate === "string") {
-      const trimmed = idCandidate.trim();
-      if (trimmed) {
-        id = trimmed;
-      }
-    }
+    agrupado.total += 1;
 
-    if (!id) {
+    if (categoria === "ativo") {
+      agrupado.ativo.push({ nome, documento, advogado });
       return;
     }
 
-    const dataValue = normalizeString(raw.data) || null;
-    const dataFormatada = dataValue ? formatDateToPtBR(dataValue) : null;
-    const tipo = normalizeString(raw.tipo) || "Update";
-    const tipoPublicacao = normalizeString(raw.tipo_publicacao) || null;
-    const conteudo = normalizeMovimentacaoText(raw.conteudo);
-    const textoCategoria = normalizeMovimentacaoText(raw.texto_categoria);
-
-    let classificacao: ProcessoMovimentacaoDetalhe["classificacao"] = null;
-    const rawClassificacao = raw.classificacao_predita;
-
-    if (rawClassificacao && typeof rawClassificacao === "object") {
-      const classificacaoObj = rawClassificacao as Record<string, unknown>;
-      const nome = normalizeString(classificacaoObj.nome);
-      const descricao = normalizeMovimentacaoText(
-        typeof classificacaoObj.descricao === "string"
-          ? classificacaoObj.descricao
-          : null,
-      );
-      const hierarquia = normalizeString(classificacaoObj.hierarquia);
-
-      if (nome || descricao || hierarquia) {
-        classificacao = {
-          nome: nome || "Predicted classification",
-          descricao,
-          hierarquia: hierarquia || null,
-        };
-      }
+    if (categoria === "passivo") {
+      agrupado.passivo.push({ nome, documento, advogado });
+      return;
     }
 
-    let fonte: ProcessoMovimentacaoDetalhe["fonte"] = null;
-    const rawFonte = raw.fonte;
-
-    if (rawFonte && typeof rawFonte === "object") {
-      const fonteObj = rawFonte as Record<string, unknown>;
-      const nome = normalizeString(fonteObj.nome) || null;
-      const sigla = normalizeString(fonteObj.sigla) || null;
-      const tipoFonte = normalizeString(fonteObj.tipo) || null;
-      const caderno = normalizeString(fonteObj.caderno) || null;
-      const grauFormatado = normalizeString(fonteObj.grau_formatado) || null;
-      const grauValue =
-        normalizeString(fonteObj.grau) ||
-        (typeof fonteObj.grau === "number" ? String(fonteObj.grau) : null);
-
-      if (nome || sigla || tipoFonte || caderno || grauFormatado || grauValue) {
-        fonte = {
-          nome,
-          sigla,
-          tipo: tipoFonte,
-          caderno,
-          grau: grauValue,
-          grauFormatado,
-        };
-      }
-    }
-
-    movimentacoes.push({
-      id,
-      data: dataValue,
-      dataFormatada: dataFormatada ?? dataValue,
-      tipo,
-      tipoPublicacao,
-      conteudo,
-      textoCategoria,
-      classificacao,
-      fonte,
-      criadoEm: normalizeString(raw.criado_em) || null,
-      atualizadoEm: normalizeString(raw.atualizado_em) || null,
+    agrupado.outros.push({
+      nome,
+      documento,
+      advogado,
+      rotulo: normalizarTexto(parte.tipo ?? parte.papel ?? parte.categoria ?? "") || "OUTROS",
     });
-  };
+  });
 
-  if (Array.isArray(value)) {
-    value.forEach(processItem);
-    return movimentacoes;
+  return agrupado;
+}
+
+function extrairTribunal(
+  cover: ProcessoResponseData["cover"] | undefined,
+  uf?: string | null,
+): string {
+  const tribunalDireto = primeiroTextoValido(cover?.tribunal_sigla, cover?.tribunal);
+  if (tribunalDireto) {
+    return tribunalDireto;
   }
 
-  if (typeof value === "string") {
-    try {
-      const parsed = JSON.parse(value);
-      if (Array.isArray(parsed)) {
-        parsed.forEach(processItem);
-      } else {
-        processItem(parsed);
-      }
-    } catch {
-      // ignore invalid JSON
-    }
-
-    return movimentacoes;
-  }
-
-  if (value && typeof value === "object") {
-    const possibleRows = (value as { rows?: unknown[] }).rows;
-    if (Array.isArray(possibleRows)) {
-      possibleRows.forEach(processItem);
+  if (uf) {
+    const textoUf = normalizarTexto(uf).toUpperCase();
+    if (textoUf.length === 2) {
+      return `TJ${textoUf}`;
     }
   }
 
-  return movimentacoes;
-};
+  return NAO_INFORMADO;
+}
 
-const buildDocumentoLinksMap = (
-  primary: unknown,
-  ...fallbacks: unknown[]
-): Record<string, string> => {
-  const links: Record<string, string> = {};
-
-  const addLink = (keyHint: string, rawValue: unknown) => {
-    if (typeof rawValue !== "string") {
-      return;
-    }
-
-    const trimmedValue = rawValue.trim();
-    if (!trimmedValue) {
-      return;
-    }
-
-    const baseKey = keyHint ? keyHint.trim().toLowerCase() : "link";
-    let candidateKey = baseKey || "link";
-    let counter = 1;
-
-    while (links[candidateKey] && links[candidateKey] !== trimmedValue) {
-      candidateKey = `${baseKey || "link"}_${counter}`;
-      counter += 1;
-    }
-
-    if (!links[candidateKey]) {
-      links[candidateKey] = trimmedValue;
-    }
-  };
-
-  const processValue = (value: unknown) => {
-    if (Array.isArray(value)) {
-      value.forEach((entry, index) => {
-        if (typeof entry === "string") {
-          addLink(`link_${index + 1}`, entry);
-          return;
-        }
-
-        if (!entry || typeof entry !== "object") {
-          return;
-        }
-
-        const entryObj = entry as Record<string, unknown>;
-        const rel =
-          typeof entryObj.rel === "string"
-            ? entryObj.rel
-            : typeof entryObj.tipo === "string"
-              ? entryObj.tipo
-              : "";
-        const href =
-          typeof entryObj.href === "string"
-            ? entryObj.href
-            : typeof entryObj.url === "string"
-              ? entryObj.url
-              : typeof entryObj.link === "string"
-                ? entryObj.link
-                : null;
-
-        addLink(rel || `link_${index + 1}`, href);
-      });
-      return;
-    }
-
-    if (value && typeof value === "object") {
-      Object.entries(value as Record<string, unknown>).forEach(([rawKey, rawValue]) => {
-        const key = typeof rawKey === "string" ? rawKey : String(rawKey);
-        addLink(key, rawValue);
-      });
-      return;
-    }
-
-    addLink("link", value);
-  };
-
-  processValue(primary);
-  fallbacks.forEach((fallback, index) => addLink(`fallback_${index + 1}`, fallback));
-
-  return links;
-};
-
-const ABSOLUTE_LINK_PATTERN = /^[a-z][a-z\d+\-.]*:/i;
-
-const resolveDocumentoLinkHref = (href: unknown): string | null => {
-  if (typeof href !== "string") {
+function construirMovimento(mov: ApiProcessoMovimentacao): MovimentoNormalizado | null {
+  const id = mov.id !== null && mov.id !== undefined ? String(mov.id) : null;
+  if (!id) {
     return null;
   }
 
-  const trimmed = href.trim();
-  if (!trimmed) {
-    return null;
+  const dataBase = primeiroTextoValido(mov.data, mov.criado_em, mov.atualizado_em);
+  const dataBruta = dataBase ? new Date(dataBase) : null;
+  const data = dataBruta && !Number.isNaN(dataBruta.getTime()) ? dataBruta : null;
+  const dataLonga = formatarData(data, "longa");
+  const dataCurta = formatarData(data, "curta");
+  const dias = diasDesde(data);
+
+  const linhas: MovimentoLinha[] = [];
+  const titulo = normalizarTexto(mov.tipo ?? "");
+  if (titulo) {
+    linhas.push({ texto: titulo, negrito: true });
   }
 
-  if (ABSOLUTE_LINK_PATTERN.test(trimmed)) {
-    return trimmed;
+  const subtitulo = normalizarTexto(mov.tipo_publicacao ?? "");
+  if (subtitulo) {
+    linhas.push({ texto: subtitulo });
   }
 
-  if (trimmed.startsWith("//")) {
-    const protocol =
-      typeof window !== "undefined" && window.location?.protocol
-        ? window.location.protocol
-        : "https:";
-    return `${protocol}${trimmed}`;
+  const conteudo = normalizarTexto(mov.conteudo ?? "");
+  if (conteudo) {
+    linhas.push(...conteudo.split("\n").map((texto) => ({ texto })));
   }
 
-  const normalizedPath = trimmed.replace(/^\/+/, "");
-  const withoutApiPrefix = normalizedPath.replace(/^api\/+/, "");
+  const observacao = normalizarTexto(mov.texto_categoria ?? "");
 
-  return getApiUrl(withoutApiPrefix);
-};
+  return {
+    id,
+    data,
+    dataCurta: dataCurta,
+    dataLonga: dataLonga,
+    dias,
+    linhas,
+    observacao: observacao || null,
+  };
+}
 
-const normalizeDocumentoLinks = (
-  links: Record<string, string>,
-): Record<string, string> => {
-  const normalizedEntries = Object.entries(links).reduce<Record<string, string>>(
-    (acc, [key, value]) => {
-      const resolved = resolveDocumentoLinkHref(value);
-
-      if (resolved) {
-        acc[key] = resolved;
-      }
-
-      return acc;
-    },
-    {},
-  );
-
-  return normalizedEntries;
-};
-
-
-
-
-export const mapApiProcessoToDetalhes = (
-  processo: ApiProcessoResponse,
-  fallbackId?: string | number,
-): ProcessoDetalhes => {
-  const rawNumero = normalizeString(processo.numero);
-  const rawStatus = normalizeString(processo.status) || NOT_INFORMED_LABEL;
-  const rawTipo = normalizeString(processo.tipo) || NOT_INFORMED_LABEL;
-  const rawClasse = normalizeString(processo.classe_judicial) || NOT_INFORMED_LABEL;
-  const rawAssunto = normalizeString(processo.assunto) || NOT_INFORMED_LABEL;
-  const rawOrgao = normalizeString(processo.orgao_julgador) || NOT_INFORMED_LABEL;
-  const rawAdvogado =
-    normalizeString(processo.advogado_responsavel) || NOT_INFORMED_LABEL;
-  const rawMunicipio = normalizeString(processo.municipio);
-  const rawUf = normalizeString(processo.uf);
-  const jurisdicao =
-    normalizeString(processo.jurisdicao) ||
-    [rawMunicipio, rawUf].filter(Boolean).join(" - ") ||
-    NOT_INFORMED_LABEL;
-  const dataDistribuicao = normalizeString(processo.data_distribuicao) || null;
-  const oportunidadeResumo = processo.oportunidade ?? null;
-  const oportunidadeId = parseOptionalInteger(
-    processo.oportunidade_id ?? oportunidadeResumo?.id ?? null,
-  );
-  const oportunidadeSequencial = parseOptionalInteger(
-    oportunidadeResumo?.sequencial_empresa,
-  );
-  const oportunidadeDataCriacao =
-    typeof oportunidadeResumo?.data_criacao === "string"
-      ? oportunidadeResumo.data_criacao
-      : null;
-  const oportunidadeSolicitante =
-    normalizeString(oportunidadeResumo?.solicitante_nome) || null;
-
-  const clienteResumo = processo.cliente ?? null;
-  const clienteId =
-    typeof clienteResumo?.id === "number"
-      ? clienteResumo.id
-      : typeof processo.cliente_id === "number"
-        ? processo.cliente_id
-        : null;
-  const clienteNome =
-    normalizeString(clienteResumo?.nome) || "Client not provided";
-  const clienteDocumento = normalizeString(clienteResumo?.documento) || null;
-  const clientePapel = resolveClientePapel(clienteResumo?.tipo);
-  const movimentacoes = mapApiMovimentacoes(processo.movimentacoes);
-  const consultasApiCount = parseInteger(processo.consultas_api_count);
-  const movimentacoesCount = Math.max(
-    parseInteger(processo.movimentacoes_count),
-    movimentacoes.length,
-  );
-  const juditTrackingId = normalizeString(processo.judit_tracking_id) || null;
-  const juditTrackingHourRange =
-    normalizeString(processo.judit_tracking_hour_range) || null;
-  const juditLastRequest = mapApiJuditRequest(processo.judit_last_request);
-  const trackingSummary = juditLastRequest
-    ? parseTrackingSummaryFromResult(juditLastRequest.result)
+export function mapApiProcessoToViewModel(processo: ApiProcessoResponse): ProcessoViewModel {
+  const juditLastRequest = processo.judit_last_request
+    ? mapApiJuditRequest(processo.judit_last_request)
     : null;
   const responseData = juditLastRequest
     ? parseResponseDataFromResult(juditLastRequest.result)
     : null;
-  const proposta =
-    oportunidadeId && oportunidadeId > 0
-      ? {
-          id: oportunidadeId,
-          label: formatPropostaLabel(
-            oportunidadeId,
-            oportunidadeSequencial,
-            oportunidadeDataCriacao,
-            oportunidadeSolicitante,
-          ),
-          solicitante: oportunidadeSolicitante,
-          dataCriacao: oportunidadeDataCriacao,
-          sequencial: oportunidadeSequencial,
-        }
-      : null;
+  const cover = responseData?.cover ?? undefined;
+  const metadata = (responseData?.metadata as Record<string, unknown> | undefined) ?? undefined;
+
+  const numero = primeiroTextoValido(cover?.numero, processo.numero) || NAO_INFORMADO;
+  const grau =
+    primeiroTextoValido(
+      cover?.grau_processual,
+      typeof metadata?.grau === "string" ? (metadata.grau as string) : null,
+      processo.metadata && typeof processo.metadata.grau === "string"
+        ? (processo.metadata.grau as string)
+        : null,
+    ) || processo.status_processo || NAO_INFORMADO;
+
+  const movimentacoesOriginais = Array.isArray(processo.movimentacoes)
+    ? processo.movimentacoes
+    : [];
+  const movimentacoesDeduplicadas = deduplicarMovimentacoes(movimentacoesOriginais);
+  const movimentos = movimentacoesDeduplicadas
+    .map(construirMovimento)
+    .filter((mov): mov is MovimentoNormalizado => mov !== null);
+
+  const grupos = agruparPorMes(movimentos);
+
+  const ultimaMovimentacaoData = movimentos.reduce<Date | null>((acc, mov) => {
+    if (mov.data && (!acc || mov.data > acc)) {
+      return mov.data;
+    }
+    return acc;
+  }, null);
+
+  const ultimaMovimentacao = ultimaMovimentacaoData
+    ? formatarData(ultimaMovimentacaoData, "curta")
+    : null;
+
+  const distribuicao =
+    formatarData(
+      primeiroTextoValido(cover?.data_distribuicao, processo.data_distribuicao),
+      "curta",
+    ) ?? NAO_INFORMADO;
+
+  const valorCausa = formatarMoeda(
+    cover?.valor_da_causa ??
+      (typeof metadata?.valor_causa === "string" || typeof metadata?.valor_causa === "number"
+        ? (metadata.valor_causa as string | number)
+        : undefined),
+  );
+
+  const partes = mapearPartes((responseData?.partes as ApiProcessoParte[] | undefined) ?? processo.partes ?? []);
+
+  const dados: DadosProcesso = {
+    tribunalDeOrigem:
+      primeiroTextoValido(cover?.tribunal, metadata?.tribunal as string | undefined) ||
+      (processo.uf ? `${normalizarTexto(processo.uf)} — Tribunal não informado` : NAO_INFORMADO),
+    comarca:
+      primeiroTextoValido(cover?.comarca, metadata?.comarca as string | undefined) || NAO_INFORMADO,
+    cidade: primeiroTextoValido(cover?.cidade, processo.municipio) || NAO_INFORMADO,
+    estado: primeiroTextoValido(cover?.estado, processo.uf) || NAO_INFORMADO,
+    segmento:
+      primeiroTextoValido(
+        cover?.segmento_justica,
+        metadata?.segmento as string | undefined,
+      ) || NAO_INFORMADO,
+    fase: primeiroTextoValido(cover?.fase, processo.fase) || NAO_INFORMADO,
+    distribuidoEm: distribuicao,
+    valorDaCausa: valorCausa,
+    classeProcessual:
+      primeiroTextoValido(
+        processo.classe_judicial,
+        cover?.classe_processual,
+        processo.classe,
+      ) || NAO_INFORMADO,
+    juizRelator:
+      primeiroTextoValido(
+        cover?.juiz_relator,
+        metadata?.juiz as string | undefined,
+        processo.advogado_responsavel,
+      ) || NAO_INFORMADO,
+    grau: normalizarGrau(
+      primeiroTextoValido(
+        cover?.grau_processual,
+        metadata?.grau as string | undefined,
+        processo.status_processo,
+      ) || grau,
+    ),
+    orgaoJulgador:
+      primeiroTextoValido(cover?.orgao_julgador, processo.orgao_julgador, processo.orgao_julgador_nome) ||
+      NAO_INFORMADO,
+    assuntos:
+      formatarListaAssuntos(
+        cover?.assuntos ?? metadata?.assuntos ?? processo.assunto ?? processo.metadata?.assunto,
+      ),
+  };
+
+  const cabecalho: CabecalhoProcesso = {
+    numero,
+    grau: normalizarGrau(grau),
+    ultimaMovimentacao,
+    chips: resolverChips(
+      processo.status ?? processo.status_processo,
+      cover?.fase,
+      metadata?.etiquetas,
+    ),
+    tribunal: extrairTribunal(cover, processo.uf),
+    valorDaCausa: valorCausa,
+    distribuidoEm: distribuicao,
+    partesResumo: [...partes.ativo, ...partes.passivo].slice(0, 5),
+    classeProcessual:
+      primeiroTextoValido(
+        processo.classe_judicial,
+        cover?.classe_processual,
+        processo.classe,
+      ) || NAO_INFORMADO,
+  };
+
+  const relacionadosArray = (responseData?.relacionados as ApiProcessoRelacionado[] | undefined) ??
+    (processo.relacionados ?? []);
+
+  const relacionados: ProcessoRelacionadoView[] = Array.isArray(relacionadosArray)
+    ? relacionadosArray
+        .map((item, index) => {
+          const numeroProcesso = primeiroTextoValido(item.numero) || NAO_INFORMADO;
+          const id =
+            item.id !== null && item.id !== undefined
+              ? String(item.id)
+              : numeroProcesso !== NAO_INFORMADO
+                ? `${numeroProcesso}-${index}`
+                : `relacionado-${index}`;
+          return {
+            id,
+            numero: numeroProcesso,
+            grau: normalizarGrau(item.grau ?? ""),
+            classe: primeiroTextoValido(item.classe) || NAO_INFORMADO,
+          };
+        })
+        .filter(Boolean)
+    : [];
+
+  const anexos = Array.isArray(responseData?.anexos)
+    ? responseData!.anexos.map((anexo: any) => ({
+        titulo: primeiroTextoValido(anexo.titulo, anexo.nome) || "Anexo",
+        data: formatarData(
+          primeiroTextoValido(anexo.attachment_date, anexo.created_at, anexo.updated_at),
+          "hora",
+        ),
+        url: primeiroTextoValido(anexo.link, anexo.url, anexo.href),
+      }))
+    : [];
+
+  const judit: JuditResumo = {
+    requestId: juditLastRequest?.requestId ?? null,
+    status: juditLastRequest?.status ?? null,
+    atualizadoEm: formatarData(juditLastRequest?.updatedAt ?? null, "hora"),
+    origem: juditLastRequest?.source ?? null,
+    consultas: Number(processo.consultas_api_count ?? 0) || 0,
+    ultimaSincronizacao: formatarData(processo.ultima_sincronizacao ?? null, "hora"),
+    trackingId: processo.judit_tracking_id ?? null,
+    janela: processo.judit_tracking_hour_range ?? null,
+    anexos,
+  };
 
   return {
-    id:
-      typeof processo.id === "number"
-        ? processo.id
-        : Number.parseInt(String(processo.id ?? fallbackId ?? 0), 10) || 0,
-    numero: rawNumero || NOT_INFORMED_LABEL,
-    status: rawStatus,
-    tipo: rawTipo,
-    classeJudicial: rawClasse,
-    assunto: rawAssunto,
-    jurisdicao,
-    orgaoJulgador: rawOrgao,
-    advogadoResponsavel: rawAdvogado,
-    dataDistribuicao,
-    dataDistribuicaoFormatada: formatDateToPtBR(dataDistribuicao),
-    criadoEm: processo.criado_em ?? null,
-    atualizadoEm: processo.atualizado_em ?? null,
-    uf: rawUf || null,
-    municipio: rawMunicipio || null,
-    cliente: clienteResumo
-      ? {
-          id: clienteId,
-          nome: clienteNome,
-          documento: clienteDocumento,
-          papel: clientePapel,
-        }
-      : null,
-    proposta,
-    consultasApiCount,
-    ultimaSincronizacao: processo.ultima_sincronizacao ?? null,
-    movimentacoesCount,
-    movimentacoes,
-    juditTrackingId,
-    juditTrackingHourRange,
-    juditLastRequest,
-    trackingSummary,
+    cabecalho,
+    dados,
+    partes,
+    movimentacoes: movimentos,
+    grupos,
+    relacionados,
+    judit,
     responseData,
   };
-};
-
-const getStatusBadgeClassName = (status: string) => {
-  const normalized = status.toLowerCase();
-
-  if (
-    normalized.includes("andamento") ||
-    normalized.includes("ativo") ||
-    normalized.includes("progress") ||
-    normalized.includes("active")
-  ) {
-    return "border-emerald-200 bg-emerald-500/10 text-emerald-600";
-  }
-
-  if (normalized.includes("arquiv") || normalized.includes("archive")) {
-    return "border-slate-200 bg-slate-500/10 text-slate-600";
-  }
-
-  if (normalized.includes("urg") || normalized.includes("urgent")) {
-    return "border-amber-200 bg-amber-500/10 text-amber-600";
-  }
-
-  return "border-primary/20 bg-primary/5 text-primary";
-};
-
-const getTipoBadgeClassName = (tipo: string) => {
-  if (!tipo) {
-    return "border-muted-foreground/20 bg-muted text-muted-foreground";
-  }
-
-  const normalized = tipo.toLowerCase();
-
-  if (normalized === "não informado" || normalized === "not informed") {
-    return "border-muted-foreground/20 bg-muted text-muted-foreground";
-  }
-
-  return "border-blue-200 bg-blue-500/10 text-blue-600";
-};
-
-interface ProcessoAttachmentsSectionProps {
-  attachments: Record<string, unknown>[];
-  currentPage: number;
-  totalPages: number;
-  pageSize: number;
-  totalItems: number;
-  onPageChange: (page: number) => void;
-  onPageSizeChange: (pageSize: number) => void;
-  processoId: number;
+}
+interface TimelineMesProps {
+  grupo: GrupoMovimentacao;
+  aberto: boolean;
+  onToggle: (chave: string) => void;
+  movimentacoesVisiveis: number;
+  onVerMais: (chave: string) => void;
+  virtualizado: boolean;
 }
 
-const ATTACHMENT_PAGE_SIZE_OPTIONS = [5, 10, 20, 50];
-const HISTORY_PAGE_SIZE_OPTIONS = [5, 10, 20, 30];
+function TimelineMes({
+  grupo,
+  aberto,
+  onToggle,
+  movimentacoesVisiveis,
+  onVerMais,
+  virtualizado,
+}: TimelineMesProps) {
+  const [intervalo, setIntervalo] = useState({ inicio: 0, fim: movimentacoesVisiveis });
 
-type ProcessoTab = "overview" | "attachments" | "timeline";
+  useEffect(() => {
+    setIntervalo({ inicio: 0, fim: movimentacoesVisiveis });
+  }, [movimentacoesVisiveis, grupo.chave]);
 
-const resolveTabValue = (value: string | null | undefined): ProcessoTab | null => {
-  switch (value) {
-    case "overview":
-    case "attachments":
-    case "timeline":
-      return value;
-    case "resumo":
-      return "overview";
-    case "anexos":
-      return "attachments";
-    case "historico":
-      return "timeline";
-    default:
-      return null;
-  }
-};
+  useEffect(() => {
+    if (!aberto || !virtualizado) {
+      return;
+    }
 
-const EN_US_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
-  month: "long",
-  day: "2-digit",
-  year: "numeric",
-});
+    setIntervalo((atual) => {
+      const fim = Math.min(grupo.itens.length, atual.inicio + Math.max(movimentacoesVisiveis, 30));
+      return { inicio: atual.inicio, fim };
+    });
+  }, [aberto, virtualizado, movimentacoesVisiveis, grupo.itens.length]);
 
-const EN_US_WEEKDAY_FORMATTER = new Intl.DateTimeFormat("en-US", {
-  weekday: "long",
-});
-
-const EN_US_TIME_FORMATTER = new Intl.DateTimeFormat("en-US", {
-  hour: "2-digit",
-  minute: "2-digit",
-});
-
-const EN_US_DATE_TIME_FORMATTER = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  day: "2-digit",
-  year: "numeric",
-  hour: "2-digit",
-  minute: "2-digit",
-});
-
-const EXCERPT_CHARACTER_LIMIT = 320;
-const NOT_INFORMED_LABEL = "Not informed";
-
-const formatDateToEnUS = (value: string | null | undefined): string | null => {
-  if (!value) {
-    return null;
-  }
-
-  const parsed = new Date(value);
-
-  if (Number.isNaN(parsed.getTime())) {
-    return null;
-  }
-
-  return EN_US_DATE_FORMATTER.format(parsed);
-};
-
-const formatDateTimeToEnUS = (value: string | null | undefined): string => {
-  if (!value) {
-    return "Date not available";
-  }
-
-  const parsed = new Date(value);
-
-  if (Number.isNaN(parsed.getTime())) {
-    return "Date not available";
-  }
-
-  return EN_US_DATE_TIME_FORMATTER.format(parsed);
-};
-
-const MOVEMENT_TRANSLATION_RULES: {
-  pattern: RegExp;
-  translation: string;
-  keepRest?: boolean;
-}[] = [
-  { pattern: /^Pet[ií]ção Inicial\b/i, translation: "Initial petition" },
-  { pattern: /^Pet[ií]ção\b/i, translation: "Petition", keepRest: true },
-  { pattern: /^Juntada\b/i, translation: "Document filing", keepRest: true },
-  { pattern: /^Decis[aã]o\b/i, translation: "Decision", keepRest: true },
-  { pattern: /^Despacho\b/i, translation: "Order", keepRest: true },
-  { pattern: /^Intima[cç][aã]o\b/i, translation: "Notice", keepRest: true },
-  { pattern: /^Cita[cç][aã]o\b/i, translation: "Service of process", keepRest: true },
-  { pattern: /^Certid[aã]o\b/i, translation: "Certificate", keepRest: true },
-  { pattern: /^Contest[aã]?[cç][aã]o\b/i, translation: "Defense brief", keepRest: true },
-  { pattern: /^Impugna[cç][aã]o\b/i, translation: "Objection", keepRest: true },
-  {
-    pattern: /^Manifest[aã]?[cç][aã]o da Advocacia P[uú]blica\b/i,
-    translation: "Public attorney statement",
-    keepRest: true,
-  },
-  { pattern: /^Manifest[aã]?[cç][aã]o\b/i, translation: "Statement", keepRest: true },
-  {
-    pattern: /^Arquivado Definitivamente\b/i,
-    translation: "Case archived permanently",
-  },
-  { pattern: /^Recebidos os autos\b/i, translation: "Case files received" },
-  { pattern: /^Conclusos para despacho\b/i, translation: "Submitted for order" },
-  {
-    pattern: /^Classe Processual alterada\b/i,
-    translation: "Case class updated",
-    keepRest: true,
-  },
-  {
-    pattern: /^Expedi[cç][aã]o de comunica[cç][aã]o via sistema\b/i,
-    translation: "Communication issued via system",
-  },
-  {
-    pattern: /^Decorrido prazo de\s*/i,
-    translation: "Deadline expired for ",
-    keepRest: true,
-  },
-  {
-    pattern: /^Remetidos os Autos\b/i,
-    translation: "Case files forwarded",
-    keepRest: true,
-  },
-  {
-    pattern: /^Proferido despacho de mero expediente\b/i,
-    translation: "Routine order issued",
-  },
-];
-
-const SECONDARY_TRANSLATIONS: { pattern: RegExp; replacement: string }[] = [
-  {
-    pattern: /Aviso de Recebimento/gi,
-    replacement: "Return receipt",
-  },
-  {
-    pattern: /Turma Recursal/gi,
-    replacement: "Appellate panel",
-  },
-  {
-    pattern: /Juizado Especial/gi,
-    replacement: "Small claims court",
-  },
-  {
-    pattern: /Perdas e Danos/gi,
-    replacement: "Losses and damages",
-  },
-  {
-    pattern: /Indeniza[cç][aã]o por Dano Moral/gi,
-    replacement: "Moral damages claim",
-  },
-];
-
-const JUDGE_KEYWORDS = [
-  "despacho",
-  "decisao",
-  "decisão",
-  "sentenca",
-  "sentença",
-  "acordao",
-  "acórdão",
-  "relator",
-  "relatório",
-  "relatorio",
-  "juiz",
-  "magistrado",
-  "poder judiciario",
-];
-
-interface TimelineEntry {
-  id: string;
-  dateKey: string;
-  dateLabel: string;
-  weekdayLabel: string | null;
-  timeLabel: string | null;
-  type: string;
-  publicationType: string | null;
-  classification: string | null;
-  source: string | null;
-  recordedAt: string | null;
-  updatedAt: string | null;
-  content: string | null;
-  excerpt: string | null;
-  hasMoreContent: boolean;
-  isJudgeDocument: boolean;
-}
-
-interface TimelineGroup {
-  dateKey: string;
-  dateLabel: string;
-  weekdayLabel: string | null;
-  items: TimelineEntry[];
-}
-
-const translateLabelToEnglish = (value: string | null | undefined): string => {
-  if (!value) {
-    return "Not informed";
-  }
-
-  let result = value.trim();
-
-  if (!result) {
-    return "Not informed";
-  }
-
-  for (const rule of MOVEMENT_TRANSLATION_RULES) {
-    if (rule.pattern.test(result)) {
-      if (rule.keepRest) {
-        const matched = result.match(rule.pattern)?.[0] ?? "";
-        const rest = result.slice(matched.length).trim();
-        result = rest ? `${rule.translation} — ${rest}` : rule.translation;
-      } else {
-        result = rule.translation;
+  const handleScroll = useCallback<UIEventHandler<HTMLDivElement>>(
+    (event) => {
+      if (!virtualizado) {
+        return;
       }
-      break;
-    }
-  }
 
-  for (const replacement of SECONDARY_TRANSLATIONS) {
-    if (replacement.pattern.test(result)) {
-      result = result.replace(replacement.pattern, replacement.replacement);
-    }
-  }
+      const alvo = event.currentTarget;
+      const inicio = Math.max(0, Math.floor(alvo.scrollTop / ALTURA_ESTIMADA_ITEM) - 5);
+      const capacidade = Math.ceil(alvo.clientHeight / ALTURA_ESTIMADA_ITEM) + 10;
+      const fim = Math.min(grupo.itens.length, inicio + capacidade);
 
-  const normalized = result.charAt(0).toUpperCase() + result.slice(1);
-  return normalized;
-};
+      setIntervalo({ inicio, fim });
+    },
+    [virtualizado, grupo.itens.length],
+  );
 
-const parseDateFromKnownFormats = (
-  ...values: (string | null | undefined)[]
-): Date | null => {
-  for (const value of values) {
-    if (!value) {
-      continue;
-    }
+  const itensRenderizados = virtualizado
+    ? grupo.itens.slice(intervalo.inicio, intervalo.fim)
+    : grupo.itens.slice(0, movimentacoesVisiveis);
 
-    const trimmed = value.trim();
-    if (!trimmed) {
-      continue;
-    }
-
-    const parsedTimestamp = Date.parse(trimmed);
-    if (!Number.isNaN(parsedTimestamp)) {
-      return new Date(parsedTimestamp);
-    }
-
-    const match = trimmed.match(
-      /^(\d{2})\/(\d{2})\/(\d{4})(?:\s+(\d{2}):(\d{2})(?::(\d{2}))?)?$/,
-    );
-
-    if (match) {
-      const [, day, month, year, hour = "0", minute = "0", second = "0"] = match;
-      return new Date(
-        Number(year),
-        Number(month) - 1,
-        Number(day),
-        Number(hour),
-        Number(minute),
-        Number(second),
-      );
-    }
-  }
-
-  return null;
-};
-
-const formatDateLabel = (date: Date | null): string => {
-  if (!date) {
-    return "Date not available";
-  }
-
-  return EN_US_DATE_FORMATTER.format(date);
-};
-
-const formatWeekdayLabel = (date: Date | null): string | null => {
-  if (!date) {
-    return null;
-  }
-
-  return EN_US_WEEKDAY_FORMATTER.format(date);
-};
-
-const formatTimeLabel = (date: Date | null): string | null => {
-  if (!date) {
-    return null;
-  }
-
-  return EN_US_TIME_FORMATTER.format(date);
-};
-
-const dedupeMovements = (
-  movements: ProcessoMovimentacaoDetalhe[],
-): ProcessoMovimentacaoDetalhe[] => {
-  const seenIds = new Set<string>();
-  const seenContent = new Set<string>();
-  const result: ProcessoMovimentacaoDetalhe[] = [];
-
-  movements.forEach((movement) => {
-    if (!movement.id) {
-      return;
-    }
-
-    const normalizedId = movement.id.trim();
-    const normalizedContentKey = [
-      (movement.data ?? "").slice(0, 10),
-      movement.tipo.trim().toLowerCase(),
-      (movement.conteudo ?? "").replace(/\s+/g, " ").toLowerCase(),
-      (movement.textoCategoria ?? "").replace(/\s+/g, " ").toLowerCase(),
-    ].join("|");
-
-    if (seenIds.has(normalizedId) || seenContent.has(normalizedContentKey)) {
-      return;
-    }
-
-    seenIds.add(normalizedId);
-    seenContent.add(normalizedContentKey);
-    result.push(movement);
-  });
-
-  return result;
-};
-
-const buildSourceDescription = (
-  fonte: ProcessoMovimentacaoDetalhe["fonte"],
-): string | null => {
-  if (!fonte) {
-    return null;
-  }
-
-  const parts = [
-    fonte.nome ? translateLabelToEnglish(fonte.nome) : fonte.sigla ?? null,
-    fonte.tipo ? translateLabelToEnglish(fonte.tipo) : null,
-    fonte.caderno ? translateLabelToEnglish(fonte.caderno) : null,
-    fonte.grauFormatado
-      ? translateLabelToEnglish(fonte.grauFormatado)
-      : fonte.grau
-        ? translateLabelToEnglish(fonte.grau)
-        : null,
-  ].filter(Boolean) as string[];
-
-  if (parts.length === 0) {
-    return null;
-  }
-
-  return parts.join(" · ");
-};
-
-const isJudgeMovement = (movement: ProcessoMovimentacaoDetalhe): boolean => {
-  const content = [
-    movement.tipo,
-    movement.tipoPublicacao,
-    movement.classificacao?.nome ?? null,
-    movement.conteudo ?? null,
-    movement.textoCategoria ?? null,
-  ]
-    .filter(Boolean)
-    .join(" ")
-    .toLowerCase();
-
-  return JUDGE_KEYWORDS.some((keyword) => content.includes(keyword));
-};
-
-const createTimelineEntries = (
-  movements: ProcessoMovimentacaoDetalhe[],
-): TimelineEntry[] => {
-  if (movements.length === 0) {
-    return [];
-  }
-
-  const uniqueMovements = dedupeMovements(movements);
-
-  const sortedMovements = [...uniqueMovements].sort((a, b) => {
-    const dateA =
-      parseDateFromKnownFormats(a.data, a.criadoEm, a.atualizadoEm)?.getTime() ?? Number.NEGATIVE_INFINITY;
-    const dateB =
-      parseDateFromKnownFormats(b.data, b.criadoEm, b.atualizadoEm)?.getTime() ?? Number.NEGATIVE_INFINITY;
-
-    return dateB - dateA;
-  });
-
-  return sortedMovements.map((movement) => {
-    const movementDate = parseDateFromKnownFormats(
-      movement.data,
-      movement.dataFormatada,
-      movement.criadoEm,
-    );
-
-    const excerpt = movement.conteudo
-      ? movement.conteudo.length > EXCERPT_CHARACTER_LIMIT
-        ? `${movement.conteudo.slice(0, EXCERPT_CHARACTER_LIMIT - 1).trimEnd()}…`
-        : movement.conteudo
-      : null;
-
-    return {
-      id: movement.id,
-      dateKey: movementDate ? movementDate.toISOString().slice(0, 10) : "unknown",
-      dateLabel: formatDateLabel(movementDate),
-      weekdayLabel: formatWeekdayLabel(movementDate),
-      timeLabel: formatTimeLabel(movementDate),
-      type: translateLabelToEnglish(movement.tipo),
-      publicationType: movement.tipoPublicacao
-        ? translateLabelToEnglish(movement.tipoPublicacao)
-        : null,
-      classification: movement.classificacao?.nome
-        ? translateLabelToEnglish(movement.classificacao.nome)
-        : null,
-      source: buildSourceDescription(movement.fonte),
-      recordedAt: formatDateTimeOrNull(movement.criadoEm),
-      updatedAt: formatDateTimeOrNull(movement.atualizadoEm),
-      content: movement.conteudo,
-      excerpt,
-      hasMoreContent:
-        typeof movement.conteudo === "string" && movement.conteudo.length > EXCERPT_CHARACTER_LIMIT,
-      isJudgeDocument: isJudgeMovement(movement),
-    } satisfies TimelineEntry;
-  });
-};
-
-const groupTimelineEntries = (entries: TimelineEntry[]): TimelineGroup[] => {
-  const groups: TimelineGroup[] = [];
-  const groupMap = new Map<string, TimelineGroup>();
-
-  entries.forEach((entry) => {
-    const key = entry.dateKey;
-    const existing = groupMap.get(key);
-
-    if (existing) {
-      existing.items.push(entry);
-      return;
-    }
-
-    const newGroup: TimelineGroup = {
-      dateKey: key,
-      dateLabel: entry.dateLabel,
-      weekdayLabel: entry.weekdayLabel,
-      items: [entry],
-    };
-
-    groupMap.set(key, newGroup);
-    groups.push(newGroup);
-  });
-
-  return groups;
-};
-
-const buildPaginationRange = (
-  currentPage: number,
-  totalPages: number,
-): (number | "ellipsis")[] => {
-  if (totalPages <= 5) {
-    return Array.from({ length: totalPages }, (_, index) => index + 1);
-  }
-
-  const range: (number | "ellipsis")[] = [1];
-  const start = Math.max(2, currentPage - 1);
-  const end = Math.min(totalPages - 1, currentPage + 1);
-
-  if (start > 2) {
-    range.push("ellipsis");
-  }
-
-  for (let page = start; page <= end; page += 1) {
-    range.push(page);
-  }
-
-  if (end < totalPages - 1) {
-    range.push("ellipsis");
-  }
-
-  range.push(totalPages);
-
-  return range;
-};
-
-export function ProcessoAttachmentsSection({
-  attachments,
-  currentPage,
-  totalPages,
-  pageSize,
-  totalItems,
-  onPageChange,
-  onPageSizeChange,
-  processoId,
-}: ProcessoAttachmentsSectionProps) {
-  const hasAttachments = totalItems > 0;
-  const paginationRange = buildPaginationRange(currentPage, totalPages);
-  const displayStart = !hasAttachments ? 0 : (currentPage - 1) * pageSize + 1;
-  const displayEnd = !hasAttachments
-    ? 0
-    : Math.min(displayStart + attachments.length - 1, totalItems);
-
-  const handlePageSizeChange = (value: string) => {
-    const parsed = Number(value);
-
-    if (!Number.isFinite(parsed) || parsed <= 0) {
-      return;
-    }
-
-    onPageSizeChange(parsed);
-  };
-
-  const handlePageChange = (page: number) => {
-    if (page === currentPage) {
-      return;
-    }
-
-    onPageChange(page);
-  };
+  const paddingSuperior = virtualizado ? intervalo.inicio * ALTURA_ESTIMADA_ITEM : 0;
+  const paddingInferior = virtualizado
+    ? Math.max(0, (grupo.itens.length - intervalo.fim) * ALTURA_ESTIMADA_ITEM)
+    : 0;
 
   return (
-    <Card>
-      <CardHeader className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-        <div className="space-y-1">
-          <CardTitle className="text-xl font-semibold">Attachments</CardTitle>
-          <CardDescription>
-            {hasAttachments
-              ? "Review the documents provided by the tracking service."
-              : "No attachments have been received yet."}
-          </CardDescription>
-        </div>
-        {hasAttachments ? (
-          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-            <span className="font-medium uppercase tracking-wide">Items per page</span>
-            <Select value={String(pageSize)} onValueChange={handlePageSizeChange}>
-              <SelectTrigger className="h-8 w-[90px] text-xs" aria-label="Items per page">
-                <SelectValue placeholder={`${pageSize}`} />
-              </SelectTrigger>
-              <SelectContent>
-                {ATTACHMENT_PAGE_SIZE_OPTIONS.map((option) => (
-                  <SelectItem key={option} value={String(option)}>
-                    {option}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        ) : null}
-      </CardHeader>
-      <CardContent className="space-y-6">
-        {!hasAttachments ? (
-          <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-4 text-sm text-muted-foreground">
-            No attachments have been received yet.
-          </div>
-        ) : (
-          <>
-            <div className="space-y-3">
-              {attachments.map((anexo, index) => {
-                const titulo =
-                  parseOptionalString(anexo.titulo) ??
-                  parseOptionalString(anexo.title) ??
-                  parseOptionalString(anexo.nome) ??
-                  parseOptionalString(anexo.attachment_name ?? anexo.attachmentName) ??
-                  `Attachment ${index + 1 + (currentPage - 1) * pageSize}`;
-                const dataBruta =
-                  parseOptionalString(anexo.attachment_date) ??
-                  parseOptionalString(anexo.data) ??
-                  parseOptionalString(anexo.created_at) ??
-                  parseOptionalString(anexo.updated_at) ??
-                  parseOptionalString(anexo.criado_em) ??
-                  parseOptionalString(anexo.atualizado_em) ??
-                  parseOptionalString(anexo.timestamp) ??
-                  parseOptionalString(anexo.date) ??
-                  null;
-                const dataFormatada = formatDateTimeToEnUS(dataBruta);
-                const links = normalizeDocumentoLinks(
-                  buildDocumentoLinksMap(
-                    anexo.links,
-                    anexo.href,
-                    anexo.url,
-                    anexo.link,
-                  ),
-                );
-                const linkEntries = Object.entries(links);
+    <div className="rounded-xl border border-muted-foreground/10 bg-white shadow-sm">
+      <button
+        type="button"
+        onClick={() => onToggle(grupo.chave)}
+        className="flex w-full items-center justify-between rounded-t-xl bg-muted/60 px-4 py-3 text-left text-sm font-medium text-muted-foreground"
+        aria-expanded={aberto}
+      >
+        <span>{grupo.rotulo}</span>
+        {aberto ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+      </button>
+      {aberto ? (
+        <div
+          className={cn(
+            "relative px-4 py-4",
+            virtualizado ? "max-h-[520px] overflow-y-auto" : "",
+          )}
+          onScroll={handleScroll}
+        >
+          <div
+            className={cn(
+              "relative",
+              virtualizado ? "space-y-0" : "space-y-6",
+            )}
+            style={
+              virtualizado
+                ? { paddingTop: paddingSuperior, paddingBottom: paddingInferior }
+                : undefined
+            }
+          >
+            {itensRenderizados.map((item, index) => {
+              const isUltimo =
+                (!virtualizado && index === itensRenderizados.length - 1 &&
+                  movimentacoesVisiveis >= grupo.itens.length) ||
+                (virtualizado && intervalo.inicio + index === grupo.itens.length - 1);
 
-                return (
-                  <div
-                    key={`${processoId}-anexo-${index}-${titulo}`}
-                    className="rounded-md border border-border/40 bg-background/60 p-3"
-                  >
-                    <p className="text-sm font-medium text-foreground">{titulo}</p>
-                    <p className="mt-1 text-xs text-muted-foreground">{dataFormatada}</p>
-                    {linkEntries.length > 0 ? (
-                      <ul className="mt-2 space-y-1 text-xs text-primary underline">
-                        {linkEntries.map(([key, value]) => (
-                          <li key={`${processoId}-anexo-${index}-${key}`}>
-                            <a
-                              href={value}
-                              target="_blank"
-                              rel="noreferrer"
-                              className="hover:text-primary/80"
-                            >
-                              {formatResponseKey(key)}
-                            </a>
-                          </li>
-                        ))}
-                      </ul>
-                    ) : null}
+              return (
+                <div key={item.id} className="relative flex gap-6 pb-8 last:pb-2">
+                  <div className="w-28 text-right">
+                    <p className="text-sm font-semibold text-emerald-600">
+                      {item.dataLonga ?? "Data não informada"}
+                    </p>
+                    {item.dias !== null && (
+                      <p className="text-xs text-muted-foreground">{`${item.dias} dias`}</p>
+                    )}
                   </div>
-                );
-              })}
+                  <div className="relative flex-1">
+                    {!isUltimo && (
+                      <span
+                        className="absolute -left-6 top-4 h-[calc(100%+1rem)] w-px bg-emerald-200"
+                        aria-hidden
+                      />
+                    )}
+                    <span className="absolute -left-[1.6rem] top-3 h-3 w-3 rounded-full border-2 border-white bg-emerald-500 shadow" />
+                    <div className="rounded-lg border border-muted-foreground/10 bg-muted/40 p-4">
+                      <div className="space-y-2 text-sm">
+                        {item.linhas.map((linha, linhaIndex) => (
+                          <p
+                            key={`${item.id}-linha-${linhaIndex}`}
+                            className={cn(
+                              "text-muted-foreground",
+                              linha.negrito ? "font-semibold text-foreground" : "",
+                            )}
+                            style={{ whiteSpace: "pre-line" }}
+                          >
+                            {linha.texto}
+                          </p>
+                        ))}
+                        {item.observacao && (
+                          <p className="text-xs text-muted-foreground" style={{ whiteSpace: "pre-line" }}>
+                            {item.observacao}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          {(!virtualizado && movimentacoesVisiveis < grupo.itens.length) ||
+          (virtualizado && intervalo.fim < grupo.itens.length) ? (
+            <div className="pt-4 text-center">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onVerMais(grupo.chave)}
+                aria-expanded={movimentacoesVisiveis < grupo.itens.length}
+              >
+                Ver mais movimentações
+              </Button>
             </div>
-            <div className="flex flex-col gap-4 border-t border-border/60 pt-4 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
-              <span>
-                Showing {displayStart}-{displayEnd} of {totalItems} attachments
-              </span>
-              <Pagination className="sm:justify-end">
-                <PaginationContent>
-                  <PaginationItem>
-                    <PaginationPrevious
-                      href="#"
-                      onClick={(event) => {
-                        event.preventDefault();
-                        if (currentPage > 1) {
-                          onPageChange(currentPage - 1);
-                        }
-                      }}
-                      className={currentPage === 1 ? "pointer-events-none opacity-50" : undefined}
-                    />
-                  </PaginationItem>
-                  {paginationRange.map((item, itemIndex) => (
-                    <PaginationItem key={`${item}-${itemIndex}`}>
-                      {item === "ellipsis" ? (
-                        <PaginationEllipsis />
-                      ) : (
-                        <PaginationLink
-                          href="#"
-                          size="default"
-                          isActive={item === currentPage}
-                          onClick={(event) => {
-                            event.preventDefault();
-                            handlePageChange(item);
-                          }}
-                        >
-                          {item}
-                        </PaginationLink>
-                      )}
-                    </PaginationItem>
-                  ))}
-                  <PaginationItem>
-                    <PaginationNext
-                      href="#"
-                      onClick={(event) => {
-                        event.preventDefault();
-                        if (currentPage < totalPages) {
-                          onPageChange(currentPage + 1);
-                        }
-                      }}
-                      className={
-                        currentPage === totalPages || totalPages === 0
-                          ? "pointer-events-none opacity-50"
-                          : undefined
-                      }
-                    />
-                  </PaginationItem>
-                </PaginationContent>
-              </Pagination>
-            </div>
-          </>
-        )}
-      </CardContent>
-    </Card>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+interface ProcessosRelacionadosProps {
+  itens: ProcessoRelacionadoView[];
+  onAbrir: (identificador: string) => void;
+}
+
+function ProcessosRelacionadosTabela({ itens, onAbrir }: ProcessosRelacionadosProps) {
+  if (!itens.length) {
+    return (
+      <div className="rounded-lg border border-dashed border-muted-foreground/40 p-6 text-center text-sm text-muted-foreground">
+        Nenhum processo relacionado
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-muted-foreground/10">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Nº PROCESSO</TableHead>
+            <TableHead>GRAU</TableHead>
+            <TableHead>CLASSE</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {itens.map((item) => (
+            <TableRow
+              key={item.id}
+              className="cursor-pointer hover:bg-muted/40"
+              onClick={() => onAbrir(item.id)}
+            >
+              <TableCell>{item.numero}</TableCell>
+              <TableCell>{item.grau}</TableCell>
+              <TableCell>{item.classe}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
   );
 }
 
+interface JuditCardProps {
+  resumo: JuditResumo;
+  onVerTodosAnexos: () => void;
+}
+
+function JuditCard({ resumo, onVerTodosAnexos }: JuditCardProps) {
+  return (
+    <div className="space-y-4">
+      <Card className="border-primary/30 bg-primary/5">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-semibold">Status da última solicitação</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p>
+            <span className="font-semibold text-foreground">ID:</span> {resumo.requestId ?? NAO_INFORMADO}
+          </p>
+          <p>
+            <span className="font-semibold text-foreground">Status:</span> {resumo.status ?? NAO_INFORMADO}
+          </p>
+          <p>
+            <span className="font-semibold text-foreground">Atualizado em:</span> {resumo.atualizadoEm ?? NAO_INFORMADO}
+          </p>
+          {resumo.origem ? (
+            <p>
+              <span className="font-semibold text-foreground">Origem:</span> {resumo.origem}
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-semibold">Resumo da automação</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
+          <p>
+            <span className="font-semibold text-foreground">Consultas API:</span> {resumo.consultas}
+          </p>
+          <p>
+            <span className="font-semibold text-foreground">Última sincronização:</span> {resumo.ultimaSincronizacao ?? NAO_INFORMADO}
+          </p>
+          <p>
+            <span className="font-semibold text-foreground">Tracking:</span> {resumo.trackingId ?? NAO_INFORMADO}
+          </p>
+          <p>
+            <span className="font-semibold text-foreground">Janela:</span> {resumo.janela ?? NAO_INFORMADO}
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-semibold">Anexos recebidos</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm text-muted-foreground">
+          {resumo.anexos.slice(0, 3).map((anexo, index) => (
+            <div key={`${anexo.titulo}-${index}`} className="rounded-md border border-muted-foreground/10 bg-muted/40 p-3">
+              <p className="font-medium text-foreground">{anexo.titulo}</p>
+              <p className="text-xs">{anexo.data ?? NAO_INFORMADO}</p>
+              {anexo.url ? (
+                <a
+                  href={anexo.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs font-medium text-primary underline-offset-2 hover:underline"
+                >
+                  Abrir documento
+                </a>
+              ) : null}
+            </div>
+          ))}
+          <Button variant="outline" size="sm" onClick={onVerTodosAnexos}>
+            Ver todos
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+interface InformacoesProcessoProps {
+  dados: DadosProcesso;
+  partes: PartesAgrupadas;
+}
+
+export function InformacoesProcesso({ dados, partes }: InformacoesProcessoProps) {
+  return (
+    <div className="space-y-8">
+      <section aria-labelledby="dados-processo" className="space-y-4">
+        <div className="flex items-center gap-2">
+          <h2 id="dados-processo" className="text-lg font-semibold text-foreground">
+            Dados do processo
+          </h2>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <CampoInformacao rotulo="Tribunal de origem" valor={dados.tribunalDeOrigem} />
+          <CampoInformacao rotulo="Comarca" valor={dados.comarca} />
+          <CampoInformacao rotulo="Cidade" valor={dados.cidade} />
+          <CampoInformacao rotulo="Estado" valor={dados.estado} />
+          <CampoInformacao rotulo="Segmento da justiça" valor={dados.segmento} />
+          <CampoInformacao rotulo="Fase" valor={dados.fase} />
+          <CampoInformacao rotulo="Distribuído em" valor={dados.distribuidoEm} />
+          <CampoInformacao rotulo="Valor da causa" valor={dados.valorDaCausa} />
+          <CampoInformacao rotulo="Classe processual" valor={dados.classeProcessual} />
+          <CampoInformacao rotulo="Juiz/Relator" valor={dados.juizRelator} />
+          <CampoInformacao rotulo="Grau do processo" valor={dados.grau} />
+          <CampoInformacao rotulo="Órgão julgador" valor={dados.orgaoJulgador} />
+          <CampoInformacao rotulo="Assuntos" valor={dados.assuntos} className="md:col-span-2" />
+        </div>
+      </section>
+
+      <section aria-labelledby="partes-processo" className="space-y-4">
+        <div className="flex items-center gap-2">
+          <h2 id="partes-processo" className="text-lg font-semibold text-foreground">
+            Partes do processo
+          </h2>
+        </div>
+        <div className="space-y-6">
+          <SubsecaoPartes titulo="Polo ativo" itens={partes.ativo} />
+          <SubsecaoPartes titulo="Polo passivo" itens={partes.passivo} mostrarAdvogado />
+          {partes.outros.length ? (
+            <div className="space-y-3">
+              <h3 className="text-base font-semibold text-foreground">Outras partes</h3>
+              <div className="space-y-2">
+                {partes.outros.map((item, index) => (
+                  <div key={`${item.rotulo}-${index}`} className="rounded-lg border border-muted-foreground/10 bg-muted/30 p-3">
+                    <p className="text-sm font-semibold text-foreground">
+                      {item.rotulo} — {item.nome}
+                    </p>
+                    {item.documento ? (
+                      <p className="text-xs text-muted-foreground">Documento: {item.documento}</p>
+                    ) : null}
+                    {item.advogado ? (
+                      <p className="text-xs text-muted-foreground">Advogado: {item.advogado}</p>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+interface CampoInformacaoProps {
+  rotulo: string;
+  valor: string;
+  className?: string;
+}
+
+function CampoInformacao({ rotulo, valor, className }: CampoInformacaoProps) {
+  return (
+    <div className={cn("rounded-lg border border-muted-foreground/10 bg-muted/30 p-4", className)}>
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{rotulo}</p>
+      <p className="mt-1 text-sm text-foreground">{valor || NAO_INFORMADO}</p>
+    </div>
+  );
+}
+
+interface SubsecaoPartesProps {
+  titulo: string;
+  itens: ParteNormalizada[];
+  mostrarAdvogado?: boolean;
+}
+
+function SubsecaoPartes({ titulo, itens, mostrarAdvogado }: SubsecaoPartesProps) {
+  return (
+    <div className="space-y-3">
+      <h3 className="text-base font-semibold text-foreground">{titulo}</h3>
+      {itens.length === 0 ? (
+        <p className="text-sm text-muted-foreground">Nenhum registro informado.</p>
+      ) : (
+        <div className="space-y-2">
+          {itens.map((parte, index) => (
+            <div key={`${titulo}-${parte.nome}-${index}`} className="rounded-lg border border-muted-foreground/10 bg-muted/30 p-3">
+              <p className="text-sm font-semibold text-foreground">{parte.nome}</p>
+              {parte.documento ? (
+                <p className="text-xs text-muted-foreground">Documento: {parte.documento}</p>
+              ) : null}
+              {mostrarAdvogado && parte.advogado ? (
+                <p className="text-xs text-muted-foreground">Advogado: {parte.advogado}</p>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
 export default function VisualizarProcesso() {
-  const { processoId } = useParams();
+  const { processoId } = useParams<{ processoId: string }>();
   const navigate = useNavigate();
   const location = useLocation<{ initialTab?: string }>();
   const [loading, setLoading] = useState(true);
-  const [processo, setProcesso] = useState<ProcessoDetalhes | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const initialTabFromLocation = resolveTabValue(location.state?.initialTab);
-  const [activeTab, setActiveTab] = useState<ProcessoTab>(
-    initialTabFromLocation ?? "overview",
-  );
+  const [erro, setErro] = useState<string | null>(null);
+  const [viewModel, setViewModel] = useState<ProcessoViewModel | null>(null);
+  const [abaAtiva, setAbaAtiva] = useState("movimentacao");
+  const [mesesVisiveis, setMesesVisiveis] = useState(MESES_INICIAIS);
+  const [mesesAbertos, setMesesAbertos] = useState<string[]>([]);
+  const [movimentosPorMes, setMovimentosPorMes] = useState<Record<string, number>>({});
 
   useEffect(() => {
-    if (!initialTabFromLocation || initialTabFromLocation === activeTab) {
-      return;
+    if (location.state?.initialTab) {
+      setAbaAtiva(location.state.initialTab);
     }
-
-    setActiveTab(initialTabFromLocation);
-  }, [activeTab, initialTabFromLocation]);
+  }, [location.state]);
 
   useEffect(() => {
-    let cancelled = false;
+    let cancelado = false;
 
-    const fetchProcesso = async () => {
+    const carregar = async () => {
       if (!processoId) {
-        setProcesso(null);
-        setError("Invalid case identifier");
+        setErro("Processo não encontrado");
         setLoading(false);
         return;
       }
 
       setLoading(true);
-      setError(null);
+      setErro(null);
 
       try {
-        const res = await fetch(getApiUrl(`processos/${processoId}`), {
+        const resposta = await fetch(getApiUrl(`processos/${processoId}`), {
           headers: { Accept: "application/json" },
         });
 
-        const text = await res.text();
-        let json: unknown = null;
-
-        if (text) {
-          try {
-            json = JSON.parse(text);
-          } catch (parseError) {
-            console.error("Failed to parse case payload", parseError);
-          }
+        if (!resposta.ok) {
+          throw new Error(`Não foi possível carregar o processo (${resposta.status})`);
         }
 
-        if (!res.ok) {
-          const message =
-            json && typeof json === "object" &&
-            "error" in json &&
-            typeof (json as { error: unknown }).error === "string"
-              ? (json as { error: string }).error
-              : `Failed to load the case (HTTP ${res.status})`;
-          throw new Error(message);
-        }
+        const json = (await resposta.json()) as ApiProcessoResponse;
+        const modelo = mapApiProcessoToViewModel(json);
 
-        if (!json || typeof json !== "object") {
-          throw new Error("Invalid response received while loading the case");
+        if (!cancelado) {
+          setViewModel(modelo);
+          setMesesAbertos(modelo.grupos.length ? [modelo.grupos[0].chave] : []);
+          const inicial: Record<string, number> = {};
+          modelo.grupos.forEach((grupo) => {
+            inicial[grupo.chave] = MOVIMENTACOES_POR_LAJE;
+          });
+          setMovimentosPorMes(inicial);
+          setMesesVisiveis(Math.min(MESES_INICIAIS, modelo.grupos.length));
         }
-
-        const processoResponse = json as ApiProcessoResponse;
-        const detalhes = mapApiProcessoToDetalhes(processoResponse, processoId);
-
-        if (!cancelled) {
-          setProcesso(detalhes);
-        }
-      } catch (fetchError) {
-        const message =
-          fetchError instanceof Error
-            ? fetchError.message
-            : "Failed to load the case details";
-        if (!cancelled) {
-          setProcesso(null);
-          setError(message);
+      } catch (error) {
+        const mensagem = error instanceof Error ? error.message : "Erro ao carregar o processo";
+        if (!cancelado) {
+          setErro(mensagem);
+          setViewModel(null);
         }
       } finally {
-        if (!cancelled) {
+        if (!cancelado) {
           setLoading(false);
         }
       }
     };
 
-    fetchProcesso();
+    void carregar();
 
     return () => {
-      cancelled = true;
+      cancelado = true;
     };
   }, [processoId]);
 
+  const totalMovimentacoes = viewModel?.movimentacoes.length ?? 0;
+  const usarVirtualizacao = totalMovimentacoes > 300;
 
-  const statusBadgeLabel = useMemo(() => {
-    if (!processo) {
+  const gruposVisiveis = useMemo(() => {
+    if (!viewModel) {
+      return [] as GrupoMovimentacao[];
+    }
+
+    return viewModel.grupos.slice(0, mesesVisiveis);
+  }, [viewModel, mesesVisiveis]);
+
+  const handleToggleMes = useCallback(
+    (chave: string) => {
+      setMesesAbertos((anteriores) =>
+        anteriores.includes(chave)
+          ? anteriores.filter((item) => item !== chave)
+          : [...anteriores, chave],
+      );
+    },
+    [],
+  );
+
+  const handleVerMaisMovimentos = useCallback(
+    (chave: string) => {
+      setMovimentosPorMes((anteriores) => ({
+        ...anteriores,
+        [chave]: (anteriores[chave] ?? MOVIMENTACOES_POR_LAJE) + MOVIMENTACOES_POR_LAJE,
+      }));
+    },
+    [],
+  );
+
+  const handleCarregarMaisMeses = useCallback(() => {
+    setMesesVisiveis((valor) => (viewModel ? Math.min(viewModel.grupos.length, valor + 2) : valor));
+  }, [viewModel]);
+
+  const handleAbrirRelacionado = useCallback(
+    (identificador: string) => {
+      navigate(`/processos/${identificador}`);
+    },
+    [navigate],
+  );
+
+  const handleVerTodosAnexos = useCallback(() => {
+    setAbaAtiva("judit");
+  }, []);
+
+  const conteudoMovimentacoes = useMemo(() => {
+    if (!viewModel) {
       return null;
     }
 
-    return translateLabelToEnglish(processo.status);
-  }, [processo]);
-
-  const typeBadgeLabel = useMemo(() => {
-    if (!processo) {
-      return null;
-    }
-
-    return translateLabelToEnglish(processo.tipo);
-  }, [processo]);
-
-  const anexos = processo?.responseData?.anexos ?? [];
-  const totalAttachments = anexos.length;
-  const [attachmentsPage, setAttachmentsPage] = useState(1);
-  const [attachmentsPageSize, setAttachmentsPageSize] = useState(10);
-  const [historyPage, setHistoryPage] = useState(1);
-  const [historyPageSize, setHistoryPageSize] = useState(10);
-  const [selectedMovement, setSelectedMovement] = useState<TimelineEntry | null>(null);
-
-  useEffect(() => {
-    setAttachmentsPage(1);
-  }, [processo?.id]);
-
-  useEffect(() => {
-    setHistoryPage(1);
-  }, [processo?.id]);
-
-  useEffect(() => {
-    setAttachmentsPage(1);
-  }, [attachmentsPageSize]);
-
-  useEffect(() => {
-    setHistoryPage(1);
-  }, [historyPageSize]);
-
-  const attachmentsTotalPages = useMemo(() => {
-    if (totalAttachments === 0) {
-      return 1;
-    }
-
-    return Math.max(1, Math.ceil(totalAttachments / attachmentsPageSize));
-  }, [attachmentsPageSize, totalAttachments]);
-
-  const timelineEntries = useMemo(() => {
-    if (!processo) {
-      return [];
-    }
-
-    return createTimelineEntries(processo.movimentacoes);
-  }, [processo]);
-
-  const totalTimelineEntries = timelineEntries.length;
-
-  const overviewFields = useMemo(() => {
-    if (!processo) {
-      return [] as { label: string; value: string }[];
-    }
-
-    const distributionDate =
-      formatDateToEnUS(processo.dataDistribuicao) ??
-      processo.dataDistribuicaoFormatada ??
-      NOT_INFORMED_LABEL;
-
-    return [
-      { label: "Case number", value: processo.numero || NOT_INFORMED_LABEL },
-      {
-        label: "Status",
-        value: translateLabelToEnglish(processo.status) || NOT_INFORMED_LABEL,
-      },
-      {
-        label: "Type",
-        value: translateLabelToEnglish(processo.tipo) || NOT_INFORMED_LABEL,
-      },
-      {
-        label: "Judicial class",
-        value:
-          translateLabelToEnglish(processo.classeJudicial) || NOT_INFORMED_LABEL,
-      },
-      {
-        label: "Subject",
-        value: translateLabelToEnglish(processo.assunto) || NOT_INFORMED_LABEL,
-      },
-      {
-        label: "Jurisdiction",
-        value:
-          translateLabelToEnglish(processo.jurisdicao) || NOT_INFORMED_LABEL,
-      },
-      {
-        label: "Judging body",
-        value:
-          translateLabelToEnglish(processo.orgaoJulgador) || NOT_INFORMED_LABEL,
-      },
-      {
-        label: "Responsible attorney",
-        value:
-          translateLabelToEnglish(processo.advogadoResponsavel) ||
-          NOT_INFORMED_LABEL,
-      },
-      {
-        label: "Distribution date",
-        value: distributionDate,
-      },
-      {
-        label: "Created at",
-        value: processo.criadoEm
-          ? formatDateTimeToEnUS(processo.criadoEm)
-          : "Date not available",
-      },
-      {
-        label: "Updated at",
-        value: processo.atualizadoEm
-          ? formatDateTimeToEnUS(processo.atualizadoEm)
-          : "Date not available",
-      },
-      {
-        label: "Last synchronization",
-        value: processo.ultimaSincronizacao
-          ? formatDateTimeToEnUS(processo.ultimaSincronizacao)
-          : "Date not available",
-      },
-      {
-        label: "Unique timeline updates",
-        value: String(totalTimelineEntries),
-      },
-    ];
-  }, [processo, totalTimelineEntries]);
-
-  const historyTotalPages = useMemo(() => {
-    if (totalTimelineEntries === 0) {
-      return 1;
-    }
-
-    return Math.max(1, Math.ceil(totalTimelineEntries / historyPageSize));
-  }, [historyPageSize, totalTimelineEntries]);
-
-  useEffect(() => {
-    setAttachmentsPage((previous) => {
-      if (previous > attachmentsTotalPages) {
-        return attachmentsTotalPages;
-      }
-
-      if (previous < 1) {
-        return 1;
-      }
-
-      return previous;
-    });
-  }, [attachmentsTotalPages]);
-
-  useEffect(() => {
-    setHistoryPage((previous) => {
-      if (previous > historyTotalPages) {
-        return historyTotalPages;
-      }
-
-      if (previous < 1) {
-        return 1;
-      }
-
-      return previous;
-    });
-  }, [historyTotalPages]);
-
-  const paginatedAttachments = useMemo(() => {
-    if (totalAttachments === 0) {
-      return [];
-    }
-
-    const start = (attachmentsPage - 1) * attachmentsPageSize;
-    const end = start + attachmentsPageSize;
-
-    return anexos.slice(start, end);
-  }, [anexos, attachmentsPage, attachmentsPageSize, totalAttachments]);
-
-  const paginatedTimelineEntries = useMemo(() => {
-    if (totalTimelineEntries === 0) {
-      return [];
-    }
-
-    const start = (historyPage - 1) * historyPageSize;
-    const end = start + historyPageSize;
-
-    return timelineEntries.slice(start, end);
-  }, [historyPage, historyPageSize, timelineEntries, totalTimelineEntries]);
-
-  const timelineGroups = useMemo(
-    () => groupTimelineEntries(paginatedTimelineEntries),
-    [paginatedTimelineEntries],
-  );
-
-  const hasTimelineEntries = totalTimelineEntries > 0;
-  const historyPaginationRange = useMemo(
-    () => buildPaginationRange(historyPage, historyTotalPages),
-    [historyPage, historyTotalPages],
-  );
-
-  const historyDisplayStart = !hasTimelineEntries
-    ? 0
-    : (historyPage - 1) * historyPageSize + 1;
-  const historyDisplayEnd = !hasTimelineEntries
-    ? 0
-    : Math.min(historyDisplayStart + paginatedTimelineEntries.length - 1, totalTimelineEntries);
-  const lastPaginatedEntryId =
-    paginatedTimelineEntries.length > 0
-      ? paginatedTimelineEntries[paginatedTimelineEntries.length - 1].id
-      : null;
-
-  const handleAttachmentsPageChange = useCallback(
-    (page: number) => {
-      setAttachmentsPage((current) => {
-        const nextPage = Math.min(
-          Math.max(Number.isFinite(page) ? page : current, 1),
-          attachmentsTotalPages,
-        );
-
-        return nextPage;
-      });
-    },
-    [attachmentsTotalPages],
-  );
-
-  const handleAttachmentsPageSizeChange = useCallback((size: number) => {
-    const nextSize = Number.isFinite(size) && size > 0 ? Math.floor(size) : 10;
-
-    setAttachmentsPageSize((currentSize) => {
-      if (currentSize === nextSize) {
-        return currentSize;
-      }
-
-      return nextSize;
-    });
-  }, []);
-
-  const handleHistoryPageChange = useCallback(
-    (page: number) => {
-      setHistoryPage((current) => {
-        const nextPage = Math.min(
-          Math.max(Number.isFinite(page) ? page : current, 1),
-          historyTotalPages,
-        );
-
-        return nextPage;
-      });
-    },
-    [historyTotalPages],
-  );
-
-  const handleHistoryPageSizeChange = useCallback((size: number) => {
-    const nextSize = Number.isFinite(size) && size > 0 ? Math.floor(size) : 10;
-
-    setHistoryPageSize((currentSize) => {
-      if (currentSize === nextSize) {
-        return currentSize;
-      }
-
-      return nextSize;
-    });
-  }, []);
-
-  if (loading && !processo) {
     return (
-      <div className="space-y-6 p-4 sm:p-6">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <Skeleton className="h-10 w-32" />
-          <div className="space-y-2 lg:w-1/2">
-            <Skeleton className="h-8 w-full" />
-            <Skeleton className="h-4 w-3/4" />
-          </div>
-        </div>
-        <div className="grid gap-4 lg:grid-cols-2">
-          <Skeleton className="h-64 w-full rounded-xl" />
-          <Skeleton className="h-64 w-full rounded-xl" />
-        </div>
-
-      </div>
-    );
-  }
-
-  if (!processo) {
-    return (
-      <div className="space-y-6 p-4 sm:p-6">
-        <Button variant="outline" onClick={() => navigate(-1)} className="w-fit">
-          <ArrowLeft className="mr-2 h-4 w-4" />
-          Back
-        </Button>
-        <Alert variant="destructive">
-          <AlertCircle className="h-4 w-4" />
-          <AlertTitle>Unable to load case</AlertTitle>
-          <AlertDescription>
-            {error ?? "The requested case information could not be found."}
-
+      <div className="space-y-6">
+        <Alert className="border-amber-300 bg-amber-50 text-amber-900">
+          <AlertTitle className="flex items-center gap-2 text-sm font-semibold">
+            <Info className="h-4 w-4" /> Dica
+          </AlertTitle>
+          <AlertDescription className="text-sm text-amber-900/80">
+            {TEXTO_DICA}{" "}
+            <Button variant="link" size="sm" className="h-auto p-0 align-baseline">
+              Configurar filtros
+            </Button>
           </AlertDescription>
         </Alert>
+
+        <div className="space-y-4">
+          {gruposVisiveis.map((grupo) => (
+            <TimelineMes
+              key={grupo.chave}
+              grupo={{ ...grupo, itens: grupo.itens }}
+              aberto={mesesAbertos.includes(grupo.chave)}
+              onToggle={handleToggleMes}
+              movimentacoesVisiveis={movimentosPorMes[grupo.chave] ?? MOVIMENTACOES_POR_LAJE}
+              onVerMais={handleVerMaisMovimentos}
+              virtualizado={usarVirtualizacao}
+            />
+          ))}
+        </div>
+
+        {viewModel.grupos.length > gruposVisiveis.length ? (
+          <div className="text-center">
+            <Button
+              variant="outline"
+              onClick={handleCarregarMaisMeses}
+              aria-expanded={gruposVisiveis.length < viewModel.grupos.length}
+            >
+              Carregar mais meses
+            </Button>
+          </div>
+        ) : null}
       </div>
     );
-  }
+  }, [
+    viewModel,
+    gruposVisiveis,
+    mesesAbertos,
+    movimentosPorMes,
+    usarVirtualizacao,
+    handleToggleMes,
+    handleVerMaisMovimentos,
+    handleCarregarMaisMeses,
+  ]);
+
+  const conteudoInformacoes = viewModel ? (
+    <InformacoesProcesso dados={viewModel.dados} partes={viewModel.partes} />
+  ) : null;
+
+  const conteudoRelacionados = viewModel ? (
+    <ProcessosRelacionadosTabela itens={viewModel.relacionados} onAbrir={handleAbrirRelacionado} />
+  ) : null;
+
+  const conteudoJudit = viewModel ? (
+    <JuditCard resumo={viewModel.judit} onVerTodosAnexos={handleVerTodosAnexos} />
+  ) : null;
 
   return (
-    <div className="space-y-6 p-4 sm:p-6">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <Button variant="outline" onClick={() => navigate(-1)} className="w-fit">
-          <ArrowLeft className="mr-2 h-4 w-4" />
-          Back
-        </Button>
-        <div className="space-y-2">
-          <h1 className="text-3xl font-bold text-foreground">
-            Case {processo.numero}
-          </h1>
-          <p className="text-sm text-muted-foreground">
-            Review the registered case data and keep every update organized in a single workspace.
-          </p>
+    <div className="space-y-6">
+      <header className="space-y-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <Button variant="ghost" size="sm" onClick={() => navigate(-1)}>
+              <ArrowLeft className="mr-2 h-4 w-4" /> Voltar
+            </Button>
+            <Breadcrumb>
+              <BreadcrumbList>
+                <BreadcrumbItem>
+                  <BreadcrumbPage>Processos</BreadcrumbPage>
+                </BreadcrumbItem>
+                <BreadcrumbSeparator />
+                <BreadcrumbItem>
+                  <BreadcrumbPage>Visualizar</BreadcrumbPage>
+                </BreadcrumbItem>
+              </BreadcrumbList>
+            </Breadcrumb>
+          </div>
         </div>
-      </div>
 
-      <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
-        <TabsList className="w-full justify-start bg-muted/50">
-          <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="attachments">Attachments</TabsTrigger>
-          <TabsTrigger value="timeline">Timeline</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="overview" className="space-y-6">
-          <Card>
-            <CardHeader className="space-y-3">
-              <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                <div className="space-y-1">
-                  <CardTitle className="text-2xl font-semibold text-foreground">
-                    Case overview
-                  </CardTitle>
-                  <CardDescription>
-                    Review the essential data captured for this case.
-                  </CardDescription>
-                </div>
-                {processo ? (
-                  <div className="flex flex-wrap items-center gap-2">
-                    {statusBadgeLabel ? (
-                      <Badge className={`text-xs ${getStatusBadgeClassName(processo.status)}`}>
-                        {statusBadgeLabel}
-                      </Badge>
-                    ) : null}
-                    {typeBadgeLabel ? (
-                      <Badge
-                        variant="outline"
-                        className={`text-xs ${getTipoBadgeClassName(processo.tipo)}`}
-                      >
-                        {typeBadgeLabel}
-                      </Badge>
-                    ) : null}
-                  </div>
-                ) : null}
-              </div>
-            </CardHeader>
-            <CardContent>
-              {overviewFields.length === 0 ? (
-                <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-4 text-sm text-muted-foreground">
-                  No case information is available.
-                </div>
-              ) : (
-                <dl className="grid gap-4 sm:grid-cols-2">
-                  {overviewFields.map((field) => (
-                    <div key={field.label} className="space-y-1">
-                      <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                        {field.label}
-                      </dt>
-                      <dd className="text-sm text-foreground">{field.value}</dd>
-                    </div>
-                  ))}
-                </dl>
-              )}
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        <TabsContent value="attachments" className="space-y-6">
-          <ProcessoAttachmentsSection
-            attachments={paginatedAttachments}
-            currentPage={attachmentsPage}
-            totalPages={attachmentsTotalPages}
-            pageSize={attachmentsPageSize}
-            totalItems={totalAttachments}
-            onPageChange={handleAttachmentsPageChange}
-            onPageSizeChange={handleAttachmentsPageSizeChange}
-            processoId={processo.id}
-          />
-        </TabsContent>
-
-        <TabsContent value="timeline" className="space-y-6">
-          <Card>
-            <CardHeader className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-              <div className="space-y-1">
-                <CardTitle className="text-xl font-semibold">Case timeline</CardTitle>
-                <CardDescription>
-                  Explore a chronological view of the official updates recorded for this lawsuit.
-                </CardDescription>
-              </div>
-              {hasTimelineEntries ? (
-                <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                  <span className="font-medium uppercase tracking-wide">Items per page</span>
-                  <Select
-                    value={String(historyPageSize)}
-                    onValueChange={(value) => {
-                      const parsed = Number(value);
-                      if (!Number.isFinite(parsed) || parsed <= 0) {
-                        return;
-                      }
-                      handleHistoryPageSizeChange(parsed);
-                    }}
-                  >
-                    <SelectTrigger className="h-8 w-[90px] text-xs" aria-label="Items per page">
-                      <SelectValue placeholder={`${historyPageSize}`} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {HISTORY_PAGE_SIZE_OPTIONS.map((option) => (
-                        <SelectItem key={option} value={String(option)}>
-                          {option}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              ) : null}
-            </CardHeader>
-            <CardContent className="space-y-6">
-              {!hasTimelineEntries ? (
-                <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-4 sm:p-6 text-sm text-muted-foreground">
-                  No updates have been recorded yet.
-                </div>
-              ) : (
-                <>
-                  <div className="space-y-8">
-                    {timelineGroups.map((group) => {
-                      return (
-                        <div key={`${group.dateKey}-${group.dateLabel}`} className="space-y-4">
-                          <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
-                            <span className="inline-flex w-fit items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
-                              {group.dateLabel}
-                            </span>
-                            {group.weekdayLabel ? (
-                              <span className="text-xs text-muted-foreground capitalize">
-                                {group.weekdayLabel}
-                              </span>
-                            ) : null}
-                          </div>
-                          <div className="relative pl-6 sm:pl-10">
-                            <div
-                              className="pointer-events-none absolute left-[11px] top-2 bottom-4 w-px bg-border/60 sm:left-[17px]"
-                              aria-hidden
-                            />
-                            <div className="space-y-6">
-                              {group.items.map((entry) => {
-                                const isLastInPage = lastPaginatedEntryId === entry.id;
-                                const indicatorDotClasses = isLastInPage
-                                  ? "bg-muted-foreground"
-                                  : "bg-primary";
-
-                                return (
-                                  <div key={entry.id} className="relative pl-6 sm:pl-10">
-                                    <span
-                                      className="absolute left-[-3px] top-2 flex h-4 w-4 items-center justify-center rounded-full border border-border/60 bg-background sm:left-0"
-                                      aria-hidden
-                                    >
-                                      <span className={`h-2 w-2 rounded-full ${indicatorDotClasses}`} />
-                                    </span>
-                                    <div
-                                      className={cn(
-                                        "rounded-xl border border-border/60 bg-background/80 p-5 shadow-sm transition hover:border-primary/40 hover:shadow-md",
-                                        entry.isJudgeDocument &&
-                                          "border-amber-400/70 bg-amber-50/40 dark:bg-amber-500/10",
-                                      )}
-                                    >
-                                      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                                        <div className="space-y-2">
-                                          <div className="flex flex-wrap items-center gap-2">
-                                            <p className="text-sm font-semibold text-foreground">{entry.type}</p>
-                                            {entry.publicationType ? (
-                                              <Badge
-                                                variant="outline"
-                                                className="rounded-full px-2.5 text-[10px] uppercase tracking-wide"
-                                              >
-                                                {entry.publicationType}
-                                              </Badge>
-                                            ) : null}
-                                            {entry.classification ? (
-                                              <Badge
-                                                variant="secondary"
-                                                className="rounded-full px-2.5 text-[10px] uppercase tracking-wide"
-                                              >
-                                                {entry.classification}
-                                              </Badge>
-                                            ) : null}
-                                            {entry.isJudgeDocument ? (
-                                              <Badge
-                                                variant="destructive"
-                                                className="rounded-full px-2.5 text-[10px] uppercase tracking-wide"
-                                              >
-                                                Judge decision
-                                              </Badge>
-                                            ) : null}
-                                          </div>
-                                          {entry.source ? (
-                                            <div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
-                                              <Newspaper className="h-3.5 w-3.5" />
-                                              <span>{entry.source}</span>
-                                            </div>
-                                          ) : null}
-                                        </div>
-                                        <div className="flex flex-col items-start gap-1 text-xs text-muted-foreground sm:items-end">
-                                          {entry.timeLabel ? (
-                                            <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
-                                              <Clock className="h-4 w-4 text-primary" />
-                                              {entry.timeLabel}
-                                            </span>
-                                          ) : (
-                                            <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
-                                              <Clock className="h-4 w-4 text-primary" />
-                                              Time not available
-                                            </span>
-                                          )}
-                                          {entry.recordedAt ? (
-                                            <span>Recorded: {entry.recordedAt}</span>
-                                          ) : null}
-                                          {entry.updatedAt && entry.updatedAt !== entry.recordedAt ? (
-                                            <span>Updated: {entry.updatedAt}</span>
-                                          ) : null}
-                                        </div>
-                                      </div>
-                                      {entry.excerpt ? (
-                                        <p className="mt-3 whitespace-pre-line text-sm text-muted-foreground">
-                                          {entry.excerpt}
-                                        </p>
-                                      ) : null}
-                                      {(entry.hasMoreContent || entry.isJudgeDocument) && entry.content ? (
-                                        <Button
-                                          variant="outline"
-                                          size="xs"
-                                          className="mt-3"
-                                          onClick={() => setSelectedMovement(entry)}
-                                        >
-                                          {entry.isJudgeDocument
-                                            ? "View judge decision"
-                                            : "View full content"}
-                                        </Button>
-                                      ) : null}
-                                    </div>
-                                  </div>
-                                );
-                              })}
-                            </div>
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                  <div className="flex flex-col gap-4 border-t border-border/60 pt-4 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
-                    <span>
-                      Showing {historyDisplayStart}-{historyDisplayEnd} of {totalTimelineEntries} updates
-                    </span>
-                    <Pagination className="sm:justify-end">
-                      <PaginationContent>
-                        <PaginationItem>
-                          <PaginationPrevious
-                            href="#"
-                            onClick={(event) => {
-                              event.preventDefault();
-                              if (historyPage > 1) {
-                                handleHistoryPageChange(historyPage - 1);
-                              }
-                            }}
-                            className={historyPage === 1 ? "pointer-events-none opacity-50" : undefined}
-                          />
-                        </PaginationItem>
-                        {historyPaginationRange.map((item, itemIndex) => (
-                          <PaginationItem key={`${item}-${itemIndex}`}>
-                            {item === "ellipsis" ? (
-                              <PaginationEllipsis />
-                            ) : (
-                              <PaginationLink
-                                href="#"
-                                size="default"
-                                isActive={item === historyPage}
-                                onClick={(event) => {
-                                  event.preventDefault();
-                                  handleHistoryPageChange(item);
-                                }}
-                              >
-                                {item}
-                              </PaginationLink>
-                            )}
-                          </PaginationItem>
-                        ))}
-                        <PaginationItem>
-                          <PaginationNext
-                            href="#"
-                            onClick={(event) => {
-                              event.preventDefault();
-                              if (historyPage < historyTotalPages) {
-                                handleHistoryPageChange(historyPage + 1);
-                              }
-                            }}
-                            className={
-                              historyPage === historyTotalPages || historyTotalPages === 0
-                                ? "pointer-events-none opacity-50"
-                                : undefined
-                            }
-                          />
-                        </PaginationItem>
-                      </PaginationContent>
-                    </Pagination>
-                  </div>
-                </>
-              )}
-            </CardContent>
-          </Card>
-        </TabsContent>
-      </Tabs>
-      <Dialog
-        open={selectedMovement !== null}
-        onOpenChange={(open) => {
-          if (!open) {
-            setSelectedMovement(null);
-          }
-        }}
-      >
-        <DialogContent className="max-w-3xl">
-          <DialogHeader>
-            <DialogTitle>{selectedMovement?.type ?? "Timeline entry"}</DialogTitle>
-            <DialogDescription>
-              {selectedMovement
-                ? `${selectedMovement.dateLabel}${selectedMovement.timeLabel ? ` • ${selectedMovement.timeLabel}` : ""}`
-                : "Detailed information about the selected update."}
-            </DialogDescription>
-          </DialogHeader>
-          <ScrollArea className="max-h-[70vh] pr-2">
-            <div className="space-y-4 pt-1">
-              {selectedMovement?.content ? (
-                <p className="whitespace-pre-line text-sm text-foreground">
-                  {selectedMovement.content}
-                </p>
-              ) : (
-                <p className="text-sm text-muted-foreground">
-                  No additional text is available for this timeline entry.
-                </p>
-              )}
-              {selectedMovement?.source ? (
-                <p className="text-xs text-muted-foreground">Source: {selectedMovement.source}</p>
-              ) : null}
-              {selectedMovement?.recordedAt ? (
-                <p className="text-xs text-muted-foreground">
-                  Recorded: {selectedMovement.recordedAt}
-                </p>
-              ) : null}
-              {selectedMovement?.updatedAt &&
-              selectedMovement.updatedAt !== selectedMovement.recordedAt ? (
-                <p className="text-xs text-muted-foreground">
-                  Updated: {selectedMovement.updatedAt}
-                </p>
+        {loading ? (
+          <div className="space-y-3">
+            <Skeleton className="h-8 w-1/2" />
+            <Skeleton className="h-5 w-1/3" />
+          </div>
+        ) : erro ? (
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>Erro ao carregar o processo</AlertTitle>
+            <AlertDescription>{erro}</AlertDescription>
+          </Alert>
+        ) : viewModel ? (
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="text-2xl font-semibold text-foreground">{viewModel.cabecalho.numero}</h1>
+              <Badge variant="outline" className="border-emerald-200 bg-emerald-50 text-emerald-700">
+                {viewModel.cabecalho.grau}
+              </Badge>
+              {viewModel.cabecalho.ultimaMovimentacao ? (
+                <span className="text-sm text-muted-foreground">
+                  Última movimentação em {viewModel.cabecalho.ultimaMovimentacao}
+                </span>
               ) : null}
             </div>
-          </ScrollArea>
-          <DialogFooter className="sm:justify-end">
-            <Button variant="outline" onClick={() => setSelectedMovement(null)}>
-              Close
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+            <div className="flex flex-wrap gap-2">
+              {viewModel.cabecalho.chips.map((chip) => (
+                <Badge key={chip} className="bg-slate-100 text-slate-700">
+                  {chip}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {viewModel ? (
+          <div className="grid gap-4 lg:grid-cols-[repeat(4,minmax(0,1fr))_240px]">
+            <Card className="border-emerald-200 bg-emerald-50 text-emerald-900">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-semibold uppercase tracking-wide text-emerald-800">
+                  Tribunal
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="text-xl font-semibold">{viewModel.cabecalho.tribunal}</CardContent>
+            </Card>
+            <Card className="border-emerald-200 bg-emerald-50 text-emerald-900">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-semibold uppercase tracking-wide text-emerald-800">
+                  Valor da causa
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="text-xl font-semibold">{viewModel.cabecalho.valorDaCausa}</CardContent>
+            </Card>
+            <Card className="border-emerald-200 bg-emerald-50 text-emerald-900">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-semibold uppercase tracking-wide text-emerald-800">
+                  Distribuído em
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="text-xl font-semibold">{viewModel.cabecalho.distribuidoEm}</CardContent>
+            </Card>
+            <Card className="border-emerald-200 bg-emerald-50 text-emerald-900">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-semibold uppercase tracking-wide text-emerald-800">
+                  Partes
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="flex items-center justify-between">
+                <span className="text-xl font-semibold">{viewModel.partes.total}</span>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="sm" className="text-emerald-800">
+                      Ver lista
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-64">
+                    <DropdownMenuLabel>Partes cadastradas</DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    {viewModel.cabecalho.partesResumo.length ? (
+                      viewModel.cabecalho.partesResumo.map((parte, index) => (
+                        <DropdownMenuItem key={`${parte.nome}-${index}`} className="flex flex-col items-start">
+                          <span className="font-medium text-foreground">{parte.nome}</span>
+                          {parte.documento ? (
+                            <span className="text-xs text-muted-foreground">{parte.documento}</span>
+                          ) : null}
+                        </DropdownMenuItem>
+                      ))
+                    ) : (
+                      <DropdownMenuItem className="text-muted-foreground">
+                        Nenhuma parte informada
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </CardContent>
+            </Card>
+            <Card className="border-l-4 border-l-primary bg-primary/10 text-primary">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-semibold uppercase tracking-wide">
+                  Classe processual
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="text-lg font-semibold text-primary">
+                {viewModel.cabecalho.classeProcessual}
+              </CardContent>
+            </Card>
+          </div>
+        ) : null}
+      </header>
+
+      <section>
+        <Tabs value={abaAtiva} onValueChange={setAbaAtiva} className="space-y-4">
+          <TabsList>
+            <TabsTrigger value="movimentacao">Movimentação processual</TabsTrigger>
+            <TabsTrigger value="informacoes">Informações</TabsTrigger>
+            <TabsTrigger value="relacionados">Processos relacionados</TabsTrigger>
+            <TabsTrigger value="judit">JUDIT IA</TabsTrigger>
+          </TabsList>
+          <TabsContent value="movimentacao" className="space-y-4">
+            {loading ? (
+              <div className="space-y-4">
+                {Array.from({ length: 3 }).map((_, index) => (
+                  <Skeleton key={index} className="h-32 w-full" />
+                ))}
+              </div>
+            ) : erro ? (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>Erro ao carregar movimentações</AlertTitle>
+                <AlertDescription>{erro}</AlertDescription>
+              </Alert>
+            ) : (
+              conteudoMovimentacoes
+            )}
+          </TabsContent>
+          <TabsContent value="informacoes">
+            {loading ? (
+              <Skeleton className="h-96 w-full" />
+            ) : erro ? (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>Erro ao carregar informações</AlertTitle>
+                <AlertDescription>{erro}</AlertDescription>
+              </Alert>
+            ) : (
+              conteudoInformacoes
+            )}
+          </TabsContent>
+          <TabsContent value="relacionados">
+            {loading ? (
+              <Skeleton className="h-48 w-full" />
+            ) : erro ? (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>Erro ao carregar relacionados</AlertTitle>
+                <AlertDescription>{erro}</AlertDescription>
+              </Alert>
+            ) : (
+              conteudoRelacionados
+            )}
+          </TabsContent>
+          <TabsContent value="judit">
+            {loading ? (
+              <Skeleton className="h-64 w-full" />
+            ) : erro ? (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>Erro ao carregar informações da JUDIT</AlertTitle>
+                <AlertDescription>{erro}</AlertDescription>
+              </Alert>
+            ) : (
+              conteudoJudit
+            )}
+          </TabsContent>
+        </Tabs>
+      </section>
     </div>
   );
 }
-
-

--- a/frontend/src/pages/operator/utils/processo-ui.ts
+++ b/frontend/src/pages/operator/utils/processo-ui.ts
@@ -1,0 +1,259 @@
+import { useMemo } from "react";
+
+export interface MovimentoComIdEData {
+  id: string;
+  data: Date | null;
+}
+
+export interface GrupoDeMovimentacoes<T extends MovimentoComIdEData> {
+  chave: string;
+  rotulo: string;
+  ano: number | null;
+  mes: number | null;
+  itens: T[];
+}
+
+export interface MovimentacaoBruta {
+  id?: string | number | null;
+  data?: string | null;
+  tipo?: string | null;
+  conteudo?: string | null;
+  texto_categoria?: string | null;
+}
+
+const ENTITY_MAP: Record<string, string> = {
+  "&nbsp;": " ",
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#34;": '"',
+  "&#39;": "'",
+  "&#x27;": "'",
+  "&#x2F;": "/",
+};
+
+const NORMALIZE_TAG_REGEX = /<[^>]+>/gi;
+const MULTIPLE_SPACES_REGEX = /[ \t]{2,}/g;
+const HTML_ENTITY_DEC_REGEX = /&#(\d+);/g;
+const HTML_ENTITY_HEX_REGEX = /&#x([0-9a-f]+);/gi;
+
+export function decodificarHtml(valor: string): string {
+  if (typeof valor !== "string" || !valor) {
+    return "";
+  }
+
+  let resultado = valor;
+
+  Object.entries(ENTITY_MAP).forEach(([entity, replacement]) => {
+    resultado = resultado.replace(new RegExp(entity, "g"), replacement);
+  });
+
+  resultado = resultado
+    .replace(HTML_ENTITY_DEC_REGEX, (_, codigo: string) => {
+      const numero = Number.parseInt(codigo, 10);
+      return Number.isFinite(numero) ? String.fromCharCode(numero) : "";
+    })
+    .replace(HTML_ENTITY_HEX_REGEX, (_, codigo: string) => {
+      const numero = Number.parseInt(codigo, 16);
+      return Number.isFinite(numero) ? String.fromCharCode(numero) : "";
+    });
+
+  return resultado;
+}
+
+export function normalizarTexto(valor?: string | null): string {
+  if (typeof valor !== "string" || !valor.trim()) {
+    return "";
+  }
+
+  let texto = decodificarHtml(valor)
+    .replace(/<br\s*\/?\s*>/gi, "\n")
+    .replace(/<\/?p>/gi, "\n")
+    .replace(/\r\n/g, "\n")
+    .replace(/\u00a0/g, " ");
+
+  texto = texto.replace(NORMALIZE_TAG_REGEX, " ");
+  texto = texto.replace(/\*\*/g, "");
+  texto = texto.replace(/\\/g, "");
+  texto = texto.replace(MULTIPLE_SPACES_REGEX, " ");
+  texto = texto
+    .split("\n")
+    .map((linha) => linha.trim())
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n");
+
+  return texto.trim();
+}
+
+export function diasDesde(data: Date | string | null | undefined): number | null {
+  if (!data) {
+    return null;
+  }
+
+  const objetoData = data instanceof Date ? data : new Date(data);
+
+  if (Number.isNaN(objetoData.getTime())) {
+    return null;
+  }
+
+  const hoje = new Date();
+  const inicio = Date.UTC(
+    objetoData.getFullYear(),
+    objetoData.getMonth(),
+    objetoData.getDate(),
+  );
+  const hojeUtc = Date.UTC(hoje.getFullYear(), hoje.getMonth(), hoje.getDate());
+
+  return Math.max(0, Math.floor((hojeUtc - inicio) / 86_400_000));
+}
+
+const MESES_PT_BR = [
+  "janeiro",
+  "fevereiro",
+  "março",
+  "abril",
+  "maio",
+  "junho",
+  "julho",
+  "agosto",
+  "setembro",
+  "outubro",
+  "novembro",
+  "dezembro",
+];
+
+const CHAVE_DESCONHECIDA = "desconhecido";
+
+export function agruparPorMes<T extends MovimentoComIdEData>(
+  movimentacoes: T[],
+): GrupoDeMovimentacoes<T>[] {
+  if (!Array.isArray(movimentacoes) || movimentacoes.length === 0) {
+    return [];
+  }
+
+  const copiado = [...movimentacoes].sort((a, b) => {
+    const dataA = a.data ? a.data.getTime() : Number.NEGATIVE_INFINITY;
+    const dataB = b.data ? b.data.getTime() : Number.NEGATIVE_INFINITY;
+
+    if (dataA === dataB) {
+      return a.id.localeCompare(b.id);
+    }
+
+    return dataB - dataA;
+  });
+
+  const grupos = new Map<string, GrupoDeMovimentacoes<T>>();
+  const desconhecidos: T[] = [];
+
+  copiado.forEach((item) => {
+    if (!item.data) {
+      desconhecidos.push(item);
+      return;
+    }
+
+    const ano = item.data.getFullYear();
+    const mes = item.data.getMonth();
+    const chave = `${ano}-${String(mes + 1).padStart(2, "0")}`;
+
+    if (!grupos.has(chave)) {
+      const rotuloMes = MESES_PT_BR[mes] ?? item.data.toLocaleString("pt-BR", {
+        month: "long",
+      });
+      const rotuloCapitalizado =
+        rotuloMes.charAt(0).toUpperCase() + rotuloMes.slice(1).toLowerCase();
+
+      grupos.set(chave, {
+        chave,
+        rotulo: `${rotuloCapitalizado} de ${ano}`,
+        ano,
+        mes: mes + 1,
+        itens: [],
+      });
+    }
+
+    grupos.get(chave)?.itens.push(item);
+  });
+
+  const resultado = Array.from(grupos.values());
+
+  resultado.forEach((grupo) => {
+    grupo.itens.sort((a, b) => {
+      const dataA = a.data ? a.data.getTime() : Number.NEGATIVE_INFINITY;
+      const dataB = b.data ? b.data.getTime() : Number.NEGATIVE_INFINITY;
+
+      if (dataA === dataB) {
+        return a.id.localeCompare(b.id);
+      }
+
+      return dataB - dataA;
+    });
+  });
+
+  if (desconhecidos.length > 0) {
+    resultado.push({
+      chave: CHAVE_DESCONHECIDA,
+      rotulo: "Data desconhecida",
+      ano: null,
+      mes: null,
+      itens: desconhecidos,
+    });
+  }
+
+  return resultado;
+}
+
+export function deduplicarMovimentacoes<T extends MovimentacaoBruta>(
+  movimentacoes: T[],
+): T[] {
+  if (!Array.isArray(movimentacoes) || movimentacoes.length === 0) {
+    return [];
+  }
+
+  const resultado: T[] = [];
+  const ids = new Set<string>();
+  const hashes = new Set<string>();
+
+  movimentacoes.forEach((mov) => {
+    const id =
+      mov.id !== null && mov.id !== undefined ? String(mov.id) : undefined;
+
+    if (id && ids.has(id)) {
+      return;
+    }
+
+    const hash = [
+      mov.data ? mov.data.slice(0, 10) : "",
+      normalizarTexto(mov.tipo),
+      normalizarTexto(mov.conteudo),
+      normalizarTexto(mov.texto_categoria),
+    ]
+      .join("|")
+      .toLowerCase();
+
+    if (!id && hash && hashes.has(hash)) {
+      return;
+    }
+
+    if (id) {
+      ids.add(id);
+    }
+
+    if (hash) {
+      hashes.add(hash);
+    }
+
+    resultado.push({
+      ...mov,
+      id: id ?? mov.id ?? null,
+    });
+  });
+
+  return resultado;
+}
+
+export function useMemorizedGroups<T extends MovimentoComIdEData>(
+  movimentacoes: T[],
+): GrupoDeMovimentacoes<T>[] {
+  return useMemo(() => agruparPorMes(movimentacoes), [movimentacoes]);
+}


### PR DESCRIPTION
## Summary
- reconstruir a tela de VisualizarProcesso com cabeçalho, cartões informativos, abas e timeline em português seguindo o modelo fornecido
- adicionar utilitários para decodificação, normalização, deduplicação e agrupamento das movimentações mensais
- criar testes cobrindo agrupamento, cálculo de dias, deduplicação e renderização das informações com dados ausentes

## Testing
- npm test *(falha: vitest não está disponível no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68d73731ffec8326ac48c5ccd33d8855