### PR TITLE
Provide development fallback for auth secret

### DIFF
--- a/backend/src/constants/auth.ts
+++ b/backend/src/constants/auth.ts
@@ -1,8 +1,39 @@
+import crypto from 'crypto';
+
 import { parseExpiration } from '../utils/tokenUtils';
 
 const FALLBACK_EXPIRATION_SECONDS = 60 * 60; // 1 hora
+const DEV_SECRET_BYTE_LENGTH = 32;
 
 let cachedSecret: string | undefined;
+
+const createDevFallbackSecret = () =>
+  `dev-insecure-secret-${crypto.randomBytes(DEV_SECRET_BYTE_LENGTH).toString('hex')}`;
+
+const shouldUseDevFallback = () => process.env.NODE_ENV !== 'production';
+
+const assignFallbackSecret = (secret: string) => {
+  if (!process.env.AUTH_TOKEN_SECRET) {
+    process.env.AUTH_TOKEN_SECRET = secret;
+  }
+};
+
+const resolveMissingSecret = () => {
+  if (!shouldUseDevFallback()) {
+    throw new Error(
+      'AUTH_TOKEN_SECRET (ou JWT_SECRET/TOKEN_SECRET) não foi definido. Defina um segredo forte antes de iniciar o servidor.'
+    );
+  }
+
+  const fallbackSecret = createDevFallbackSecret();
+
+  console.warn(
+    'AUTH_TOKEN_SECRET não definido. Um valor inseguro foi gerado automaticamente apenas para uso local. Defina AUTH_TOKEN_SECRET com um segredo forte antes de iniciar o servidor em ambientes reais.'
+  );
+
+  assignFallbackSecret(fallbackSecret);
+  return fallbackSecret;
+};
 
 const resolveAuthSecret = (): string => {
   if (cachedSecret) {
@@ -12,13 +43,7 @@ const resolveAuthSecret = (): string => {
   const secretFromEnv =
     process.env.AUTH_TOKEN_SECRET || process.env.JWT_SECRET || process.env.TOKEN_SECRET;
 
-  if (!secretFromEnv) {
-    throw new Error(
-      'AUTH_TOKEN_SECRET (ou JWT_SECRET/TOKEN_SECRET) não foi definido. Defina um segredo forte antes de iniciar o servidor.'
-    );
-  }
-
-  cachedSecret = secretFromEnv;
+  cachedSecret = secretFromEnv || resolveMissingSecret();
   return cachedSecret;
 };
 
@@ -32,4 +57,8 @@ export const authConfig = {
     process.env.AUTH_TOKEN_EXPIRATION || process.env.JWT_EXPIRATION,
     FALLBACK_EXPIRATION_SECONDS
   ),
+};
+
+export const __resetAuthSecretCacheForTests = () => {
+  cachedSecret = undefined;
 };

--- a/backend/tests/authConstants.test.ts
+++ b/backend/tests/authConstants.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { __resetAuthSecretCacheForTests, getAuthSecret } from '../src/constants/auth';
+
+const AUTH_ENV_KEYS = ['AUTH_TOKEN_SECRET', 'JWT_SECRET', 'TOKEN_SECRET'] as const;
+
+describe('constants/auth', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  const clearAuthEnv = () => {
+    for (const key of AUTH_ENV_KEYS) {
+      delete process.env[key];
+    }
+  };
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    clearAuthEnv();
+    delete process.env.NODE_ENV;
+    __resetAuthSecretCacheForTests();
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key];
+    }
+
+    Object.assign(process.env, originalEnv);
+    __resetAuthSecretCacheForTests();
+  });
+
+  it('gera um segredo temporário quando nenhuma variável foi definida em ambiente não produtivo', () => {
+    process.env.NODE_ENV = 'development';
+
+    const secret = getAuthSecret();
+
+    assert.ok(secret.startsWith('dev-insecure-secret-'));
+    assert.strictEqual(process.env.AUTH_TOKEN_SECRET, secret);
+    assert.strictEqual(getAuthSecret(), secret, 'utiliza o valor em cache nas próximas chamadas');
+  });
+
+  it('lança erro em produção quando nenhum segredo foi definido', () => {
+    process.env.NODE_ENV = 'production';
+
+    assert.throws(
+      () => {
+        getAuthSecret();
+      },
+      (error: unknown) =>
+        error instanceof Error &&
+        error.message.includes('AUTH_TOKEN_SECRET (ou JWT_SECRET/TOKEN_SECRET) não foi definido')
+    );
+  });
+
+  it('respeita segredos definidos via variável de ambiente', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.JWT_SECRET = 'jwt-secret-value';
+
+    const secret = getAuthSecret();
+
+    assert.strictEqual(secret, 'jwt-secret-value');
+    assert.strictEqual(process.env.AUTH_TOKEN_SECRET, undefined);
+  });
+});


### PR DESCRIPTION
## Summary
- generate a temporary development secret when AUTH_TOKEN_SECRET and related variables are unset
- cache the generated value, surface a warning, and expose a test helper to reset the cached secret
- add automated coverage that validates the development fallback, production guard, and environment overrides

## Testing
- npm test *(fails: missing dependency `tsx` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b7b4b4748326bdf16b68aeae0dfb