### PR TITLE
Improve mobile responsiveness of conversations view

### DIFF
--- a/frontend/src/features/chat/components/ChatSidebar.module.css
+++ b/frontend/src/features/chat/components/ChatSidebar.module.css
@@ -31,9 +31,34 @@
   justify-content: space-between;
 }
 
+.titleActions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .titleRow h1 {
   font-size: 1.6rem;
   font-weight: 700;
+}
+
+.closeButton {
+  border: 1px solid hsl(var(--sidebar-border));
+  background: hsl(var(--background));
+  color: inherit;
+  border-radius: 999px;
+  width: 2.25rem;
+  height: 2.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.closeButton:hover,
+.closeButton:focus-visible {
+  background: hsl(var(--sidebar-accent));
 }
 
 .newButton {
@@ -291,5 +316,23 @@
 
   .footer {
     display: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .titleRow {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .titleActions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .newButton {
+    flex: 1;
+    justify-content: center;
   }
 }

--- a/frontend/src/features/chat/components/ChatSidebar.tsx
+++ b/frontend/src/features/chat/components/ChatSidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { MessageCircle, Plus, Search, Pin } from "lucide-react";
+import { MessageCircle, Plus, Search, Pin, X } from "lucide-react";
 import type { ConversationSummary } from "../types";
 import { formatConversationTimestamp, normalizeText } from "../utils/format";
 import styles from "./ChatSidebar.module.css";
@@ -21,6 +21,8 @@ interface ChatSidebarProps {
   isLoadingMore?: boolean;
   allowUnassignedFilter?: boolean;
   isResponsibleFilterLocked?: boolean;
+  onClose?: () => void;
+  isMobileView?: boolean;
 }
 
 export const ChatSidebar = ({
@@ -40,6 +42,8 @@ export const ChatSidebar = ({
   isLoadingMore = false,
   allowUnassignedFilter = true,
   isResponsibleFilterLocked = false,
+  onClose,
+  isMobileView = false,
 }: ChatSidebarProps) => {
   const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
   const filtered = useMemo(() => {
@@ -121,9 +125,26 @@ export const ChatSidebar = ({
       <div className={styles.header}>
         <div className={styles.titleRow}>
           <h1>Conversas</h1>
-          <button type="button" className={styles.newButton} onClick={onNewConversation} aria-label="Iniciar nova conversa">
-            <Plus size={18} aria-hidden="true" /> Nova conversa
-          </button>
+          <div className={styles.titleActions}>
+            {isMobileView && onClose ? (
+              <button
+                type="button"
+                className={styles.closeButton}
+                onClick={onClose}
+                aria-label="Fechar lista de conversas"
+              >
+                <X size={18} aria-hidden="true" />
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className={styles.newButton}
+              onClick={onNewConversation}
+              aria-label="Iniciar nova conversa"
+            >
+              <Plus size={18} aria-hidden="true" /> Nova conversa
+            </button>
+          </div>
         </div>
         <div className={styles.searchBox}>
           <Search size={18} aria-hidden="true" />

--- a/frontend/src/features/chat/components/ChatWindow.module.css
+++ b/frontend/src/features/chat/components/ChatWindow.module.css
@@ -51,6 +51,7 @@
   display: flex;
   align-items: center;
   gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .headerInfo img {
@@ -58,6 +59,27 @@
   height: 3rem;
   border-radius: 999px;
   object-fit: cover;
+}
+
+.mobileBackButton {
+  border: none;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.mobileBackButton:hover,
+.mobileBackButton:focus-visible {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
 }
 
 .headerText {
@@ -729,6 +751,44 @@
   width: 100%;
 }
 
+.placeholderContent {
+  width: min(520px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: center;
+  text-align: center;
+}
+
+.placeholderActions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.placeholderActions p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.placeholderButton {
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.5rem;
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  font-weight: 600;
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.placeholderButton:hover,
+.placeholderButton:focus-visible {
+  background: hsl(var(--primary-hover));
+}
+
 .loadingOverlay {
   position: absolute;
   inset: 0;
@@ -1033,5 +1093,11 @@
 
   .headerDetails {
     gap: 0.45rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .mobileBackButton {
+    display: none;
   }
 }

--- a/frontend/src/features/chat/components/ChatWindow.tsx
+++ b/frontend/src/features/chat/components/ChatWindow.tsx
@@ -8,6 +8,7 @@ import {
   type FormEventHandler,
 } from "react";
 import {
+  ArrowLeft,
   CalendarPlus,
   CheckSquare,
   Info,
@@ -186,6 +187,8 @@ interface ChatWindowProps {
   onCreateAppointment?: () => void;
   responsibleOptions?: ChatResponsibleOption[];
   isLoadingResponsibles?: boolean;
+  onShowConversationList?: () => void;
+  isMobileView?: boolean;
 }
 
 export const ChatWindow = ({
@@ -205,6 +208,8 @@ export const ChatWindow = ({
   onCreateAppointment,
   responsibleOptions: providedResponsibleOptions = [],
   isLoadingResponsibles = false,
+  onShowConversationList,
+  isMobileView = false,
 }: ChatWindowProps) => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [detailsOpen, setDetailsOpen] = useState(false);
@@ -790,17 +795,33 @@ export const ChatWindow = ({
     });
   };
 
+  const showMobileListButton = isMobileView && typeof onShowConversationList === "function";
+
   if (!conversation) {
     return (
       <div className={styles.wrapper}>
         <div className={styles.mainColumn}>
           <div className={styles.viewportWrapper}>
             <div className={styles.deviceLinkPlaceholder}>
-              <DeviceLinkContent
-                isActive
-                layout="inline"
-                className={styles.deviceLinkContent}
-              />
+              <div className={styles.placeholderContent}>
+                <DeviceLinkContent
+                  isActive
+                  layout="inline"
+                  className={styles.deviceLinkContent}
+                />
+                {showMobileListButton ? (
+                  <div className={styles.placeholderActions}>
+                    <p>Selecione uma conversa para começar.</p>
+                    <button
+                      type="button"
+                      className={styles.placeholderButton}
+                      onClick={onShowConversationList}
+                    >
+                      Abrir lista de conversas
+                    </button>
+                  </div>
+                ) : null}
+              </div>
             </div>
           </div>
         </div>
@@ -818,6 +839,17 @@ export const ChatWindow = ({
       <div className={styles.mainColumn}>
         <header className={styles.header}>
           <div className={styles.headerInfo}>
+            {showMobileListButton ? (
+              <button
+                type="button"
+                className={styles.mobileBackButton}
+                onClick={onShowConversationList}
+                aria-label="Voltar para a lista de conversas"
+              >
+                <ArrowLeft size={18} aria-hidden="true" />
+                <span>Conversas</span>
+              </button>
+            ) : null}
             <img src={conversation.avatar} alt="" aria-hidden="true" />
             <div className={styles.headerText}>
               <div className={styles.headerTitleRow}>


### PR DESCRIPTION
## Summary
- add layout state management in the WhatsApp layout to toggle the conversation list on smaller screens
- provide mobile-specific controls and styling updates for the chat sidebar and chat window, including back and close buttons
- refresh empty-state messaging and spacing so the conversations experience adapts cleanly on phones

## Testing
- npm run lint *(fails: missing @eslint/js package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d84b7a7cd883269088dd494e09db21