### PR TITLE
Refine site marketing copy for broader tech positioning

### DIFF
--- a/frontend/src/pages/site/Blog.tsx
+++ b/frontend/src/pages/site/Blog.tsx
@@ -103,11 +103,11 @@ const BlogPage = () => {
                 Blog Jus Connect
               </Badge>
               <h1 className="text-4xl md:text-5xl font-bold leading-tight">
-                Insights que conectam tecnologia, estratégia e resultados jurídicos
+                Insights que conectam tecnologia, estratégia e resultados de negócio
               </h1>
               <p className="text-lg md:text-xl text-muted-foreground">
                 Explore análises profundas, guias práticos e tendências sobre inteligência artificial, automação e transformação
-                digital para escritórios e departamentos jurídicos que querem liderar o futuro.
+                digital para organizações que querem liderar o futuro.
               </p>
             </div>
 

--- a/frontend/src/pages/site/NossaHistoria.tsx
+++ b/frontend/src/pages/site/NossaHistoria.tsx
@@ -11,31 +11,31 @@ const milestones = [
     period: "2016",
     title: "Origens do Jus Connect",
     description:
-      "A Quantum Tecnologia inicia pesquisas com escritórios e departamentos jurídicos para mapear dores e oportunidades.",
+      "A Quantum Tecnologia inicia pesquisas com equipes de negócio intensivas em dados para mapear dores e oportunidades.",
   },
   {
     period: "2018",
     title: "Primeiros pilotos",
     description:
-      "Protótipos da plataforma integram publicações de tribunais, CRM e automações de atendimento em um único ambiente.",
+      "Protótipos da plataforma integram CRM, automações de atendimento e analytics em um único ambiente colaborativo.",
   },
   {
     period: "2020",
     title: "Lançamento oficial",
     description:
-      "O Jus Connect chega ao mercado com squads consultivos, fluxos prontos e integrações nativas com ecossistemas jurídicos.",
+      "O Jus Connect chega ao mercado com squads consultivos, fluxos prontos e integrações nativas com os principais sistemas corporativos.",
   },
   {
     period: "2022",
     title: "Expansão de módulos",
     description:
-      "Incluímos analytics jurídicos, financial ops e conectores low-code para acelerar projetos personalizados.",
+      "Incluímos analytics avançado, financial ops e conectores low-code para acelerar projetos personalizados.",
   },
   {
     period: "2024+",
     title: "Evolução contínua",
     description:
-      "Seguimos co-criando com clientes, parceiros e comunidade legaltech para ampliar os resultados do Jus Connect.",
+      "Seguimos co-criando com clientes, parceiros e comunidade tech para ampliar os resultados do Jus Connect.",
   },
 ];
 
