### PR TITLE
Enable card payments for plan charges

### DIFF
--- a/frontend/src/features/plans/api.ts
+++ b/frontend/src/features/plans/api.ts
@@ -130,6 +130,8 @@ export type PlanPaymentPayload = {
     email: string;
     notes?: string;
   };
+  cardToken?: string;
+  cardMetadata?: Record<string, unknown>;
 };
 
 export type PlanPaymentCharge = {


### PR DESCRIPTION
## Summary
- allow the operator plan management flow to select corporate cards, collect the cardholder data, tokenize it with Asaas and send the resulting token when generating a charge
- extend the plan payment API payload to carry card token/metadata and forward those details (plus the client IP) from the controller to the Asaas charge service
- add controller-level tests that validate the new credit-card pathways, including the required token validation and the metadata forwarding

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d74845c4508326bf49313b1cccc803