### PR TITLE
feat: enforce plan limits on judit sync triggers

### DIFF
--- a/backend/src/services/processSyncQuotaService.ts
+++ b/backend/src/services/processSyncQuotaService.ts
@@ -1,0 +1,116 @@
+import { fetchPlanLimitsForCompany, type CompanyPlanLimits } from './planLimitsService';
+import pool from './db';
+
+const toNonNegativeInteger = (value: unknown): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.max(0, Math.trunc(value));
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return 0;
+    }
+
+    const parsed = Number.parseInt(trimmed, 10);
+    if (Number.isFinite(parsed)) {
+      return Math.max(0, Math.trunc(parsed));
+    }
+  }
+
+  return 0;
+};
+
+const getCurrentMonthStart = (reference: Date = new Date()): Date => {
+  const monthStart = new Date(reference);
+  monthStart.setUTCDate(1);
+  monthStart.setUTCHours(0, 0, 0, 0);
+  return monthStart;
+};
+
+export const countCompanyProcessSyncUsage = async (
+  companyId: number,
+  referenceDate: Date = new Date(),
+): Promise<number> => {
+  if (!Number.isInteger(companyId) || companyId <= 0) {
+    return 0;
+  }
+
+  const since = getCurrentMonthStart(referenceDate).toISOString();
+
+  const [syncResult, consultaResult] = await Promise.all([
+    pool.query<{ total: unknown }>(
+      `SELECT COUNT(*)::bigint AS total
+         FROM public.process_sync ps
+         JOIN public.processos p ON p.id = ps.processo_id
+        WHERE p.idempresa IS NOT DISTINCT FROM $1
+          AND COALESCE(ps.requested_at, ps.created_at) >= $2::timestamptz`,
+      [companyId, since],
+    ),
+    pool.query<{ total: unknown }>(
+      `SELECT COUNT(*)::bigint AS total
+         FROM public.processo_consultas_api pc
+         JOIN public.processos p ON p.id = pc.processo_id
+        WHERE p.idempresa IS NOT DISTINCT FROM $1
+          AND pc.consultado_em >= $2::timestamptz`,
+      [companyId, since],
+    ),
+  ]);
+
+  const syncCount = syncResult.rowCount > 0 ? toNonNegativeInteger(syncResult.rows[0]?.total) : 0;
+  const consultaCount =
+    consultaResult.rowCount > 0 ? toNonNegativeInteger(consultaResult.rows[0]?.total) : 0;
+
+  return syncCount + consultaCount;
+};
+
+export type ProcessSyncAvailabilityReason = 'disabled' | 'quota_exceeded';
+
+export interface ProcessSyncAvailabilityResult {
+  allowed: boolean;
+  remainingQuota: number | null;
+  planLimits: CompanyPlanLimits | null;
+  reason?: ProcessSyncAvailabilityReason;
+}
+
+export const evaluateProcessSyncAvailability = async (
+  companyId: number,
+  planLimits?: CompanyPlanLimits | null,
+): Promise<ProcessSyncAvailabilityResult> => {
+  const limits = planLimits ?? (await fetchPlanLimitsForCompany(companyId));
+
+  if (!limits || limits.sincronizacaoProcessosHabilitada !== true) {
+    return {
+      allowed: false,
+      remainingQuota: limits?.sincronizacaoProcessosCota ?? null,
+      planLimits: limits,
+      reason: 'disabled',
+    };
+  }
+
+  if (limits.sincronizacaoProcessosCota == null) {
+    return {
+      allowed: true,
+      remainingQuota: null,
+      planLimits: limits,
+    };
+  }
+
+  const usage = await countCompanyProcessSyncUsage(companyId);
+  const remaining = Math.max(0, limits.sincronizacaoProcessosCota - usage);
+
+  if (remaining <= 0) {
+    return {
+      allowed: false,
+      remainingQuota: 0,
+      planLimits: limits,
+      reason: 'quota_exceeded',
+    };
+  }
+
+  return {
+    allowed: true,
+    remainingQuota: remaining,
+    planLimits: limits,
+  };
+};

