### PR TITLE
feat: surface plan badge in header actions

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,47 +1,10 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { HeaderActions } from "@/components/layout/HeaderActions";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
-import { usePlan } from "@/features/plans/PlanProvider";
-
-const getPlanDisplayName = (name: string | null | undefined, id: number | null | undefined) => {
-  const normalizedName = typeof name === "string" ? name.trim() : "";
-  if (normalizedName.length > 0) {
-    return normalizedName;
-  }
-
-  if (typeof id === "number" && Number.isFinite(id)) {
-    return `Plano ${id}`;
-  }
-
-  return "Plano não definido";
-};
-
-interface PlanStatusProps {
-  label: string;
-  toneClass: string;
-}
-
-function PlanStatus({ label, toneClass }: PlanStatusProps) {
-  return (
-    <div className="min-w-0">
-      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Plano atual</p>
-      <span
-        className={cn(
-          "mt-1 inline-flex max-w-full items-center gap-2 truncate rounded-full border px-3 py-1 text-sm font-semibold",
-          toneClass,
-        )}
-        title={label}
-      >
-        {label}
-      </span>
-    </div>
-  );
-}
 
 export function Header() {
-  const { plan, isLoading, error } = usePlan();
   const [isScrolled, setIsScrolled] = useState(false);
 
   useEffect(() => {
@@ -71,27 +34,6 @@ export function Header() {
     };
   }, []);
 
-  const planName = useMemo(
-    () => getPlanDisplayName(plan?.nome, plan?.id),
-    [plan?.id, plan?.nome],
-  );
-
-  const planStatusLabel = useMemo(() => {
-    if (isLoading) {
-      return "Carregando plano...";
-    }
-
-    if (error) {
-      return "Não foi possível carregar o plano";
-    }
-
-    return planName;
-  }, [error, isLoading, planName]);
-
-  const planStatusTone = error
-    ? "text-destructive border-destructive/40 bg-destructive/10"
-    : "text-primary border-primary/30 bg-primary/10";
-
   return (
     <header
       className={cn(
@@ -101,15 +43,11 @@ export function Header() {
           : "bg-background",
       )}
     >
-      <div className="flex h-16 flex-wrap items-center gap-3 px-4 sm:px-6">
-        <div className="flex min-w-0 flex-1 items-center gap-3">
+      <div className="flex h-16 flex-wrap items-center justify-between gap-3 px-4 sm:px-6">
+        <div className="flex items-center gap-3">
           <SidebarTrigger className="text-muted-foreground" />
-
-          {/* Plano exibido diretamente no cabeçalho para rápido acesso */}
-          <PlanStatus label={planStatusLabel} toneClass={planStatusTone} />
         </div>
 
-        {/* Actions */}
         <HeaderActions />
       </div>
     </header>

--- a/frontend/src/components/layout/__tests__/HeaderActions.test.tsx
+++ b/frontend/src/components/layout/__tests__/HeaderActions.test.tsx
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react-dom/test-utils";
+import { MemoryRouter } from "react-router-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { HeaderActions } from "../HeaderActions";
+import { useAuth } from "@/features/auth/AuthProvider";
+import { usePlan } from "@/features/plans/PlanProvider";
+import { fetchMeuPerfil } from "@/services/meuPerfil";
+
+vi.mock("@/features/auth/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/features/plans/PlanProvider", () => ({
+  usePlan: vi.fn(),
+}));
+
+vi.mock("@/services/meuPerfil", () => ({
+  fetchMeuPerfil: vi.fn(),
+}));
+
+vi.mock("@/components/ui/mode-toggle", () => ({
+  ModeToggle: () => <div data-testid="mode-toggle" />,
+}));
+
+vi.mock("@/components/notifications/IntimacaoMenu", () => ({
+  IntimacaoMenu: () => <div data-testid="intimacao-menu" />,
+}));
+
+describe("HeaderActions", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  const renderHeaderActions = async () => {
+    act(() => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={["/"]}>
+            <HeaderActions />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+  };
+
+  const mockPlanState = (override: Partial<ReturnType<typeof usePlan>>) => {
+    vi.mocked(usePlan).mockReturnValue({
+      plan: null,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      ...override,
+    } as ReturnType<typeof usePlan>);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    queryClient = new QueryClient();
+
+    vi.mocked(useAuth).mockReturnValue({
+      user: {
+        id: 1,
+        nome_completo: "Usuário Teste",
+        email: "teste@example.com",
+        modulos: [],
+      },
+      logout: vi.fn(),
+    } as unknown as ReturnType<typeof useAuth>);
+
+    vi.mocked(fetchMeuPerfil).mockResolvedValue({
+      name: "Usuário Teste",
+      email: "teste@example.com",
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    queryClient.clear();
+  });
+
+  it("renders the current plan name with crowns and shows the upgrade CTA when allowed", async () => {
+    mockPlanState({
+      plan: { id: 2, nome: "Essencial", modules: [] },
+      isLoading: false,
+      error: null,
+    });
+
+    await renderHeaderActions();
+
+    const badgeLabel = container.querySelector('[data-testid="plan-badge-label"]');
+    const crowns = container.querySelectorAll('[data-testid="plan-crown"]');
+    const upgradeButton = container.querySelector('[data-testid="plan-upgrade-button"]');
+
+    expect(badgeLabel?.textContent ?? "").toContain("Essencial");
+    expect(crowns.length).toBeGreaterThan(0);
+    expect(upgradeButton).not.toBeNull();
+  });
+
+  it("hides the upgrade CTA when the plan is already at the maximum tier", async () => {
+    mockPlanState({
+      plan: { id: 5, nome: "Premium", modules: [] },
+      isLoading: false,
+      error: null,
+    });
+
+    await renderHeaderActions();
+
+    const upgradeButton = container.querySelector('[data-testid="plan-upgrade-button"]');
+    expect(upgradeButton).toBeNull();
+  });
+
+  it("shows a loading message while the plan is being resolved", async () => {
+    mockPlanState({
+      plan: null,
+      isLoading: true,
+      error: null,
+    });
+
+    await renderHeaderActions();
+
+    const badgeLabel = container.querySelector('[data-testid="plan-badge-label"]');
+    expect(badgeLabel?.textContent ?? "").toContain("Carregando plano...");
+  });
+
+  it("displays an error message when the plan fails to load", async () => {
+    mockPlanState({
+      plan: null,
+      isLoading: false,
+      error: "Falhou",
+    });
+
+    await renderHeaderActions();
+
+    const badgeLabel = container.querySelector('[data-testid="plan-badge-label"]');
+    const upgradeButton = container.querySelector('[data-testid="plan-upgrade-button"]');
+
+    expect(badgeLabel?.textContent ?? "").toContain("Não foi possível carregar o plano");
+    expect(upgradeButton).toBeNull();
+  });
+});

--- a/frontend/src/features/plans/planVisuals.ts
+++ b/frontend/src/features/plans/planVisuals.ts
@@ -1,0 +1,90 @@
+import type { PlanInfo } from "@/features/plans/PlanProvider";
+
+export interface PlanVisualMeta {
+  tier: string;
+  crowns: number;
+  canUpgrade: boolean;
+}
+
+const FALLBACK_PLAN_META: PlanVisualMeta = {
+  tier: "Plano",
+  crowns: 0,
+  canUpgrade: true,
+};
+
+const PLAN_META_MAP: Record<string, PlanVisualMeta> = (() => {
+  const entries: Array<{ keys: string[]; meta: PlanVisualMeta }> = [
+    {
+      keys: ["basico", "básico", "starter", "inicial"],
+      meta: { tier: "Essencial", crowns: 1, canUpgrade: true },
+    },
+    {
+      keys: ["essencial", "standard", "padrao", "padrão"],
+      meta: { tier: "Essencial", crowns: 1, canUpgrade: true },
+    },
+    {
+      keys: ["intermediario", "intermediário", "pro", "profissional"],
+      meta: { tier: "Profissional", crowns: 2, canUpgrade: true },
+    },
+    {
+      keys: ["avancado", "avançado", "premium", "completo"],
+      meta: { tier: "Premium", crowns: 3, canUpgrade: false },
+    },
+    {
+      keys: ["enterprise", "corporativo", "ilimitado"],
+      meta: { tier: "Enterprise", crowns: 3, canUpgrade: false },
+    },
+  ];
+
+  const map: Record<string, PlanVisualMeta> = {};
+
+  for (const { keys, meta } of entries) {
+    for (const key of keys) {
+      const normalized = normalizePlanName(key);
+      if (normalized) {
+        map[normalized] = meta;
+      }
+    }
+  }
+
+  return map;
+})();
+
+function normalizePlanName(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const withoutPrefix = trimmed.replace(/^plano\s+/iu, "");
+  return withoutPrefix
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}
+
+export function getPlanVisualMeta(plan: Pick<PlanInfo, "nome"> | null): PlanVisualMeta {
+  const normalizedName = normalizePlanName(plan?.nome ?? null);
+  if (!normalizedName) {
+    return FALLBACK_PLAN_META;
+  }
+
+  return PLAN_META_MAP[normalizedName] ?? FALLBACK_PLAN_META;
+}
+
+export function getPlanDisplayName(plan: Pick<PlanInfo, "id" | "nome"> | null): string {
+  const normalizedName = typeof plan?.nome === "string" ? plan.nome.trim() : "";
+  if (normalizedName.length > 0) {
+    return normalizedName;
+  }
+
+  if (typeof plan?.id === "number" && Number.isFinite(plan.id)) {
+    return `Plano ${plan.id}`;
+  }
+
+  return "Plano não definido";
+}


### PR DESCRIPTION
## Summary
- add a plan visuals helper to centralize tier metadata, crown counts, and upgrade eligibility
- render the current plan badge and contextual upgrade CTA inside HeaderActions with loading and error handling
- simplify the Header layout and add focused tests covering plan badge states and CTA visibility

## Testing
- npm run test *(fails: vitest not found because dependencies could not be installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d74d32a5488326a91a918f8f341538