### PR TITLE
Fix active conversation initialization order

### DIFF
--- a/frontend/src/components/waha/WhatsAppLayout.tsx
+++ b/frontend/src/components/waha/WhatsAppLayout.tsx
@@ -464,6 +464,8 @@ export const WhatsAppLayout = ({
     messagePaginationState,
   } = wahaState;
 
+  const activeConversationId = activeChatId ?? undefined;
+
   useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
       return;
@@ -610,8 +612,6 @@ export const WhatsAppLayout = ({
     }
     return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name, "pt-BR"));
   }, [responsibleOptions, conversations, restrictToAssigned, currentUserId, user?.nome_completo]);
-
-  const activeConversationId = activeChatId ?? undefined;
 
   const activeConversation = useMemo(
     () => conversations.find((conversation) => conversation.id === activeConversationId),


### PR DESCRIPTION
## Summary
- initialize `activeConversationId` immediately after reading it from WAHA state to prevent reference errors
- rely on the derived value across effects without accessing it before declaration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d956f88d58832685ba5e93e72ea4d5