### PR TITLE
Fix sidebar handlers initialization order

### DIFF
--- a/frontend/src/components/waha/WhatsAppLayout.tsx
+++ b/frontend/src/components/waha/WhatsAppLayout.tsx
@@ -669,6 +669,18 @@ export const WhatsAppLayout = ({
   const hasMoreMessages = Boolean(activePagination?.hasMore);
   const isLoadingMoreMessages = Boolean(activePagination?.isLoading && activePagination?.isLoaded);
 
+  const handleShowSidebar = useCallback(() => {
+    if (!isDesktopLayout) {
+      setIsSidebarVisible(true);
+    }
+  }, [isDesktopLayout]);
+
+  const handleHideSidebar = useCallback(() => {
+    if (!isDesktopLayout) {
+      setIsSidebarVisible(false);
+    }
+  }, [isDesktopLayout]);
+
   const handleSelectConversation = useCallback(
     async (conversationId: string, options?: { skipNavigation?: boolean }) => {
       if (conversationId === activeConversationId && messageMap[conversationId]) {
@@ -797,18 +809,6 @@ export const WhatsAppLayout = ({
     () => conversations.slice(0, 60),
     [conversations],
   );
-
-  const handleShowSidebar = useCallback(() => {
-    if (!isDesktopLayout) {
-      setIsSidebarVisible(true);
-    }
-  }, [isDesktopLayout]);
-
-  const handleHideSidebar = useCallback(() => {
-    if (!isDesktopLayout) {
-      setIsSidebarVisible(false);
-    }
-  }, [isDesktopLayout]);
 
   const handleModalSelect = useCallback(
     async (conversationId: string) => {


### PR DESCRIPTION
## Summary
- move the sidebar visibility handlers above the conversation selection hook so they are initialized before being referenced

## Testing
- pnpm -C frontend lint *(fails: missing dependencies in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9669ff8b88326b829f56a3d29b85f