### PR TITLE
Fix Docker npm config and update dotenv integrity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN npm config set registry https://registry.npmjs.org/ \
  && npm config set fetch-retries 5 \
  && npm config set fetch-retry-mintimeout 20000 \
  && npm config set fetch-retry-maxtimeout 120000 \
- && npm config set cache-min 0 \
  && npm cache clean --force || true \
  && rm -rf ~/.npm/_cacache || true \
  && npm cache verify || true
@@ -165,7 +164,6 @@ RUN npm config set registry https://registry.npmjs.org/ \
  && npm config set fetch-retries 5 \
  && npm config set fetch-retry-mintimeout 20000 \
  && npm config set fetch-retry-maxtimeout 120000 \
- && npm config set cache-min 0 \
  && npm cache clean --force || true \
  && rm -rf ~/.npm/_cacache || true \
  && npm cache verify || true

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -862,7 +862,7 @@
     "node_modules/dotenv": {
       "version": "16.4.6",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.6.tgz",
-      "integrity": "sha512-MGqzPFejqylh4G6dkprdFMn/hTyBC0bY4Z1cdqUPVHtV6nRvWmvMRGsiE9zMDFMvx6bMpiKFFitvolG/Gp2w==",
+      "integrity": "sha512-JhcR/+KIjkkjiU8yEpaB/USlzVi3i5whwOjpIRNGi9svKEXZSe+Qp6IWAjFjv+2GViAoDRCUv/QLNziQxsLqDg==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"


### PR DESCRIPTION
## Summary
- align the backend lockfile with the checksum currently served for dotenv 16.4.6 to prevent EINTEGRITY failures during installs
- drop use of the deprecated npm cache-min configuration in both build and runtime Docker layers

## Testing
- npm --prefix backend ci --no-audit --no-fund *(fails in CI environment: 403 Forbidden when downloading dotenv tarball)*

------
https://chatgpt.com/codex/tasks/task_e_68d9bd7092688326ac1b187f08708186