### PR TITLE
Fix missing finally block termination in financial controller

### DIFF
--- a/backend/src/controllers/financialController.ts
+++ b/backend/src/controllers/financialController.ts
@@ -1881,6 +1881,9 @@ export const refundAsaasCharge = async (req: Request, res: Response) => {
     res.status(500).json({ error: 'Internal server error' });
   } finally {
     client.release();
+  }
+};
+
 export const getAsaasChargeForFlow = async (req: Request, res: Response) => {
   const { id } = req.params;
   const flowId = normalizeFlowId(id);


### PR DESCRIPTION
## Summary
- close the refundAsaasCharge finally block to terminate the function correctly and allow subsequent exports to compile

## Testing
- npm run dev *(fails: `tsx` not found in this environment due to npm install restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b6fe3bac83268cf139e2e7664056