### PR TITLE
Fix duplicate fallback env declarations (#938)

### DIFF
--- a/backend/dist/utils/loadEnv.js
+++ b/backend/dist/utils/loadEnv.js
@@ -118,12 +118,6 @@ const loadDefaultEnvFile = () => {
         fallbackCandidates.push(ancestorEnvFile);
     }
     fallbackCandidates.push(backendEnvPath, repoEnvPath);
-    const ancestorEnvFile = findEnvFileInAncestors(process.cwd());
-    const fallbackCandidates = [
-        ancestorEnvFile,
-        path_1.default.join(backendRoot, '.env'),
-        path_1.default.join(repoRoot, '.env'),
-    ];
     loadEnvFilesInOrder(fallbackCandidates);
 };
 loadDefaultEnvFile();


### PR DESCRIPTION
## Summary
- remove the duplicate fallback candidate declarations generated in the compiled loadEnv helper
- ensure the production bundle only evaluates each fallback .env path once

## Testing
- node -e "require('./backend/dist/utils/loadEnv.js')"


------
https://chatgpt.com/codex/tasks/task_e_68d9a2e783e48326908167b518af98c2