### PR TITLE
Add configurable argon2 fallback loader

### DIFF
--- a/backend/tests/passwordUtils.test.ts
+++ b/backend/tests/passwordUtils.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  hashPassword,
+  verifyPassword,
+  __testing as passwordUtilsTesting,
+} from '../src/utils/passwordUtils';
+
+const ORIGINAL_ENV = process.env.PASSWORD_HASH_FORCE_FALLBACK;
+
+test.beforeEach(() => {
+  process.env.PASSWORD_HASH_FORCE_FALLBACK = 'true';
+  passwordUtilsTesting.resetArgon2ModuleCache();
+});
+
+test.afterEach(() => {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env.PASSWORD_HASH_FORCE_FALLBACK;
+  } else {
+    process.env.PASSWORD_HASH_FORCE_FALLBACK = ORIGINAL_ENV;
+  }
+  passwordUtilsTesting.resetArgon2ModuleCache();
+});
+
+test('hashPassword utiliza o fallback quando configurado', async () => {
+  const password = 'senha-secreta';
+
+  const hashed = await hashPassword(password);
+
+  assert.ok(hashed.startsWith('argon2:$argon2id$'));
+
+  const verification = await verifyPassword(password, hashed);
+  assert.equal(verification.isValid, true);
+  assert.equal(verification.needsRehash, false);
+  assert.equal(verification.migratedHash, undefined);
+});


### PR DESCRIPTION
## Summary
- add a runtime flag to force the argon2 fallback implementation and track whether the native or fallback module is cached
- expose a cache reset helper for tests and cover the fallback hashing path with a new unit test

## Testing
- npm --prefix backend test -- passwordUtils.test.ts *(fails: repository ships a win32 esbuild binary instead of linux)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a8a130508326845ce8836a6cf722