### PR TITLE
feat: incluir limite de clientes nas telas de planos

### DIFF
--- a/frontend/src/pages/administrator/Subscriptions.tsx
+++ b/frontend/src/pages/administrator/Subscriptions.tsx
@@ -34,6 +34,7 @@ type ApiPlanLimits = {
   usuarios?: number | string | null;
   processos?: number | string | null;
   propostas?: number | string | null;
+  clientes?: number | string | null;
 };
 
 interface ApiPlan {
@@ -62,6 +63,7 @@ type PlanLimits = {
   users: number | null;
   processes: number | null;
   proposals: number | null;
+  clients: number | null;
 };
 
 interface Subscription {
@@ -331,10 +333,17 @@ const extractPlanLimits = (plan: ApiPlan | undefined): PlanLimits => {
     parseInteger(plan?.limite_propostas) ??
     parseInteger(plan?.max_propostas);
 
+  const clients =
+    parseInteger(limitsRecord?.clientes) ??
+    parseInteger(limitsRecord?.clients) ??
+    parseInteger(plan?.limite_clientes) ??
+    parseInteger((plan as { max_clientes?: unknown })?.max_clientes);
+
   return {
     users: users ?? null,
     processes: processes ?? null,
     proposals: proposals ?? null,
+    clients: clients ?? null,
   };
 };
 
@@ -726,6 +735,9 @@ export default function Subscriptions() {
                           <div className="space-y-1 text-xs text-muted-foreground">
                             <div>
                               <span className="font-medium text-foreground">Usuários:</span> {formatLimitValue(subscription.planLimits.users)}
+                            </div>
+                            <div>
+                              <span className="font-medium text-foreground">Clientes:</span> {formatLimitValue(subscription.planLimits.clients)}
                             </div>
                             <div>
                               <span className="font-medium text-foreground">Processos:</span> {formatLimitValue(subscription.planLimits.processes)}

--- a/frontend/src/pages/operator/MeuPlano.tsx
+++ b/frontend/src/pages/operator/MeuPlano.tsx
@@ -58,6 +58,7 @@ type PlanoDetalhe = {
   valorMensal: number | null;
   valorAnual: number | null;
   limiteUsuarios: number | null;
+  limiteClientes: number | null;
   limiteProcessos: number | null;
   limitePropostas: number | null;
   precoMensal: string | null;
@@ -665,6 +666,7 @@ function MeuPlanoContent() {
               (typeof rawValorAnual === "string" && rawValorAnual.trim() ? rawValorAnual.trim() : null);
 
             const limiteUsuarios = toNumber(raw.limite_usuarios ?? raw.limiteUsuarios);
+            const limiteClientes = toNumber(raw.limite_clientes ?? raw.limiteClientes);
             const limiteProcessos = toNumber(raw.limite_processos ?? raw.limiteProcessos);
             const limitePropostas = toNumber(raw.limite_propostas ?? raw.limitePropostas);
 
@@ -678,6 +680,7 @@ function MeuPlanoContent() {
               valorMensal,
               valorAnual,
               limiteUsuarios: limiteUsuarios ?? null,
+              limiteClientes: limiteClientes ?? null,
               limiteProcessos: limiteProcessos ?? null,
               limitePropostas: limitePropostas ?? null,
               precoMensal,
@@ -783,6 +786,13 @@ function MeuPlanoContent() {
         limit: planoExibido.limiteUsuarios,
       });
     }
+    if (planoExibido.limiteClientes !== null || metrics.clientesAtivos !== null) {
+      items.push({
+        label: "Clientes ativos",
+        current: metrics.clientesAtivos,
+        limit: planoExibido.limiteClientes,
+      });
+    }
     if (planoExibido.limiteProcessos !== null || metrics.processosAtivos !== null) {
       items.push({
         label: "Processos cadastrados",
@@ -797,19 +807,13 @@ function MeuPlanoContent() {
         limit: planoExibido.limitePropostas,
       });
     }
-    if (metrics.clientesAtivos !== null) {
-      items.push({
-        label: "Clientes ativos",
-        current: metrics.clientesAtivos,
-      });
-    }
 
     return items;
   }, [
-    metrics.clientesAtivos,
     metrics.processosAtivos,
     metrics.propostasEmitidas,
     metrics.usuariosAtivos,
+    metrics.clientesAtivos,
     planoExibido,
   ]);
 
@@ -1049,7 +1053,7 @@ function MeuPlanoContent() {
 
               <Separator className="border-primary/20" />
 
-              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5">
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6">
                 <div className="rounded-2xl border border-primary/20 bg-primary/5 p-4">
                   <p className="text-xs font-medium uppercase tracking-wide text-primary">Plano contratado</p>
                   <p className="text-sm font-semibold text-foreground">{planoAtual.nome}</p>
@@ -1073,6 +1077,15 @@ function MeuPlanoContent() {
                   </p>
                   <p className="text-xs text-muted-foreground">
                     {previewPlano ? "Limite estimado para o plano em pré-visualização" : "Limite do plano atual"}
+                  </p>
+                </div>
+                <div className="rounded-2xl border border-border/60 bg-background/60 p-4">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Clientes incluídos</p>
+                  <p className="text-sm font-semibold text-foreground">
+                    {formatLimitValue(planoExibido?.limiteClientes ?? null, "cliente", "clientes")}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {previewPlano ? "Estimativa para o plano selecionado" : "Limite do plano atual"}
                   </p>
                 </div>
                 <div className="rounded-2xl border border-border/60 bg-background/60 p-4">


### PR DESCRIPTION
## Summary
- exibe o limite de clientes junto aos demais limites no resumo do plano do operador
- inclui o novo limite nos cards de métricas de utilização
- apresenta o limite de clientes na tabela de assinaturas do administrador

## Testing
- npm run lint *(falha: dependências do ESLint não estão disponíveis no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a27ff14083269dfd4e3b27c11085