### PR TITLE
Handle Asaas webhooks when charge records are missing

### DIFF
--- a/backend/tests/asaasWebhookController.test.ts
+++ b/backend/tests/asaasWebhookController.test.ts
@@ -77,7 +77,12 @@ test('handleAsaasWebhook processes PAYMENT_RECEIVED and updates financial flow',
   const signature = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
 
   const { calls, restore } = setupQueryMock([
-    { rows: [{ id: 1, credential_id: 55, financial_flow_id: 90, cliente_id: null }], rowCount: 1 },
+    {
+      rows: [
+        { id: 1, credential_id: 55, financial_flow_id: 90, cliente_id: null, company_id: null },
+      ],
+      rowCount: 1,
+    },
     { rows: [{ webhook_secret: secret }], rowCount: 1 },
     { rows: [], rowCount: 1 },
     { rows: [], rowCount: 1 },
@@ -163,7 +168,12 @@ test('handleAsaasWebhook logs error and skips updates when signature is invalid'
   const wrongSignature = crypto.createHmac('sha256', 'other-secret').update(rawBody).digest('hex');
 
   const { calls, restore } = setupQueryMock([
-    { rows: [{ id: 10, credential_id: 42, financial_flow_id: 77, cliente_id: null }], rowCount: 1 },
+    {
+      rows: [
+        { id: 10, credential_id: 42, financial_flow_id: 77, cliente_id: null, company_id: null },
+      ],
+      rowCount: 1,
+    },
     { rows: [{ webhook_secret: secret }], rowCount: 1 },
   ]);
 


### PR DESCRIPTION
## Summary
- extend the Asaas webhook controller to derive charge context even when the local charge record is absent by looking up financial flows and company metadata
- capture additional payment fields (customer, external reference, metadata) to resolve the company and credential associated with a webhook
- adjust the existing webhook tests to reflect the enriched charge record data

## Testing
- npm test *(fails: missing optional dependency `tsx` in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ca4ec0cc83268dbef9a59a178eeb