--- a/backend/tests/processoController.test.ts
+++ b/backend/tests/processoController.test.ts
@@ -233,15 +233,6 @@ test('getProcessoById triggers Judit when history is missing', async () => {
     judit_last_request: null,
   };
 
-  const poolResponses: QueryResponse[] = [
-    { rows: [{ empresa: processoRow.idempresa }], rowCount: 1 },
-    { rows: [processoRow], rowCount: 1 },
-    { rows: [], rowCount: 0 },
-    { rows: [], rowCount: 0 },
-    { rows: [], rowCount: 0 },
-    { rows: [], rowCount: 0 },
-  ];
-
   const req = {
     params: { id: String(processoRow.id) },
     auth: { userId: 44 },
@@ -250,10 +241,53 @@ test('getProcessoById triggers Judit when history is missing', async () => {
   const res = createMockResponse();
 
   const poolMock = test.mock.method(pool, 'query', async (text: string) => {
-    if (poolResponses.length === 0) {
-      throw new Error(`Unexpected pool query: ${text}`);
+    if (/FROM public\.usuarios/.test(text)) {
+      return { rows: [{ empresa: processoRow.idempresa }], rowCount: 1 };
     }
-    return poolResponses.shift()!;
+
+    if (/FROM public\.processos\b/.test(text) && /WHERE p\.id = \$1/.test(text)) {
+      return { rows: [processoRow], rowCount: 1 };
+    }
+
+    if (/FROM public\.processo_movimentacoes/.test(text)) {
+      return { rows: [], rowCount: 0 };
+    }
+
+    if (/FROM public\.process_response/.test(text)) {
+      return { rows: [], rowCount: 0 };
+    }
+
+    if (/FROM public\.sync_audit/.test(text)) {
+      return { rows: [], rowCount: 0 };
+    }
+
+    if (/FROM public\.empresas/.test(text)) {
+      return {
+        rows: [
+          {
+            limite_usuarios: null,
+            limite_processos: null,
+            limite_propostas: null,
+            sincronizacao_processos_habilitada: true,
+            sincronizacao_processos_cota: null,
+          },
+        ],
+        rowCount: 1,
+      };
+    }
+
+    if (/FROM public\.process_sync/.test(text)) {
+      if (/COUNT\(\*\)/i.test(text)) {
+        return { rows: [{ total: '0' }], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    }
+
+    if (/FROM public\.processo_consultas_api/.test(text)) {
+      return { rows: [{ total: '0' }], rowCount: 1 };
+    }
+
+    throw new Error(`Unexpected pool query: ${text}`);
   });
 
   const originalListSyncs = juditProcessServiceModule.listProcessSyncs;
@@ -424,6 +458,153 @@ test('getProcessoById does not trigger Judit when audit trail is present', async
     juditService.triggerRequestForProcess = originalTrigger;
     juditService.ensureTrackingForProcess = originalEnsure;
     juditService.isEnabled = originalIsEnabled;
+    poolMock.mock.restore();
+  }
+});
+
+test('getProcessoById does not trigger Judit when plan blocks synchronization', async () => {
+  const processoRow: ProcessResponseShape = {
+    id: 404,
+    cliente_id: null,
+    idempresa: 99,
+    numero: '2222222-22.2222.2.22.2222',
+    uf: null,
+    municipio: null,
+    orgao_julgador: null,
+    tipo: null,
+    status: null,
+    classe_judicial: null,
+    assunto: null,
+    jurisdicao: null,
+    oportunidade_id: null,
+    oportunidade_sequencial_empresa: null,
+    oportunidade_data_criacao: null,
+    oportunidade_numero_processo_cnj: null,
+    oportunidade_numero_protocolo: null,
+    oportunidade_solicitante_id: null,
+    oportunidade_solicitante_nome: null,
+    advogado_responsavel: null,
+    data_distribuicao: null,
+    criado_em: '2024-03-01T10:00:00.000Z',
+    atualizado_em: '2024-03-01T11:00:00.000Z',
+    ultima_sincronizacao: null,
+    consultas_api_count: 0,
+    judit_tracking_id: null,
+    judit_tracking_hour_range: null,
+    cliente_nome: null,
+    cliente_documento: null,
+    cliente_tipo: null,
+    advogados: '[]',
+    movimentacoes: '[]',
+    movimentacoes_count: 0,
+    judit_last_request: null,
+  };
+
+  const req = {
+    params: { id: String(processoRow.id) },
+    auth: { userId: 101 },
+  } as unknown as Request;
+
+  const res = createMockResponse();
+
+  const poolMock = test.mock.method(pool, 'query', async (text: string) => {
+    if (/FROM public\.usuarios/.test(text)) {
+      return { rows: [{ empresa: processoRow.idempresa }], rowCount: 1 };
+    }
+
+    if (/FROM public\.processos\b/.test(text) && /WHERE p\.id = \$1/.test(text)) {
+      return { rows: [processoRow], rowCount: 1 };
+    }
+
+    if (/FROM public\.processo_movimentacoes/.test(text)) {
+      return { rows: [], rowCount: 0 };
+    }
+
+    if (/FROM public\.process_response/.test(text)) {
+      return { rows: [], rowCount: 0 };
+    }
+
+    if (/FROM public\.sync_audit/.test(text)) {
+      return { rows: [], rowCount: 0 };
+    }
+
+    if (/FROM public\.empresas/.test(text)) {
+      return {
+        rows: [
+          {
+            limite_usuarios: null,
+            limite_processos: null,
+            limite_propostas: null,
+            sincronizacao_processos_habilitada: true,
+            sincronizacao_processos_cota: 5,
+          },
+        ],
+        rowCount: 1,
+      };
+    }
+
+    if (/FROM public\.process_sync/.test(text)) {
+      if (/COUNT\(\*\)/i.test(text)) {
+        return { rows: [{ total: '5' }], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    }
+
+    if (/FROM public\.processo_consultas_api/.test(text)) {
+      return { rows: [{ total: '0' }], rowCount: 1 };
+    }
+
+    throw new Error(`Unexpected pool query: ${text}`);
+  });
+
+  const originalListSyncs = juditProcessServiceModule.listProcessSyncs;
+  const originalListResponses = juditProcessServiceModule.listProcessResponses;
+  const originalListAudits = juditProcessServiceModule.listSyncAudits;
+
+  juditProcessServiceModule.listProcessSyncs = async () => [];
+  juditProcessServiceModule.listProcessResponses = async () => [];
+  juditProcessServiceModule.listSyncAudits = async () => [];
+
+  const juditService = getJuditServiceInstance();
+  const originalIsEnabled = juditService.isEnabled;
+  const originalEnsure = juditService.ensureTrackingForProcess;
+  const originalTrigger = juditService.triggerRequestForProcess;
+
+  const ensureCalls: unknown[][] = [];
+  const triggerCalls: unknown[][] = [];
+
+  juditService.isEnabled = async () => true;
+  juditService.ensureTrackingForProcess = async (...args: unknown[]) => {
+    ensureCalls.push(args);
+    return { tracking_id: 'tracking-abc', hour_range: '04-08' };
+  };
+  juditService.triggerRequestForProcess = async (...args: unknown[]) => {
+    triggerCalls.push(args);
+    return {
+      requestId: 'req-777',
+      status: 'pending',
+      source: 'details',
+      result: null,
+      createdAt: '2024-03-01T12:00:00.000Z',
+      updatedAt: '2024-03-01T12:00:00.000Z',
+    };
+  };
+
+  try {
+    await getProcessoById(req, res);
+
+    assert.equal(res.statusCode, 200);
+    const body = res.body as Record<string, unknown>;
+    assert.ok(body);
+    assert.equal(ensureCalls.length, 0);
+    assert.equal(triggerCalls.length, 0);
+  } finally {
+    juditService.triggerRequestForProcess = originalTrigger;
+    juditService.ensureTrackingForProcess = originalEnsure;
+    juditService.isEnabled = originalIsEnabled;
+    juditProcessServiceModule.listSyncAudits = originalListAudits;
+    juditProcessServiceModule.listProcessResponses = originalListResponses;
+    juditProcessServiceModule.listProcessSyncs = originalListSyncs;
     poolMock.mock.restore();
   }
 });


### PR DESCRIPTION
## Summary
- add a quota service that counts recent Judit sync usage and resolves plan availability
- block manual and automatic Judit sync triggers when the company plan disables the feature or exhausts the quota
- limit the cron job to plans with sync enabled and skip companies without remaining requests, covering the scenarios with targeted tests

## Testing
- node --test --import tsx tests/juditProcessController.test.ts
- node --test --import tsx tests/processoController.test.ts
- node --test --import tsx tests/cronJobs.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d74d024c18832686bd656dae7281da