### PR TITLE
Fix undefined sidebar handlers in WhatsApp layout

### DIFF
--- a/frontend/src/components/waha/WhatsAppLayout.tsx
+++ b/frontend/src/components/waha/WhatsAppLayout.tsx
@@ -641,18 +641,6 @@ export const WhatsAppLayout = ({
   const hasMoreMessages = Boolean(activePagination?.hasMore);
   const isLoadingMoreMessages = Boolean(activePagination?.isLoading && activePagination?.isLoaded);
 
-  const handleShowSidebar = useCallback(() => {
-    if (!isDesktopLayout) {
-      setIsSidebarVisible(true);
-    }
-  }, [isDesktopLayout]);
-
-  const handleHideSidebar = useCallback(() => {
-    if (!isDesktopLayout) {
-      setIsSidebarVisible(false);
-    }
-  }, [isDesktopLayout]);
-
   const handleSelectConversation = useCallback(
     async (conversationId: string, options?: { skipNavigation?: boolean }) => {
       if (conversationId === activeConversationId && messageMap[conversationId]) {


### PR DESCRIPTION
## Summary
- remove the unused sidebar visibility callbacks that referenced an undefined desktop layout flag and caused the layout to crash at runtime

## Testing
- pnpm lint *(fails: missing node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d96e68a25883268104be5d9d6aaebb