### PR TITLE
Improve backend env loader fallback

### DIFF
--- a/backend/dist/utils/loadEnv.js
+++ b/backend/dist/utils/loadEnv.js
@@ -1,0 +1,94 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const parseLine = (line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+        return null;
+    }
+    const exportPrefix = 'export ';
+    const normalized = trimmed.startsWith(exportPrefix)
+        ? trimmed.slice(exportPrefix.length)
+        : trimmed;
+    const equalsIndex = normalized.indexOf('=');
+    if (equalsIndex === -1) {
+        return null;
+    }
+    const key = normalized.slice(0, equalsIndex).trim();
+    if (!key) {
+        return null;
+    }
+    const rawValue = normalized.slice(equalsIndex + 1).trim();
+    let value = rawValue;
+    if ((rawValue.startsWith('"') && rawValue.endsWith('"')) ||
+        (rawValue.startsWith("'") && rawValue.endsWith("'"))) {
+        value = rawValue.slice(1, -1);
+    }
+    return [key, value];
+};
+const loadEnvFile = (filePath) => {
+    if (!fs_1.default.existsSync(filePath)) {
+        return;
+    }
+    const content = fs_1.default.readFileSync(filePath, 'utf8');
+    const lines = content.split(/\r?\n/);
+    for (const line of lines) {
+        const parsed = parseLine(line);
+        if (!parsed) {
+            continue;
+        }
+        const [key, value] = parsed;
+        if (process.env[key] === undefined) {
+            process.env[key] = value;
+        }
+    }
+};
+const findEnvFileInAncestors = (startDir) => {
+    let currentDir = path_1.default.resolve(startDir);
+    while (true) {
+        const candidate = path_1.default.join(currentDir, '.env');
+        if (fs_1.default.existsSync(candidate)) {
+            return candidate;
+        }
+        const parentDir = path_1.default.dirname(currentDir);
+        if (parentDir === currentDir) {
+            break;
+        }
+        currentDir = parentDir;
+    }
+    return null;
+};
+const loadDefaultEnvFile = () => {
+    const customPath = process.env.DOTENV_CONFIG_PATH;
+    if (customPath) {
+        const resolvedCustomPath = path_1.default.isAbsolute(customPath)
+            ? customPath
+            : path_1.default.resolve(process.cwd(), customPath);
+        if (fs_1.default.existsSync(resolvedCustomPath)) {
+            loadEnvFile(resolvedCustomPath);
+            return;
+        }
+    }
+    const ancestorEnvFile = findEnvFileInAncestors(process.cwd());
+    if (ancestorEnvFile) {
+        loadEnvFile(ancestorEnvFile);
+        return;
+    }
+    const backendRoot = path_1.default.resolve(__dirname, '..', '..');
+    const repoRoot = path_1.default.resolve(backendRoot, '..');
+    const fallbackCandidates = [
+        path_1.default.join(backendRoot, '.env'),
+        path_1.default.join(repoRoot, '.env'),
+    ];
+    for (const candidate of fallbackCandidates) {
+        if (fs_1.default.existsSync(candidate)) {
+            loadEnvFile(candidate);
+            return;
+        }
+    }
+};
+loadDefaultEnvFile();

--- a/backend/tests/loadEnv.test.ts
+++ b/backend/tests/loadEnv.test.ts
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const TEST_KEY = 'LOAD_ENV_TEST_REPO_ROOT';
+
+const writeEnvFileWithTestValue = (envPath: string, previousContent: string | null) => {
+  const baseContent = previousContent ?? '';
+  const normalized = baseContent.endsWith('\n') || baseContent.length === 0 ? baseContent : `${baseContent}\n`;
+  fs.writeFileSync(envPath, `${normalized}${TEST_KEY}=root-level-value\n`, 'utf8');
+};
+
+test('loads .env from repository root when cwd is backend directory', async () => {
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const backendRoot = path.resolve(__dirname, '..');
+  const envPath = path.join(repoRoot, '.env');
+
+  const originalCwd = process.cwd();
+  const originalEnvValue = process.env[TEST_KEY];
+  const originalDotenvConfigPath = process.env.DOTENV_CONFIG_PATH;
+  const envFileExisted = fs.existsSync(envPath);
+  const previousContent = envFileExisted ? fs.readFileSync(envPath, 'utf8') : null;
+
+  try {
+    writeEnvFileWithTestValue(envPath, previousContent);
+
+    process.chdir(backendRoot);
+    delete process.env[TEST_KEY];
+    delete process.env.DOTENV_CONFIG_PATH;
+
+    const modulePath = path.resolve(backendRoot, 'src/utils/loadEnv.ts');
+    try {
+      delete require.cache[require.resolve(modulePath)];
+    } catch {
+      // ignore if the module is not in the cache yet or cannot be resolved via require
+    }
+
+    const moduleUrl = pathToFileURL(modulePath);
+    moduleUrl.searchParams.set('test', Date.now().toString());
+    await import(moduleUrl.href);
+
+    assert.strictEqual(
+      process.env[TEST_KEY],
+      'root-level-value',
+      'env var from repo root should be loaded when cwd is backend/'
+    );
+  } finally {
+    process.chdir(originalCwd);
+
+    if (originalEnvValue === undefined) {
+      delete process.env[TEST_KEY];
+    } else {
+      process.env[TEST_KEY] = originalEnvValue;
+    }
+
+    if (originalDotenvConfigPath === undefined) {
+      delete process.env.DOTENV_CONFIG_PATH;
+    } else {
+      process.env.DOTENV_CONFIG_PATH = originalDotenvConfigPath;
+    }
+
+    if (envFileExisted) {
+      fs.writeFileSync(envPath, previousContent ?? '', 'utf8');
+    } else if (fs.existsSync(envPath)) {
+      fs.unlinkSync(envPath);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- update the backend env loader to search ancestor directories and fall back to backend and repo roots when no explicit path is provided
- add a regression test ensuring a repository-level .env is respected when running from the backend directory
- commit the compiled dist artifact that reflects the new env loader logic

## Testing
- node --test --import tsx tests/loadEnv.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d99a35263c832684dbbf4e40d7ddfb