@@ -50,13 +50,13 @@ const pillars = [
     icon: Users,
     title: "Parceria de longo prazo",
     description:
-      "Trabalhamos lado a lado com o time jurídico, capacitando pessoas e garantindo adoção contínua.",
+      "Trabalhamos lado a lado com cada time, capacitando pessoas e garantindo adoção contínua.",
   },
   {
     icon: Lightbulb,
     title: "Inovação aplicada",
     description:
-      "IA generativa, automações e UX centrado no usuário para resolver desafios reais do dia a dia jurídico.",
+      "IA generativa, automações e UX centrado no usuário para resolver desafios reais do dia a dia.",
   },
   {
     icon: ShieldCheck,
@@ -68,8 +68,8 @@ const pillars = [
 
 const recognitions = [
   {
-    title: "+120 operações jurídicas",
-    description: "Escritórios e departamentos que confiam no Jus Connect para conduzir sua estratégia.",
+    title: "+120 operações digitais",
+    description: "Empresas que confiam no Jus Connect para conduzir sua estratégia.",
   },
   {
     title: "+8 anos de evolução",
@@ -97,10 +97,10 @@ const NossaHistoria = () => {
                 Nossa trajetória
               </div>
               <h1 className="mt-6 text-4xl md:text-6xl font-bold leading-tight">
-                Uma trajetória construída com escritórios e departamentos jurídicos em todo o Brasil
+                Uma trajetória construída com empresas e equipes de alta performance em todo o Brasil
               </h1>
               <p className="mt-6 text-lg md:text-xl text-white/85">
-                O Jus Connect nasceu para organizar dados jurídicos, relacionamentos e finanças em um único ecossistema. Evoluímos em conjunto com clientes que buscam previsibilidade e escala.
+                O Jus Connect nasceu para organizar dados, relacionamento e finanças em um único ecossistema. Evoluímos em conjunto com clientes que buscam previsibilidade e escala.
               </p>
               <div className="mt-10 grid gap-6 sm:grid-cols-3">
                 <Card className="border-white/20 bg-white/10 backdrop-blur">
@@ -142,7 +142,7 @@ const NossaHistoria = () => {
                 Marcos da nossa jornada
               </h2>
               <p className="text-lg text-muted-foreground">
-                Crescemos com clientes que buscavam previsibilidade, segurança e produtividade no contencioso e no relacionamento com clientes.
+                Crescemos com clientes que buscavam previsibilidade, segurança e produtividade em operações complexas e no relacionamento com clientes.
               </p>
             </div>
 

--- a/frontend/src/pages/site/Services.tsx
+++ b/frontend/src/pages/site/Services.tsx
@@ -39,11 +39,15 @@ const services = [
     link: "/servicos/automacoes",
   },
   {
-    title: "CRM para Advogados",
+    title: "CRM inteligente omnichannel",
     description:
-      "Uma plataforma completa para escritórios jurídicos com gestão de clientes, prazos, documentos e indicadores estratégicos.",
+      "Uma plataforma completa para equipes de relacionamento com gestão de clientes, pipelines, documentos e indicadores estratégicos.",
     icon: ShieldCheck,
-    highlights: ["Gestão de processos com SLA", "Organização de documentos sensíveis", "Visão 360º do relacionamento"],
+    highlights: [
+      "Gestão de oportunidades com SLA",
+      "Organização de documentos e contratos sensíveis",
+      "Visão 360º do relacionamento",
+    ],
     link: "/servicos/crm",
   },
   {
@@ -252,9 +256,9 @@ const ServicesPage = () => {
                 <div className="flex items-center gap-3">
                   <Workflow className="h-5 w-5 text-quantum-bright" />
                   <span>
-                    +120 projetos entregues com NPS médio de 92 em segmentos como jurídico, varejo, saúde e financeiro.
+                    +120 projetos entregues com NPS médio de 92 em segmentos como serviços, varejo, saúde e financeiro.
                   </span>
-                </div>
+              </div>
               </div>
             </div>
 

--- a/frontend/src/pages/site/components/About.tsx
+++ b/frontend/src/pages/site/components/About.tsx
@@ -13,7 +13,7 @@ interface Pillar {
 const PILLARS: Pillar[] = [
   {
     title: "Onboarding consultivo",
-    description: "Especialistas acompanham cada etapa para adaptar o Jus Connect à sua realidade jurídica.",
+    description: "Especialistas acompanham cada etapa para adaptar o Jus Connect aos processos da sua organização.",
     icon: HandshakeIcon,
   },
   {
@@ -23,7 +23,7 @@ const PILLARS: Pillar[] = [
   },
   {
     title: "Inovação pragmática",
-    description: "IA generativa, automações e analytics aplicados a fluxos que aceleram decisões.",
+    description: "IA generativa, automações e analytics aplicados a fluxos que aceleram decisões em toda a empresa.",
     icon: Lightbulb,
   },
   {
@@ -70,17 +70,17 @@ const About = () => {
               Sobre o Jus Connect
             </span>
             <h2 className="text-3xl font-semibold text-foreground md:text-4xl">
-              Plataforma completa para escritórios e departamentos jurídicos
+              Plataforma completa para operações de alto impacto
             </h2>
             <p className="text-base text-muted-foreground">
-              Nasceu dentro da Quantum Tecnologia para organizar equipes jurídicas de alto volume. Hoje o Jus Connect integra
-              relacionamento com clientes, contencioso, finanças e colaboração em uma única experiência digital.
+              Nasceu dentro da Quantum Tecnologia para conectar operações intensivas em dados. Hoje o Jus Connect integra
+              relacionamento com clientes, processos de negócio, finanças e colaboração em uma única experiência digital.
             </p>
             <div className="grid gap-4 sm:grid-cols-3">
               <Card className="border-border/40 bg-background/80">
                 <CardHeader className="pb-2">
                   <CardTitle className="text-3xl font-semibold text-foreground">120+</CardTitle>
-                  <CardDescription>equipes jurídicas conectadas</CardDescription>
+                  <CardDescription>equipes conectadas em diferentes segmentos</CardDescription>
                 </CardHeader>
               </Card>
               <Card className="border-border/40 bg-background/80">
@@ -92,7 +92,7 @@ const About = () => {
               <Card className="border-border/40 bg-background/80">
                 <CardHeader className="pb-2">
                   <CardTitle className="text-3xl font-semibold text-foreground">8</CardTitle>
-                  <CardDescription>anos evoluindo com o setor jurídico</CardDescription>
+                  <CardDescription>anos impulsionando organizações digitais</CardDescription>
                 </CardHeader>
               </Card>
             </div>
@@ -127,7 +127,7 @@ const About = () => {
           <div className="space-y-2">
             <h3 className="text-lg font-semibold text-foreground">Time multidisciplinar</h3>
             <p className="text-sm text-muted-foreground">
-              Estratégia, dados, UX e operações atuam juntos para suportar missões críticas do jurídico.
+              Estratégia, dados, UX e operações atuam juntos para suportar missões críticas do seu negócio.
             </p>
           </div>
           <div className="space-y-2">

--- a/frontend/src/pages/site/components/Hero.tsx
+++ b/frontend/src/pages/site/components/Hero.tsx
@@ -13,17 +13,17 @@ const HIGHLIGHTS: Highlight[] = [
   {
     icon: Sparkles,
     title: "Dados confiáveis",
-    description: "Centralize processos, publicações e documentos em um painel único.",
+    description: "Centralize operações, interações e documentos críticos em um painel único.",
   },
   {
     icon: Workflow,
     title: "Fluxos automatizados",
-    description: "Padronize tarefas críticas com automações e playbooks jurídicos.",
+    description: "Padronize tarefas recorrentes com automações e playbooks inteligentes.",
   },
   {
     icon: ShieldCheck,
     title: "Conformidade total",
-    description: "Governança, rastreabilidade e controles alinhados à LGPD.",
+    description: "Governança, rastreabilidade e controles alinhados às exigências regulatórias.",
   },
 ];
 
@@ -36,14 +36,14 @@ const Hero = () => {
       <div className="container relative z-10 grid gap-12 px-4 pb-24 pt-28">
         <div className="space-y-8">
           <span className="inline-flex items-center rounded-full bg-primary/10 px-4 py-1.5 text-sm font-medium text-primary">
-            Plataforma jurídica inteligente
+            Plataforma tecnológica completa
           </span>
           <h1 className="text-4xl font-semibold leading-tight tracking-tight text-foreground md:text-5xl">
-            Jus Connect organiza o contencioso e o relacionamento com clientes em um só lugar
+            Jus Connect conecta equipes, clientes e dados em um só lugar
           </h1>
           <p className="max-w-2xl text-lg text-muted-foreground">
-            Elimine planilhas paralelas, acompanhe indicadores em tempo real e ofereça experiências digitais modernas para o
-            seu escritório ou departamento jurídico.
+            Elimine silos operacionais, acompanhe indicadores em tempo real e entregue experiências digitais modernas para
+            qualquer unidade de negócio.
           </p>
           <dl className="grid gap-4 sm:grid-cols-3">
             {HIGHLIGHTS.map((highlight) => (

--- a/frontend/src/pages/site/components/Services.tsx
+++ b/frontend/src/pages/site/components/Services.tsx
@@ -35,13 +35,13 @@ const SERVICES: ServiceCard[] = [
     href: "/servicos/automacoes",
   },
   {
-    title: "CRM para advocacia",
+    title: "CRM inteligente omnichannel",
     description:
-      "Plataforma única para gerir processos, tarefas, agendas, documentos padrão, finanças e relacionamento com clientes.",
+      "Plataforma única para gerenciar relacionamento com clientes, pipelines, tarefas, documentos padronizados e finanças.",
     highlights: [
-      "Gestão completa de processos e fluxos de trabalho",
-      "Central de conversas com WhatsApp integrado",
-      "Integração com PJe, PROJUDI e gateways de pagamento",
+      "Gestão completa de oportunidades e projetos",
+      "Central de conversas com integrações nativas",
+      "Conexões com ERPs, gateways e ferramentas colaborativas",
     ],
     icon: ShieldCheck,
     href: "/servicos/crm",
@@ -89,7 +89,7 @@ const Services = () => {
             Soluções Jus Connect
           </span>
           <h2 className="text-3xl font-semibold text-foreground md:text-4xl">
-            Tudo o que sua operação jurídica precisa para escalar
+            Tudo o que sua operação digital precisa para escalar
           </h2>
           <p className="mx-auto max-w-2xl text-base text-muted-foreground">
             Do primeiro contato à fidelização, conectamos pessoas, processos e tecnologia para garantir uma experiência

--- a/frontend/src/pages/site/services/CRM.tsx
+++ b/frontend/src/pages/site/services/CRM.tsx
@@ -22,11 +22,10 @@ import {
   Layers,
   MessageSquare,
   Shield,
+  Sparkle,
   Users,
   Workflow,
   Zap,
-  Scale,
-  Sparkle,
   CheckCircle2
 } from "lucide-react";
 import { useServiceBySlug } from "@/hooks/useServices";
@@ -276,45 +275,45 @@ const CRM = () => {
 
   const industries = [
     {
-      icon: Scale,
-      title: "Advocacia",
-      description: "Gestão completa de processos, prazos e relacionamento com clientes e correspondentes.",
-      highlights: ["Integração com tribunais", "Automação de prazos", "Geração de peças e contratos"],
+      icon: Building2,
+      title: "Serviços profissionais",
+      description: "Gestão completa de projetos, contratos e relacionamento com clientes corporativos.",
+      highlights: ["Workflows configuráveis por equipe", "Integração com ferramentas de produtividade", "Follow-up automático"],
     },
     {
-      icon: Building2,
-      title: "Mercado Imobiliário",
-      description: "Gestão de funil de vendas, propostas e pós-venda para construtoras e imobiliárias.",
-      highlights: ["Integração com portais", "Controle de documentos", "Follow-up automático"],
+      icon: Sparkle,
+      title: "SaaS e tecnologia",
+      description: "Unifique dados do produto, suporte e sucesso do cliente em um painel único.",
+      highlights: ["Pipelines de expansão e retenção", "Métricas em tempo real", "Conectores com plataformas cloud"],
     },
   ];
 
-  const lawDifferentials = [
+  const operationDifferentials = [
     {
       icon: Users,
-      title: "Gestão de Clientes e Casos",
-      description: "Dossiês completos com histórico de atendimento, honorários e documentos vinculados."
+      title: "Visão 360º do cliente",
+      description: "Dossiês completos com histórico de interações, contratos e entregas."
     },
     {
       icon: FileText,
-      title: "Automação de Peças",
-      description: "Modelos inteligentes que preenchem dados de processos e geram peças em poucos cliques."
+      title: "Modelos inteligentes",
+      description: "Templates dinâmicos que preenchem dados automaticamente e padronizam comunicações."
     },
     {
       icon: Workflow,
-      title: "Fluxos de Prazos",
-      description: "Alertas automáticos e redistribuição de tarefas conforme SLA e especialidade jurídica."
+      title: "Fluxos guiados por SLA",
+      description: "Alertas automáticos e redistribuição de tarefas conforme prioridade e capacidade da equipe."
     },
     {
       icon: Layers,
-      title: "Controle Financeiro",
-      description: "Painéis de receitas recorrentes, adiantamentos e divisão de honorários por sócio."
+      title: "Governança financeira",
+      description: "Painéis de receitas recorrentes, previsões e divisão de metas por squad."
     }
   ];
 
   const successMetrics = [
-    "Redução média de 45% no tempo de atualização de processos",
-    "Aumento de 60% na taxa de conversão de leads jurídicos",
+    "Redução média de 45% no tempo de atualização de pipelines",
+    "Aumento de 60% na taxa de conversão de leads qualificados",
     "Visão 360º da carteira com relatórios executivos semanais",
     "Suporte especializado com onboarding em até 14 dias"
   ];
@@ -602,11 +601,10 @@ const CRM = () => {
         <div className="container px-4">
           <div className="text-center mb-16">
             <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-gradient-quantum bg-clip-text text-transparent">
-              Especializado em Segmentos Estratégicos
+              Especializado em segmentos estratégicos
             </h2>
             <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-              Operações jurídicas e imobiliárias contam com fluxos prontos, integrações profundas e relatórios sob medida para
-              acelerar resultados desde o primeiro mês.
+              Operações de serviços, tecnologia, finanças e mercado imobiliário contam com fluxos prontos, integrações profundas e relatórios sob medida para acelerar resultados desde o primeiro mês.
             </p>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
@@ -640,25 +638,25 @@ const CRM = () => {
         </div>
       </section>
 
-      {/* Highlight Section for Legal CRM */}
+      {/* Highlight Section for CRM */}
       <section className="py-20 bg-background relative overflow-hidden">
         <div className="absolute inset-0 bg-grid-pattern opacity-5"></div>
         <div className="container px-4 relative z-10">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
             <div>
               <div className="inline-flex items-center px-4 py-2 mb-6 text-sm font-medium rounded-full bg-gradient-quantum text-white animate-pulse-glow">
-                <Scale className="h-4 w-4 mr-2" />
-                CRM para Escritórios de Advocacia
+                <Sparkle className="h-4 w-4 mr-2" />
+                CRM para operações complexas
               </div>
               <h2 className="text-4xl md:text-5xl font-bold mb-6">
-                Especialistas em Gestão Jurídica Digital
+                Especialistas em jornadas de relacionamento B2B e B2C
               </h2>
               <p className="text-lg text-muted-foreground mb-8">
-                Com mais de uma década acompanhando escritórios de diferentes portes, desenvolvemos um CRM que une gestão de processos, atendimento consultivo e inteligência financeira em uma única plataforma.
+                Com mais de uma década acompanhando operações de alta complexidade, desenvolvemos um CRM que une gestão de pipelines, atendimento consultivo e inteligência financeira em uma única plataforma.
               </p>
               <div className="space-y-10 mb-10">
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  {lawDifferentials.map((item) => (
+                  {operationDifferentials.map((item) => (
                     <Card key={item.title} className="border-quantum-light/20 hover:border-quantum-bright/40 transition-all duration-300 hover:-translate-y-1">
                       <CardHeader className="pb-3">
                         <div className="p-3 rounded-full bg-gradient-quantum w-fit mb-3">
@@ -675,9 +673,9 @@ const CRM = () => {
 
                 <div className="space-y-6">
                   <div className="space-y-2">
-                    <h3 className="text-2xl font-semibold">Planos disponíveis para escritórios</h3>
+                    <h3 className="text-2xl font-semibold">Planos disponíveis para sua equipe</h3>
                     <p className="text-sm text-muted-foreground">
-                      Compare modalidades, benefícios e encontre o pacote ideal para o seu time jurídico.
+                      Compare modalidades, benefícios e encontre o pacote ideal para o seu time.
                     </p>
                   </div>
 
@@ -830,7 +828,7 @@ const CRM = () => {
                 </div>
               </div>
               <div className="flex flex-wrap gap-4">
-                <Button variant="quantum" size="lg" className="track-link" onClick={() => handleDemoClick("legal_section")}>
+                <Button variant="quantum" size="lg" className="track-link" onClick={() => handleDemoClick("crm_section")}>
                   Solicitar Demonstração
                   <ArrowRight className="h-5 w-5 ml-2" />
                 </Button>
@@ -838,18 +836,15 @@ const CRM = () => {
                   variant="outline_quantum"
                   size="lg"
                   className="track-link"
-                  onClick={() => handleWhatsappClick("legal_section")}
+                  onClick={() => handleWhatsappClick("crm_section")}
                 >
                   Falar no WhatsApp
-                </Button>
-                <Button variant="outline_quantum" size="lg" className="track-link" asChild>
-                  <a href="/servicos/crm/advocacia">Conheça o CRM para Advocacia</a>
                 </Button>
               </div>
             </div>
             <Card className="bg-gradient-quantum text-white border-0 shadow-quantum">
               <CardContent className="p-8 space-y-6">
-                <h3 className="text-2xl font-bold">Principais ganhos para seu escritório</h3>
+                <h3 className="text-2xl font-bold">Principais ganhos para sua operação</h3>
                 <div className="space-y-4">
                   {successMetrics.map((metric) => (
                     <div key={metric} className="flex items-start space-x-3">

--- a/frontend/src/pages/site/services/CRMAdvocacia.tsx
+++ b/frontend/src/pages/site/services/CRMAdvocacia.tsx
@@ -27,11 +27,10 @@ import {
   CheckCircle2,
   FileText,
   FolderCog,
-  Gavel,
   Layers,
   Link as LinkIcon,
   MessageSquare,
-  Scale,
+  Sparkles,
   Workflow
 } from "lucide-react";
 import { useServiceBySlug } from "@/hooks/useServices";
@@ -94,23 +93,23 @@ const CRMAdvocacia = () => {
     () => [
       {
         icon: FolderCog,
-        title: "Gestão de processos e tarefas",
-        description: "Centralize fluxos, prazos, agendas e relatórios para ter domínio total da operação jurídica.",
+        title: "Gestão de projetos e tarefas",
+        description: "Centralize fluxos, prazos, agendas e relatórios para ter domínio total da operação.",
       },
       {
         icon: FileText,
         title: "Documentos padrão com IA",
-        description: "Monte modelos inteligentes e utilize a inteligência artificial para elaborar peças e resumos em segundos.",
+        description: "Monte modelos inteligentes e utilize a inteligência artificial para elaborar propostas, contratos e resumos em segundos.",
       },
       {
         icon: MessageSquare,
-        title: "Conversas com WhatsApp integrado",
-        description: "Atenda clientes sem sair da tela, mantendo histórico unificado e automações de atendimento.",
+        title: "Conversas integradas",
+        description: "Atenda clientes em qualquer canal, mantendo histórico unificado e automações de atendimento.",
       },
       {
         icon: LinkIcon,
-        title: "Integrações judiciais e financeiras",
-        description: "Receba intimações do PJe, PROJUDI e mais, além de conectar gateways de pagamento ao seu CRM.",
+        title: "Integrações com sistemas críticos",
+        description: "Conecte ERPs, gateways de pagamento e plataformas colaborativas ao seu CRM.",
       },
     ],
     [],
@@ -132,17 +131,17 @@ const CRMAdvocacia = () => {
     });
   }, [heroHighlights, service]);
 
-  const heroLabel = service?.title ?? "CRM Especializado para Escritórios de Advocacia";
-  const heroHeadline = service?.summary ?? "Controle absoluto dos seus processos, clientes e resultados";
+  const heroLabel = service?.title ?? "CRM especializado para operações consultivas";
+  const heroHeadline = service?.summary ?? "Controle absoluto dos seus clientes, projetos e resultados";
   const heroDescription =
     service?.description ??
-    "Um CRM completo para escritórios: gestão de processos, tarefas, agendas, relatórios, documentos padrão e fluxos de trabalho com inteligência artificial. Experimente grátis por 14 dias.";
+    "Um CRM completo para organizações consultivas: gestão de pipelines, tarefas, agendas, relatórios, documentos padrão e fluxos de trabalho com inteligência artificial. Experimente grátis por 14 dias.";
 
   const productivityMetrics = [
     {
       value: "-45%",
-      label: "tempo na atualização de andamentos",
-      description: "Robôs jurídicos capturam movimentações automaticamente e notificam o time responsável."
+      label: "tempo na atualização de pipelines",
+      description: "Automações capturam movimentações automaticamente e notificam o time responsável."
     },
     {
       value: "+60%",
@@ -152,16 +151,16 @@ const CRMAdvocacia = () => {
     {
       value: "14 dias",
       label: "para go-live completo",
-      description: "Metodologia de implementação guiada por especialistas em operações jurídicas."
+      description: "Metodologia de implementação guiada por especialistas em operações digitais."
     }
   ];
 
   const modules = [
     {
       icon: FolderCog,
-      title: "Gestão de processos e fluxos",
+      title: "Gestão de projetos e fluxos",
       description:
-        "Controle processos, tarefas e workflows personalizados com checklists, responsáveis e fases totalmente configuráveis.",
+        "Controle projetos, tarefas e workflows personalizados com checklists, responsáveis e fases totalmente configuráveis.",
       features: [
         "Agenda de prazos integrada ao calendário do time",
         "Relatórios completos por área, cliente e responsável",
@@ -181,18 +180,18 @@ const CRMAdvocacia = () => {
     },
     {
       icon: FileText,
-      title: "Documentos padrão com IA jurídica",
+      title: "Documentos padrão com IA",
       description:
-        "Construa modelos inteligentes e utilize a IA para elaborar peças, contratos e resumos de processos automaticamente.",
+        "Construa modelos inteligentes e utilize a IA para elaborar propostas, contratos e relatórios automaticamente.",
       features: [
         "Biblioteca de modelos personalizada",
-        "Preenchimento automático com dados do processo",
+        "Preenchimento automático com dados do CRM",
         "Resumos e insights gerados por inteligência artificial",
       ],
     },
     {
       icon: MessageSquare,
-      title: "Conversas com WhatsApp no CRM",
+      title: "Conversas integradas no CRM",
       description:
         "Gerencie atendimentos sem sair da plataforma com o WhatsApp integrado e histórico completo dos clientes.",
       features: [
@@ -203,12 +202,12 @@ const CRMAdvocacia = () => {
     },
     {
       icon: LinkIcon,
-      title: "Integrações judiciais e financeiras",
+      title: "Integrações com sistemas críticos",
       description:
-        "Sincronize o CRM com PJe, PROJUDI e principais sistemas judiciais, além de gateways de pagamento para receber online.",
+        "Sincronize o CRM com ERPs, plataformas financeiras e ferramentas colaborativas, além de gateways de pagamento para receber online.",
       features: [
-        "Receba intimações e atualizações dentro do CRM",
-        "Consulta automática aos principais tribunais",
+        "Atualizações automáticas dentro do CRM",
+        "Conectores com APIs REST e webhooks",
         "Integração com os principais gateways de pagamento",
       ],
     },
@@ -217,15 +216,15 @@ const CRMAdvocacia = () => {
   const automationFlows = [
     {
       icon: Workflow,
-      title: "Fluxos Processuais Automatizados",
+      title: "Workflows automatizados",
       description:
-        "Dispare tarefas e notificações com base em eventos processuais, prazos e metas estratégicas do escritório."
+        "Dispare tarefas e notificações com base em eventos do funil, contratos e metas estratégicas da empresa."
     },
     {
       icon: CalendarClock,
       title: "Agenda e Prazos Integrados",
       description:
-        "Visualize audiências, compromissos e prazos críticos em uma agenda compartilhada com alertas multicanal."
+        "Visualize compromissos, entregas e prazos críticos em uma agenda compartilhada com alertas multicanal."
     },
     {
       icon: Layers,
@@ -277,32 +276,32 @@ const CRMAdvocacia = () => {
 
   const implementationSteps = [
     {
-      title: "Diagnóstico Jurídico",
+      title: "Diagnóstico colaborativo",
       description:
-        "Mapeamos áreas de atuação, sistemas existentes e indicadores estratégicos para configurar o CRM sob medida."
+        "Mapeamos jornadas de cliente, sistemas existentes e indicadores estratégicos para configurar o CRM sob medida."
     },
     {
-      title: "Configuração Guiada",
+      title: "Configuração guiada",
       description:
-        "Parametrização de pipelines, prazos, templates e automações com treinamento por núcleo jurídico."
+        "Parametrização de pipelines, prazos, templates e automações com treinamento por unidade de negócio."
     },
     {
-      title: "Adoção e Performance",
+      title: "Adoção e performance",
       description:
         "Acompanhamento pós-go-live com revisão de indicadores, comitês de melhoria contínua e suporte especializado."
     }
   ];
 
   const supportHighlights = [
-    "Especialistas em operações jurídicas disponíveis em horário estendido",
-    "Central de conhecimento com playbooks por área de atuação",
+    "Especialistas em operações digitais disponíveis em horário estendido",
+    "Central de conhecimento com playbooks por jornada do cliente",
     "Comunidade de clientes com benchmark exclusivo de indicadores"
   ];
 
   const handleDemoClick = (source: string) => {
     const gtag = getGtag();
-    gtag?.("event", "crm_advocacia_demo_click", {
-      service: "crm_advocacia",
+    gtag?.("event", "crm_advanced_demo_click", {
+      service: "crm_advanced",
       source
     });
     document.getElementById("contato")?.scrollIntoView({ behavior: "smooth" });
@@ -310,12 +309,12 @@ const CRMAdvocacia = () => {
 
   const handleWhatsappClick = (source: string) => {
     const gtag = getGtag();
-    gtag?.("event", "crm_advocacia_whatsapp_click", {
-      service: "crm_advocacia",
+    gtag?.("event", "crm_advanced_whatsapp_click", {
+      service: "crm_advanced",
       source
     });
     window.open(
-      "https://wa.me/553193054200?text=Olá! Gostaria de conhecer o CRM do Jus Connect para escritórios de advocacia.",
+      "https://wa.me/553193054200?text=Olá! Gostaria de conhecer o CRM avançado do Jus Connect.",
       "_blank"
     );
   };
@@ -332,7 +331,7 @@ const CRMAdvocacia = () => {
         <div className="container px-4 relative z-10">
           <div className="max-w-5xl mx-auto text-center">
             <div className="inline-flex items-center px-4 py-2 mb-6 text-sm font-medium rounded-full bg-white/15 backdrop-blur animate-pulse-glow">
-              <Gavel className="h-4 w-4 mr-2" />
+              <Sparkles className="h-4 w-4 mr-2" />
               {heroLabel}
             </div>
             <h1 className="text-5xl md:text-7xl font-bold mb-6">{heroHeadline}</h1>
@@ -340,8 +339,7 @@ const CRMAdvocacia = () => {
             <div className="flex flex-wrap justify-center gap-4">
               <Button variant="quantum" size="xl" className="track-link shadow-quantum" onClick={() => handleDemoClick("hero")}
               >
-                              Experimente gratuitamente por 14 dias.
-
+                Experimente gratuitamente por 14 dias
                 <ArrowRight className="h-5 w-5 ml-2" />
               </Button>
               <Button
@@ -397,10 +395,10 @@ const CRMAdvocacia = () => {
         <div className="container px-4">
           <div className="text-center mb-16">
             <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-gradient-quantum bg-clip-text text-transparent">
-              Resultados reais para bancas jurídicas
+              Resultados reais para operações consultivas
             </h2>
             <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-              O CRM do Jus Connect combina automação, dados e atendimento consultivo para acelerar o crescimento do seu escritório.
+              O CRM do Jus Connect combina automação, dados e atendimento consultivo para acelerar o crescimento da sua operação.
             </p>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
@@ -425,10 +423,10 @@ const CRMAdvocacia = () => {
         <div className="container px-4">
           <div className="text-center mb-16">
             <h2 className="text-4xl md:text-5xl font-bold mb-4 bg-gradient-quantum bg-clip-text text-transparent">
-              Módulos especializados para a advocacia
+              Módulos especializados para operações consultivas
             </h2>
             <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-              Configure fluxos para contencioso, consultivo, societário, tributário e todas as áreas que compõem sua operação.
+              Configure fluxos para prospecção, projetos, pós-venda, financeiro e todas as áreas que compõem sua operação.
             </p>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
@@ -465,13 +463,13 @@ const CRMAdvocacia = () => {
             <div>
               <div className="inline-flex items-center px-4 py-2 mb-6 text-sm font-medium rounded-full bg-gradient-quantum text-white">
                 <Workflow className="h-4 w-4 mr-2" />
-                Automação centrada no cliente jurídico
+                Automação centrada no cliente
               </div>
               <h2 className="text-4xl md:text-5xl font-bold mb-6">
-                Orquestração completa dos fluxos do escritório
+                Orquestração completa dos fluxos da sua operação
               </h2>
               <p className="text-lg text-muted-foreground mb-8">
-                Do primeiro contato ao encerramento do caso, a plataforma garante visibilidade e colaboração em todas as etapas.
+                Do primeiro contato ao pós-venda, a plataforma garante visibilidade e colaboração em todas as etapas.
               </p>
               <div className="space-y-6">
                 {automationFlows.map((flow) => (
@@ -491,9 +489,9 @@ const CRMAdvocacia = () => {
             </div>
             <Card className="bg-gradient-quantum text-white border-0 shadow-quantum">
               <CardContent className="p-8 space-y-6">
-                <h3 className="text-2xl font-semibold">Painel executivo jurídico</h3>
+                <h3 className="text-2xl font-semibold">Painel executivo de performance</h3>
                 <p className="text-white/80">
-                  Consolide indicadores de produção, receita, satisfação dos clientes e riscos em um cockpit desenhado para sócios e diretoria.
+                  Consolide indicadores de produção, receita, satisfação dos clientes e riscos em um cockpit desenhado para lideranças.
                 </p>
                 <ul className="space-y-3 text-white/80 text-sm">
                   <li className="flex items-start space-x-3">
@@ -502,11 +500,11 @@ const CRMAdvocacia = () => {
                   </li>
                   <li className="flex items-start space-x-3">
                     <CheckCircle2 className="h-5 w-5 text-white flex-shrink-0 mt-0.5" />
-                    <span>Comparativos de metas x realizado com projeção de honorários</span>
+                    <span>Comparativos de metas x realizado com projeção de receita</span>
                   </li>
                   <li className="flex items-start space-x-3">
                     <CheckCircle2 className="h-5 w-5 text-white flex-shrink-0 mt-0.5" />
-                    <span>Alertas proativos de riscos, prescrições e alçadas</span>
+                    <span>Alertas proativos de riscos, dependências e prazos críticos</span>
                   </li>
                 </ul>
                 <Button
@@ -539,10 +537,10 @@ const CRMAdvocacia = () => {
               Escolha o plano ideal
             </div>
             <h2 className="text-4xl md:text-5xl font-bold bg-gradient-quantum bg-clip-text text-transparent">
-              Planos que evoluem com o seu escritório
+              Planos que evoluem com a sua operação
             </h2>
             <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
-              Comece em minutos com acesso completo à plataforma, suporte consultivo e infraestrutura preparada para escalar de acordo com o ritmo do seu escritório.
+              Comece em minutos com acesso completo à plataforma, suporte consultivo e infraestrutura preparada para escalar de acordo com o ritmo da sua organização.
             </p>
           </div>
           {isPlansLoading ? (
@@ -625,7 +623,7 @@ const CRMAdvocacia = () => {
                         </CardHeader>
                         <CardContent className="flex-1 space-y-4">
                           <div className="rounded-lg border border-quantum-light/20 bg-background/60 p-4 text-sm leading-relaxed text-muted-foreground">
-                            Inicie agora com 14 dias de acesso completo, templates prontos e especialistas auxiliando a configuração do CRM para o seu escritório.
+                            Inicie agora com 14 dias de acesso completo, templates prontos e especialistas auxiliando a configuração do CRM para a sua operação.
                           </div>
                           <div className="flex items-center gap-2 text-xs text-muted-foreground">
                             <CheckCircle2 className="h-4 w-4 text-quantum-bright" />
@@ -674,7 +672,7 @@ const CRMAdvocacia = () => {
                   <CardTitle className="text-xl">Planos sob medida</CardTitle>
                   <CardDescription className="text-sm text-muted-foreground">
                     Nenhum plano pôde ser carregado no momento. Converse com nossos especialistas para receber uma proposta
-                    personalizada para o seu escritório.
+                    personalizada para a sua operação.
                   </CardDescription>
                 </CardHeader>
                 <CardContent>
@@ -707,7 +705,7 @@ const CRMAdvocacia = () => {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
             <div>
               <div className="inline-flex items-center px-4 py-2 mb-6 text-sm font-medium rounded-full bg-gradient-quantum text-white">
-                <Scale className="h-4 w-4 mr-2" />
+                <Layers className="h-4 w-4 mr-2" />
                 Implementação apoiada por especialistas
               </div>
               <h2 className="text-4xl md:text-5xl font-bold mb-6">
@@ -756,10 +754,10 @@ const CRMAdvocacia = () => {
           <Card className="bg-gradient-quantum text-white border-0 shadow-quantum max-w-5xl mx-auto">
             <CardContent className="p-12 text-center space-y-8">
               <h3 className="text-3xl md:text-4xl font-bold">
-                Pronto para elevar a gestão do seu escritório?
+                Pronto para elevar a gestão da sua operação?
               </h3>
               <p className="text-xl text-white/90 max-w-3xl mx-auto leading-relaxed">
-                Agende uma demonstração personalizada e descubra como nossos especialistas podem acelerar a transformação digital da sua operação jurídica.
+                Agende uma demonstração personalizada e descubra como nossos especialistas podem acelerar a transformação digital do seu relacionamento com clientes.
               </p>
               <div className="flex flex-wrap justify-center gap-4">
                 <Button
@@ -768,8 +766,7 @@ const CRMAdvocacia = () => {
                   className="bg-white/20 border-white/30 text-white hover:bg-white hover:text-quantum-deep track-link"
                   onClick={() => handleDemoClick("final_cta")}
                 >
-                                  Experimente gratuitamente por 14 dias.
-
+                  Solicitar demonstração
                   <ArrowRight className="h-5 w-5 ml-2" />
                 </Button>
                 <Button


### PR DESCRIPTION
## Summary
- repositioned hero, about, services grid, and other marketing sections to highlight multi-sector technology support
- refreshed blog and history pages with neutral language focused on digital transformation
- updated CRM solution detail pages to remove legal references and showcase cross-industry workflows and automations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d756f735288326bf8495a2b9bf1069