### PR TITLE
Track Asaas webhook credentials in charges

### DIFF
--- a/backend/dist/sql/asaas_charges.sql
+++ b/backend/dist/sql/asaas_charges.sql
@@ -3,12 +3,16 @@ CREATE TABLE IF NOT EXISTS asaas_charges (
   financial_flow_id INTEGER NOT NULL REFERENCES financial_flows(id) ON DELETE CASCADE,
   cliente_id INTEGER REFERENCES public.clientes(id),
   integration_api_key_id BIGINT REFERENCES integration_api_keys(id),
+  credential_id BIGINT REFERENCES asaas_credentials(id),
   asaas_charge_id TEXT NOT NULL,
   billing_type TEXT NOT NULL CHECK (billing_type IN ('PIX','BOLETO','CREDIT_CARD')),
   status TEXT NOT NULL,
   due_date DATE NOT NULL,
   value NUMERIC NOT NULL,
   invoice_url TEXT,
+  last_event TEXT,
+  payload JSONB,
+  paid_at TIMESTAMPTZ,
   pix_payload TEXT,
   pix_qr_code TEXT,
   boleto_url TEXT,
@@ -39,3 +43,15 @@ CREATE TRIGGER trg_asaas_charges_updated_at
   BEFORE UPDATE ON asaas_charges
   FOR EACH ROW
   EXECUTE FUNCTION set_asaas_charges_updated_at();
+
+ALTER TABLE asaas_charges
+  ADD COLUMN IF NOT EXISTS credential_id BIGINT REFERENCES asaas_credentials(id);
+
+ALTER TABLE asaas_charges
+  ADD COLUMN IF NOT EXISTS last_event TEXT;
+
+ALTER TABLE asaas_charges
+  ADD COLUMN IF NOT EXISTS payload JSONB;
+
+ALTER TABLE asaas_charges
+  ADD COLUMN IF NOT EXISTS paid_at TIMESTAMPTZ;

--- a/backend/dist/sql/asaas_credentials.sql
+++ b/backend/dist/sql/asaas_credentials.sql
@@ -1,0 +1,36 @@
+CREATE TABLE IF NOT EXISTS asaas_credentials (
+  id BIGSERIAL PRIMARY KEY,
+  integration_api_key_id BIGINT UNIQUE REFERENCES integration_api_keys(id) ON DELETE CASCADE,
+  webhook_secret TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE OR REPLACE FUNCTION set_asaas_credentials_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_asaas_credentials_updated_at ON asaas_credentials;
+CREATE TRIGGER trg_asaas_credentials_updated_at
+  BEFORE UPDATE ON asaas_credentials
+  FOR EACH ROW
+  EXECUTE FUNCTION set_asaas_credentials_updated_at();
+
+ALTER TABLE asaas_credentials
+  ADD COLUMN IF NOT EXISTS integration_api_key_id BIGINT REFERENCES integration_api_keys(id) ON DELETE CASCADE;
+
+ALTER TABLE asaas_credentials
+  ADD COLUMN IF NOT EXISTS webhook_secret TEXT;
+
+ALTER TABLE asaas_credentials
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+ALTER TABLE asaas_credentials
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+ALTER TABLE asaas_credentials
+  ADD CONSTRAINT IF NOT EXISTS asaas_credentials_integration_api_key_id_key UNIQUE (integration_api_key_id);

--- a/backend/sql/asaas_charges.sql
+++ b/backend/sql/asaas_charges.sql
@@ -3,12 +3,16 @@ CREATE TABLE IF NOT EXISTS asaas_charges (
   financial_flow_id INTEGER NOT NULL REFERENCES financial_flows(id) ON DELETE CASCADE,
   cliente_id INTEGER REFERENCES public.clientes(id),
   integration_api_key_id BIGINT REFERENCES integration_api_keys(id),
+  credential_id BIGINT REFERENCES asaas_credentials(id),
   asaas_charge_id TEXT NOT NULL,
   billing_type TEXT NOT NULL CHECK (billing_type IN ('PIX','BOLETO','CREDIT_CARD')),
   status TEXT NOT NULL,
   due_date DATE NOT NULL,
   value NUMERIC NOT NULL,
   invoice_url TEXT,
+  last_event TEXT,
+  payload JSONB,
+  paid_at TIMESTAMPTZ,
   pix_payload TEXT,
   pix_qr_code TEXT,
   boleto_url TEXT,
@@ -39,3 +43,15 @@ CREATE TRIGGER trg_asaas_charges_updated_at
   BEFORE UPDATE ON asaas_charges
   FOR EACH ROW
   EXECUTE FUNCTION set_asaas_charges_updated_at();
+
+ALTER TABLE asaas_charges
+  ADD COLUMN IF NOT EXISTS credential_id BIGINT REFERENCES asaas_credentials(id);
+
+ALTER TABLE asaas_charges
+  ADD COLUMN IF NOT EXISTS last_event TEXT;
+
+ALTER TABLE asaas_charges
+  ADD COLUMN IF NOT EXISTS payload JSONB;
+
+ALTER TABLE asaas_charges
+  ADD COLUMN IF NOT EXISTS paid_at TIMESTAMPTZ;

--- a/backend/sql/asaas_credentials.sql
+++ b/backend/sql/asaas_credentials.sql
@@ -1,0 +1,36 @@
+CREATE TABLE IF NOT EXISTS asaas_credentials (
+  id BIGSERIAL PRIMARY KEY,
+  integration_api_key_id BIGINT UNIQUE REFERENCES integration_api_keys(id) ON DELETE CASCADE,
+  webhook_secret TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE OR REPLACE FUNCTION set_asaas_credentials_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_asaas_credentials_updated_at ON asaas_credentials;
+CREATE TRIGGER trg_asaas_credentials_updated_at
+  BEFORE UPDATE ON asaas_credentials
+  FOR EACH ROW
+  EXECUTE FUNCTION set_asaas_credentials_updated_at();
+
+ALTER TABLE asaas_credentials
+  ADD COLUMN IF NOT EXISTS integration_api_key_id BIGINT REFERENCES integration_api_keys(id) ON DELETE CASCADE;
+
+ALTER TABLE asaas_credentials
+  ADD COLUMN IF NOT EXISTS webhook_secret TEXT;
+
+ALTER TABLE asaas_credentials
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+ALTER TABLE asaas_credentials
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+ALTER TABLE asaas_credentials
+  ADD CONSTRAINT IF NOT EXISTS asaas_credentials_integration_api_key_id_key UNIQUE (integration_api_key_id);

--- a/backend/src/controllers/financialController.ts
+++ b/backend/src/controllers/financialController.ts
@@ -558,12 +558,19 @@ const normalizeAsaasChargeFromRow = (row: QueryResultRow): AsaasChargeRecord => 
     financialFlowId: normalizeFinancialFlowIdValue(record.financial_flow_id),
     clienteId: parseNullableInteger(record.cliente_id),
     integrationApiKeyId: parseNullableInteger(record.integration_api_key_id),
+    credentialId: parseNullableInteger(record.credential_id),
     asaasChargeId: String(record.asaas_charge_id ?? ''),
     billingType: normalizeBillingTypeFromRow(record.billing_type),
     status: String(record.status ?? ''),
     dueDate: formatDateOnly(record.due_date),
     value: String(record.value ?? ''),
     invoiceUrl: record.invoice_url ? String(record.invoice_url) : null,
+    lastEvent: record.last_event ? String(record.last_event) : null,
+    payload:
+      record.payload && typeof record.payload === 'object'
+        ? (record.payload as Record<string, unknown>)
+        : null,
+    paidAt: record.paid_at ? formatDateTime(record.paid_at) : null,
     pixPayload: record.pix_payload ? String(record.pix_payload) : null,
     pixQrCode: record.pix_qr_code ? String(record.pix_qr_code) : null,
     boletoUrl: record.boleto_url ? String(record.boleto_url) : null,
@@ -578,17 +585,21 @@ const findAsaasChargeByFlowId = async (
   flowId: string | number,
 ): Promise<AsaasChargeRecord | null> => {
   const result = await pool.query(
-    `SELECT
+      `SELECT
         id,
         financial_flow_id,
         cliente_id,
         integration_api_key_id,
+        credential_id,
         asaas_charge_id,
         billing_type,
         status,
         due_date,
         value,
         invoice_url,
+        last_event,
+        payload,
+        paid_at,
         pix_payload,
         pix_qr_code,
         boleto_url,

--- a/backend/tests/asaasChargeService.test.ts
+++ b/backend/tests/asaasChargeService.test.ts
@@ -71,12 +71,16 @@ test('AsaasChargeService.createCharge persists PIX charge and updates flow', asy
     financial_flow_id: 10,
     cliente_id: 55,
     integration_api_key_id: 7,
+    credential_id: 99,
     asaas_charge_id: 'ch_123',
     billing_type: 'PIX',
     status: 'PENDING',
     due_date: '2024-02-10',
     value: '150.50',
     invoice_url: 'https://asaas.example/invoice',
+    last_event: null,
+    payload: null,
+    paid_at: null,
     pix_payload: '000201...',
     pix_qr_code: 'iVBORw0KGgoAAA',
     boleto_url: null,
@@ -107,7 +111,7 @@ test('AsaasChargeService.createCharge persists PIX charge and updates flow', asy
     assert.equal(options.integrationApiKeyId, 7);
     assert.equal(options.financialFlowId, 10);
     assert.strictEqual(options.db, db);
-    return fakeClient;
+    return { client: fakeClient, credentialId: 99, integrationApiKeyId: 7 };
   });
 
   const result = await service.createCharge(createChargeInput());
@@ -122,13 +126,14 @@ test('AsaasChargeService.createCharge persists PIX charge and updates flow', asy
   assert.equal(insertQuery.values?.[0], 10);
   assert.equal(insertQuery.values?.[1], 55);
   assert.equal(insertQuery.values?.[2], 7);
-  assert.equal(insertQuery.values?.[3], 'ch_123');
-  assert.equal(insertQuery.values?.[4], 'PIX');
-  assert.equal(insertQuery.values?.[5], 'PENDING');
-  assert.equal(insertQuery.values?.[6], '2024-02-10');
-  assert.equal(insertQuery.values?.[7], 150.5);
-  assert.equal(insertQuery.values?.[9], '000201...');
-  assert.equal(insertQuery.values?.[10], 'iVBORw0KGgoAAA');
+  assert.equal(insertQuery.values?.[3], 99);
+  assert.equal(insertQuery.values?.[4], 'ch_123');
+  assert.equal(insertQuery.values?.[5], 'PIX');
+  assert.equal(insertQuery.values?.[6], 'PENDING');
+  assert.equal(insertQuery.values?.[7], '2024-02-10');
+  assert.equal(insertQuery.values?.[8], 150.5);
+  assert.equal(insertQuery.values?.[13], '000201...');
+  assert.equal(insertQuery.values?.[14], 'iVBORw0KGgoAAA');
 
   assert.match(updateQuery.text, /UPDATE financial_flows/);
   assert.deepEqual(updateQuery.values, ['asaas', 'ch_123', 'pendente', 10]);
@@ -160,12 +165,16 @@ test('AsaasChargeService.createCharge maps credit card responses to paid status'
     financial_flow_id: 11,
     cliente_id: null,
     integration_api_key_id: null,
+    credential_id: null,
     asaas_charge_id: 'card_999',
     billing_type: 'CREDIT_CARD',
     status: 'CONFIRMED',
     due_date: '2024-03-15',
     value: '320.00',
     invoice_url: null,
+    last_event: null,
+    payload: null,
+    paid_at: null,
     pix_payload: null,
     pix_qr_code: null,
     boleto_url: null,
@@ -197,7 +206,7 @@ test('AsaasChargeService.createCharge maps credit card responses to paid status'
     assert.equal(options.integrationApiKeyId, null);
     assert.equal(options.financialFlowId, 11);
     assert.strictEqual(options.db, db);
-    return fakeClient;
+    return { client: fakeClient, credentialId: null, integrationApiKeyId: null };
   });
 
   const input = createChargeInput({
@@ -232,12 +241,16 @@ test('AsaasChargeService.createCharge maps refunded responses to estornado statu
     financial_flow_id: 13,
     cliente_id: null,
     integration_api_key_id: null,
+    credential_id: null,
     asaas_charge_id: 'refund_42',
     billing_type: 'PIX',
     status: 'REFUNDED',
     due_date: '2024-03-25',
     value: '275.00',
     invoice_url: null,
+    last_event: null,
+    payload: null,
+    paid_at: null,
     pix_payload: null,
     pix_qr_code: null,
     boleto_url: null,
@@ -292,12 +305,16 @@ test('AsaasChargeService.createCharge sends debit card payloads with token metad
     financial_flow_id: 12,
     cliente_id: 77,
     integration_api_key_id: 3,
+    credential_id: 88,
     asaas_charge_id: 'debit_321',
     billing_type: 'DEBIT_CARD',
     status: 'PENDING',
     due_date: '2024-04-01',
     value: '510.00',
     invoice_url: null,
+    last_event: null,
+    payload: null,
+    paid_at: null,
     pix_payload: null,
     pix_qr_code: null,
     boleto_url: null,
@@ -329,7 +346,7 @@ test('AsaasChargeService.createCharge sends debit card payloads with token metad
     assert.equal(options.integrationApiKeyId, 3);
     assert.equal(options.financialFlowId, 12);
     assert.strictEqual(options.db, db);
-    return fakeClient;
+    return { client: fakeClient, credentialId: 88, integrationApiKeyId: 3 };
   });
 
   const input = createChargeInput({

--- a/backend/tests/asaasIntegrationResolver.test.ts
+++ b/backend/tests/asaasIntegrationResolver.test.ts
@@ -15,10 +15,13 @@ class FakePool {
   async query(text: string, params?: unknown[]) {
     this.calls.push({ text, params });
     const response = this.responses.shift();
-    if (!response) {
-      throw new Error('No response configured');
+    if (response) {
+      return response;
     }
-    return response;
+    if (/asaas_credentials/i.test(text)) {
+      return { rows: [], rowCount: 0 };
+    }
+    throw new Error('No response configured');
   }
 }
 


### PR DESCRIPTION
## Summary
- add credential reference and webhook metadata columns to `asaas_charges` and create the `asaas_credentials` table used by webhooks
- update the Asaas integration resolver and charge service to resolve credential IDs and persist them with new charges
- ensure integration API key creation and updates manage Asaas webhook secrets and adjust tests accordingly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9bf11718883269f2a9a896d4c46e1