### PR TITLE
Support overriding argon2 fallback in tests

### DIFF
--- a/backend/tests/passwordUtils.test.ts
+++ b/backend/tests/passwordUtils.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  hashPassword,
+  verifyPassword,
+  __testing as passwordUtilsTesting,
+} from '../src/utils/passwordUtils';
+
+test.beforeEach(() => {
+  passwordUtilsTesting.setForceFallbackOverride(true);
+});
+
+test.afterEach(() => {
+  passwordUtilsTesting.setForceFallbackOverride(null);
+});
+
+test('hashPassword utiliza o fallback quando configurado', async () => {
+  const password = 'senha-secreta';
+
+  const hashed = await hashPassword(password);
+
+  assert.ok(hashed.startsWith('argon2:$argon2id$'));
+
+  const verification = await verifyPassword(password, hashed);
+  assert.equal(verification.isValid, true);
+  assert.equal(verification.needsRehash, false);
+  assert.equal(verification.migratedHash, undefined);
+});


### PR DESCRIPTION
## Summary
- add a boolean env parser and override hook so tests can force the argon2 fallback without mutating process.env
- expose a testing helper that flips the override while resetting the cached loader
- update the password utils test to rely on the override helper instead of environment juggling

## Testing
- npm --prefix backend test -- passwordUtils.test.ts *(fails: repository includes a win32-only esbuild binary)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a8a130508326845ce8836a6cf722