### PR TITLE
Handle nullable rowCount in process sync quota service

### DIFF
--- a/backend/src/services/processSyncQuotaService.ts
+++ b/backend/src/services/processSyncQuotaService.ts
@@ -57,9 +57,12 @@ export const countCompanyProcessSyncUsage = async (
     ),
   ]);
 
-  const syncCount = syncResult.rowCount > 0 ? toNonNegativeInteger(syncResult.rows[0]?.total) : 0;
+  const syncCount =
+    (syncResult.rowCount ?? 0) > 0 ? toNonNegativeInteger(syncResult.rows[0]?.total) : 0;
   const consultaCount =
-    consultaResult.rowCount > 0 ? toNonNegativeInteger(consultaResult.rows[0]?.total) : 0;
+    (consultaResult.rowCount ?? 0) > 0
+      ? toNonNegativeInteger(consultaResult.rows[0]?.total)
+      : 0;
 
   return syncCount + consultaCount;
 };


### PR DESCRIPTION
## Summary
- ensure process sync usage counting handles null rowCount values from Postgres queries by defaulting to zero

## Testing
- npm --prefix backend run build

------
https://chatgpt.com/codex/tasks/task_e_68d846bb198c832684bfef09674eb315