### PR TITLE
Add client limit to administrator plan forms

### DIFF
--- a/frontend/src/pages/administrator/NewPlan.tsx
+++ b/frontend/src/pages/administrator/NewPlan.tsx
@@ -267,6 +267,7 @@ export default function NewPlan() {
     setSubmitSuccess(null);
 
     const orderedModules = orderModules(formState.modules, availableModules);
+    const clientLimit = parseInteger(formState.clientLimit);
     const userLimit = parseInteger(formState.userLimit);
     const processLimit = parseInteger(formState.processLimit);
     const proposalLimit = parseInteger(formState.proposalLimit);
@@ -287,6 +288,9 @@ export default function NewPlan() {
         customAvailable,
         customUnavailable,
       }),
+      limite_clientes: clientLimit,
+      clientes_limit: clientLimit,
+      client_limit: clientLimit,
       limite_usuarios: userLimit,
       qtde_usuarios: userLimit,
       limite_processos: processLimit,
@@ -488,7 +492,26 @@ export default function NewPlan() {
               </div>
             </div>
 
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+              <div className="space-y-2">
+                <Label htmlFor="plan-client-limit">Limite de clientes</Label>
+                <Input
+                  id="plan-client-limit"
+                  placeholder="Ilimitado"
+                  inputMode="numeric"
+                  value={formState.clientLimit}
+                  onChange={(event) =>
+                    setFormState((prev) => ({
+                      ...prev,
+                      clientLimit: sanitizeLimitInput(event.target.value),
+                    }))
+                  }
+                  disabled={submitting}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Use valores inteiros. Campos em branco manterão o limite aberto.
+                </p>
+              </div>
               <div className="space-y-2">
                 <Label htmlFor="plan-user-limit">Limite de usuários</Label>
                 <Input

--- a/frontend/src/pages/administrator/Plans.tsx
+++ b/frontend/src/pages/administrator/Plans.tsx
@@ -214,6 +214,7 @@ const createFormStateFromPlan = (plan: Plan): PlanFormState => ({
   modules: [...plan.modules],
   customAvailableFeatures: plan.customAvailableFeatures.join(", "),
   customUnavailableFeatures: plan.customUnavailableFeatures.join(", "),
+  clientLimit: plan.clientLimit != null ? String(plan.clientLimit) : "",
   userLimit: plan.userLimit != null ? String(plan.userLimit) : "",
   processLimit: plan.processLimit != null ? String(plan.processLimit) : "",
   proposalLimit: plan.proposalLimit != null ? String(plan.proposalLimit) : "",
@@ -423,6 +424,7 @@ export default function Plans() {
     setEditError(null);
 
     const orderedModules = orderModules(editFormState.modules, availableModules);
+    const clientLimit = parseInteger(editFormState.clientLimit);
     const userLimit = parseInteger(editFormState.userLimit);
     const processLimit = parseInteger(editFormState.processLimit);
     const proposalLimit = parseInteger(editFormState.proposalLimit);
@@ -443,6 +445,9 @@ export default function Plans() {
         customAvailable,
         customUnavailable,
       }),
+      limite_clientes: clientLimit,
+      clientes_limit: clientLimit,
+      client_limit: clientLimit,
       limite_usuarios: userLimit,
       qtde_usuarios: userLimit,
       limite_processos: processLimit,
@@ -569,6 +574,9 @@ export default function Plans() {
                       <TableCell className="align-top">{renderModuleBadges(plan.modules)}</TableCell>
                       <TableCell className="align-top">
                         <div className="space-y-1 text-sm">
+                          <p>
+                            <span className="font-medium">Clientes:</span> {formatLimit(plan.clientLimit)}
+                          </p>
                           <p>
                             <span className="font-medium">Usuários:</span> {formatLimit(plan.userLimit)}
                           </p>
@@ -733,7 +741,22 @@ export default function Plans() {
               </div>
             </div>
 
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+              <div className="space-y-2">
+                <Label htmlFor="edit-plan-client-limit">Limite de clientes</Label>
+                <Input
+                  id="edit-plan-client-limit"
+                  inputMode="numeric"
+                  value={editFormState.clientLimit}
+                  onChange={(event) =>
+                    setEditFormState((prev) => ({
+                      ...prev,
+                      clientLimit: sanitizeLimitInput(event.target.value),
+                    }))
+                  }
+                  disabled={isSavingEdit}
+                />
+              </div>
               <div className="space-y-2">
                 <Label htmlFor="edit-plan-user-limit">Limite de usuários</Label>
                 <Input

--- a/frontend/src/pages/administrator/plans-utils.ts
+++ b/frontend/src/pages/administrator/plans-utils.ts
@@ -37,6 +37,7 @@ export interface Plan {
   modules: string[];
   customAvailableFeatures: string[];
   customUnavailableFeatures: string[];
+  clientLimit: number | null;
   userLimit: number | null;
   processLimit: number | null;
   proposalLimit: number | null;
@@ -51,6 +52,7 @@ export type PlanFormState = {
   modules: string[];
   customAvailableFeatures: string;
   customUnavailableFeatures: string;
+  clientLimit: string;
   userLimit: string;
   processLimit: string;
   proposalLimit: string;
@@ -65,6 +67,7 @@ export const initialPlanFormState: PlanFormState = {
   modules: [],
   customAvailableFeatures: "",
   customUnavailableFeatures: "",
+  clientLimit: "",
   userLimit: "",
   processLimit: "",
   proposalLimit: "",
@@ -386,6 +389,19 @@ export const parsePlan = (raw: unknown): Plan | null => {
         data.maxPropostas ??
         data.propostasLimit
     ) ?? null;
+  const clientLimit =
+    parseInteger(
+      data.limite_clientes ??
+        data.clientLimit ??
+        data.clienteLimit ??
+        data.client_limit ??
+        data.clientes_limit ??
+        data.limiteClientes ??
+        data.max_clientes ??
+        data.maxClientes ??
+        data.clientesMax ??
+        data.clientsLimit
+    ) ?? null;
 
   const processSyncEnabled = parseBoolean(
     data.sincronizacao_processos_habilitada ??
@@ -425,6 +441,7 @@ export const parsePlan = (raw: unknown): Plan | null => {
     modules,
     customAvailableFeatures: customResources.available,
     customUnavailableFeatures: customResources.unavailable,
+    clientLimit,
     userLimit,
     processLimit,
     proposalLimit,


### PR DESCRIPTION
## Summary
- extend plan parsing and form state utilities to track client limits alongside other quotas
- surface the client limit field in the administrator plan listing and edit dialog
- capture the client limit when creating new plans so it is sent with the payload

## Testing
- pnpm --dir frontend lint *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a1262558832685881ac781cbb9b5