### PR TITLE
Ensure auth secret configuration is explicit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Authentication
+AUTH_TOKEN_SECRET=gerar_um_segredo_unico_e_forte
+
 # Backend Asaas integration
 ASAAS_API_URL=https://www.asaas.com/api/v3
 ASAAS_ACCESS_TOKEN=asaas_live_or_sandbox_token_here

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ psql -f sql/intimacoes.sql
 npm run dev
 ```
 
+### Segredo do token de autenticação
+
+O backend **não inicia** sem um segredo explícito para assinar os tokens JWT. Defina a variável
+`AUTH_TOKEN_SECRET` (ou uma das alternativas `JWT_SECRET`/`TOKEN_SECRET`) com um valor forte e único
+antes de executar `npm run dev` ou publicar o serviço. Em ambientes de contêiner/Docker, exporte a
+variável na orquestração (Compose, Kubernetes, etc.) para evitar subir instâncias com segredos
+padrão.
+
 ### Integração com notificações do PJE
 
 Para habilitar o agendamento automático de webhooks com o PJE, defina as

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -53,9 +53,26 @@ import { ensureProcessSyncSchema } from './services/processSyncSchema';
 import { ensureSupportSchema } from './services/supportSchema';
 import { authenticateRequest } from './middlewares/authMiddleware';
 import { authorizeModules } from './middlewares/moduleAuthorization';
+import { getAuthSecret } from './constants/auth';
 
 const app = express();
 const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3001;
+
+const ensureCriticalConfig = () => {
+  try {
+    getAuthSecret();
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'AUTH_TOKEN_SECRET (ou JWT_SECRET/TOKEN_SECRET) não foi definido.';
+
+    console.error(`Falha ao iniciar o servidor: ${message}`);
+    process.exit(1);
+  }
+};
+
+ensureCriticalConfig();
 
 app.use(
   express.json({


### PR DESCRIPTION
## Summary
- remove the JWT secret fallback and throw when no authentication secret is configured
- stop the backend during startup with a clear error if the token secret is missing
- document the required AUTH_TOKEN_SECRET variable in the README and .env example for deploy environments

## Testing
- npm --prefix backend run build

------
https://chatgpt.com/codex/tasks/task_e_68d8b21c2f8c8326aac587be01613a94