### PR TITLE
Handle ASAAS webhook secret fallback

### DIFF
--- a/docs/manual-interno.md
+++ b/docs/manual-interno.md
@@ -39,6 +39,7 @@
 
 ## Boas práticas operacionais
 - Mantenha o `ASAAS_WEBHOOK_SECRET` atualizado sempre que gerar uma nova assinatura no portal Asaas.
+- Caso um webhook seja configurado sem credencial associada no CRM, defina `ASAAS_WEBHOOK_SECRET` no ambiente: o backend usa o valor (após remover espaços extras) como fallback para validar as assinaturas recebidas.
 - Nunca compartilhe tokens em canais públicos; utilize o cofre de senhas da empresa.
 - Agende revisão trimestral dos planos e taxas no Asaas para garantir que o CRM reflita as condições atuais.
 


### PR DESCRIPTION
## Summary
- add a helper that trims ASAAS_WEBHOOK_SECRET and uses it as a fallback when webhook credentials are missing
- extend the ASAAS webhook controller tests to cover the fallback scenarios
- mention the new fallback behaviour in the internal operations manual

## Testing
- node --test --import tsx --test-name-pattern="handleAsaasWebhook" tests/asaasWebhookController.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9d49ca71c8326a82c38325e4d923d