### PR TITLE
fix: pin dotenv and improve npm install resiliency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,18 +15,22 @@ RUN npm config set registry https://registry.npmjs.org/ \
  && npm config set fetch-retries 5 \
  && npm config set fetch-retry-mintimeout 20000 \
  && npm config set fetch-retry-maxtimeout 120000 \
+ && npm config set cache-min 0 \
  && npm cache clean --force || true \
+ && rm -rf ~/.npm/_cacache || true \
  && npm cache verify || true
 
 # instalar dependências do backend (inclui dev para build TS) com retry
 RUN if [ -f backend/package-lock.json ]; then \
       install_ok=0; \
+      rm -rf ~/.npm/_cacache || true; \
       for i in 1 2 3; do \
         if npm --prefix backend ci --no-audit --no-fund; then \
           install_ok=1; \
           break; \
         else \
           npm cache clean --force; \
+          rm -rf ~/.npm/_cacache || true; \
           sleep 2; \
         fi; \
       done; \
@@ -37,20 +41,34 @@ RUN if [ -f backend/package-lock.json ]; then \
         fi; \
       fi; \
       if [ "$install_ok" != "1" ]; then \
+        echo "npm install --include=dev fallback failed, trying prefer-offline with registry override"; \
+        if npm --prefix backend install --include=dev --no-audit --no-fund --prefer-offline --registry=https://registry.npmjs.org/; then \
+          install_ok=1; \
+        fi; \
+      fi; \
+      if [ "$install_ok" != "1" ]; then \
         echo "Failed to install backend dependencies"; \
         exit 1; \
       fi; \
     else \
       install_ok=0; \
+      rm -rf ~/.npm/_cacache || true; \
       for i in 1 2 3; do \
         if npm --prefix backend install --no-audit --no-fund; then \
           install_ok=1; \
           break; \
         else \
           npm cache clean --force; \
+          rm -rf ~/.npm/_cacache || true; \
           sleep 2; \
         fi; \
       done; \
+      if [ "$install_ok" != "1" ]; then \
+        echo "npm install fallback failed, trying prefer-offline with registry override"; \
+        if npm --prefix backend install --no-audit --no-fund --prefer-offline --registry=https://registry.npmjs.org/; then \
+          install_ok=1; \
+        fi; \
+      fi; \
       if [ "$install_ok" != "1" ]; then \
         echo "Failed to install backend dependencies"; \
         exit 1; \
@@ -60,12 +78,14 @@ RUN if [ -f backend/package-lock.json ]; then \
 # instalar dependências do frontend com fallback para install e retry
 RUN if [ -f frontend/package-lock.json ]; then \
       install_ok=0; \
+      rm -rf ~/.npm/_cacache || true; \
       for i in 1 2 3; do \
         if npm --prefix frontend ci --no-audit --no-fund; then \
           install_ok=1; \
           break; \
         else \
           npm cache clean --force; \
+          rm -rf ~/.npm/_cacache || true; \
           sleep 2; \
         fi; \
       done; \
@@ -76,20 +96,34 @@ RUN if [ -f frontend/package-lock.json ]; then \
         fi; \
       fi; \
       if [ "$install_ok" != "1" ]; then \
+        echo "npm install fallback failed, trying prefer-offline with registry override"; \
+        if npm --prefix frontend install --no-audit --no-fund --prefer-offline --registry=https://registry.npmjs.org/; then \
+          install_ok=1; \
+        fi; \
+      fi; \
+      if [ "$install_ok" != "1" ]; then \
         echo "Failed to install frontend dependencies"; \
         exit 1; \
       fi; \
     else \
       install_ok=0; \
+      rm -rf ~/.npm/_cacache || true; \
       for i in 1 2 3; do \
         if npm --prefix frontend install --no-audit --no-fund; then \
           install_ok=1; \
           break; \
         else \
           npm cache clean --force; \
+          rm -rf ~/.npm/_cacache || true; \
           sleep 2; \
         fi; \
       done; \
+      if [ "$install_ok" != "1" ]; then \
+        echo "npm install fallback failed, trying prefer-offline with registry override"; \
+        if npm --prefix frontend install --no-audit --no-fund --prefer-offline --registry=https://registry.npmjs.org/; then \
+          install_ok=1; \
+        fi; \
+      fi; \
       if [ "$install_ok" != "1" ]; then \
         echo "Failed to install frontend dependencies"; \
         exit 1; \
