### PR TITLE
Fix duplicate fallback env declarations

### DIFF
--- a/backend/src/utils/loadEnv.ts
+++ b/backend/src/utils/loadEnv.ts
@@ -148,14 +148,6 @@ const loadDefaultEnvFile = () => {
 
   fallbackCandidates.push(backendEnvPath, repoEnvPath);
 
-
-  const ancestorEnvFile = findEnvFileInAncestors(process.cwd());
-  const fallbackCandidates = [
-    ancestorEnvFile,
-    path.join(backendRoot, '.env'),
-    path.join(repoRoot, '.env'),
-  ];
-
   loadEnvFilesInOrder(fallbackCandidates);
 };
 


### PR DESCRIPTION
## Summary
- remove duplicate fallback env array declarations in the env loader
- ensure we reuse the existing candidate list when loading env files

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9a2440fcc8326bccd7e11bd2ceb36