@@ -131,18 +165,58 @@ RUN npm config set registry https://registry.npmjs.org/ \
  && npm config set fetch-retries 5 \
  && npm config set fetch-retry-mintimeout 20000 \
  && npm config set fetch-retry-maxtimeout 120000 \
+ && npm config set cache-min 0 \
  && npm cache clean --force || true \
+ && rm -rf ~/.npm/_cacache || true \
  && npm cache verify || true
 
 # instalar apenas dependências de produção no final (com retry)
 RUN if [ -f /app/backend/package-lock.json ]; then \
+      rm -rf ~/.npm/_cacache || true; \
+      install_ok=0; \
       for i in 1 2 3; do \
-        npm --prefix /app/backend ci --omit=dev --prefer-offline --no-audit && break || (npm cache clean --force; sleep 2); \
+        if npm --prefix /app/backend ci --omit=dev --prefer-offline --no-audit; then \
+          install_ok=1; \
+          break; \
+        else \
+          npm cache clean --force; \
+          rm -rf ~/.npm/_cacache || true; \
+          sleep 2; \
+        fi; \
       done; \
+      if [ "$install_ok" != "1" ]; then \
+        echo "Production npm ci failed, trying prefer-offline install with registry override"; \
+        if npm --prefix /app/backend install --omit=dev --prefer-offline --no-audit --registry=https://registry.npmjs.org/; then \
+          install_ok=1; \
+        fi; \
+      fi; \
+      if [ "$install_ok" != "1" ]; then \
+        echo "Failed to install production dependencies"; \
+        exit 1; \
+      fi; \
     else \
+      rm -rf ~/.npm/_cacache || true; \
+      install_ok=0; \
       for i in 1 2 3; do \
-        npm --prefix /app/backend install --omit=dev --prefer-offline --no-audit && break || (npm cache clean --force; sleep 2); \
+        if npm --prefix /app/backend install --omit=dev --prefer-offline --no-audit; then \
+          install_ok=1; \
+          break; \
+        else \
+          npm cache clean --force; \
+          rm -rf ~/.npm/_cacache || true; \
+          sleep 2; \
+        fi; \
       done; \
+      if [ "$install_ok" != "1" ]; then \
+        echo "Production npm install fallback failed, trying registry override"; \
+        if npm --prefix /app/backend install --omit=dev --prefer-offline --no-audit --registry=https://registry.npmjs.org/; then \
+          install_ok=1; \
+        fi; \
+      fi; \
+      if [ "$install_ok" != "1" ]; then \
+        echo "Failed to install production dependencies"; \
+        exit 1; \
+      fi; \
     fi
 
 # metadata

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "argon2": "file:vendor/argon2",
-        "dotenv": "^16.4.5",
+        "dotenv": "16.4.6",
         "esbuild": "~0.25.0",
         "express": "^4.19.2",
         "pg": "^8.11.3",
@@ -860,9 +860,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZpT1v1QBK1YWS21jElXD0v7EpA6c7QJir+to6mZMmMDp6BbYKT1e77/IU68E2Ygm7XN6+lUlRH1buf7FhSnC1g==",
+      "version": "16.4.6",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.6.tgz",
+      "integrity": "sha512-MGqzPFejqylh4G6dkprdFMn/hTyBC0bY4Z1cdqUPVHtV6nRvWmvMRGsiE9zMDFMvx6bMpiKFFitvolG/Gp2w==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "argon2": "file:vendor/argon2",
     "esbuild": "~0.25.0",
-    "dotenv": "^16.4.5",
+    "dotenv": "16.4.6",
     "express": "^4.19.2",
     "pg": "^8.11.3",
     "swagger-jsdoc": "^6.2.8",


### PR DESCRIPTION
## Summary
- pin the backend dotenv dependency to version 16.4.6 and refresh the lockfile
- harden npm cache preparation in the Dockerfile by resetting cache-min and clearing the cacache
- add extra cache cleaning and prefer-offline registry fallbacks to backend, frontend, and runtime install loops

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9ba93531c8326b9272bc642a76313