### PR TITLE
Normalize Asaas environment aliases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ AUTH_TOKEN_SECRET=gerar_um_segredo_unico_e_forte
 ASAAS_API_URL=https://www.asaas.com/api/v3
 ASAAS_ACCESS_TOKEN=asaas_live_or_sandbox_token_here
 ASAAS_WEBHOOK_SECRET=webhook_signature_secret_here
+# Valores suportados: homologacao (padrão), producao, produção, production, prod, live
+ASAAS_ENVIRONMENT=homologacao
 
 # Opcional: substitua caso utilize ambientes separados
 #VITE_API_URL=http://localhost:3001/api

--- a/README.md
+++ b/README.md
@@ -140,11 +140,12 @@ Após iniciar, acesse o frontend em `http://localhost:5173` e utilize o menu **D
 
 Configure as seguintes variáveis antes de iniciar o backend. Utilize o arquivo [`.env.example`](./.env.example) como referência:
 
-| Variável               | Descrição                                                                                     |
-| ---------------------- | --------------------------------------------------------------------------------------------- |
-| `ASAAS_API_URL`        | URL base da API. Utilize `https://sandbox.asaas.com/api/v3` no ambiente de testes.            |
-| `ASAAS_ACCESS_TOKEN`   | Token pessoal ou de aplicação gerado no painel do Asaas (`Configurações > Integrações > API`). |
-| `ASAAS_WEBHOOK_SECRET` | Segredo configurado no webhook para validar a assinatura `x-asaas-signature`.                 |
+| Variável               | Descrição                                                                                                                                           |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ASAAS_API_URL`        | URL base da API. Utilize `https://sandbox.asaas.com/api/v3` no ambiente de testes.                                                                  |
+| `ASAAS_ACCESS_TOKEN`   | Token pessoal ou de aplicação gerado no painel do Asaas (`Configurações > Integrações > API`).                                                       |
+| `ASAAS_WEBHOOK_SECRET` | Segredo configurado no webhook para validar a assinatura `x-asaas-signature`.                                                                       |
+| `ASAAS_ENVIRONMENT`    | Ambiente utilizado ao consumir a API. Aceita `homologacao` (padrão) ou os aliases de produção `producao`, `produção`, `production`, `prod` e `live`. |
 
 > 💡 Defina as mesmas chaves no ambiente de build do frontend caso ele consuma endpoints intermediários (`VITE_API_URL`).
 

--- a/backend/src/services/asaas/urlNormalization.ts
+++ b/backend/src/services/asaas/urlNormalization.ts
@@ -5,10 +5,21 @@ export const ASAAS_DEFAULT_BASE_URLS = {
 
 export type AsaasEnvironment = keyof typeof ASAAS_DEFAULT_BASE_URLS;
 
+const PRODUCAO_ALIASES = new Set(['producao', 'production', 'prod', 'live']);
+
 export function normalizeAsaasEnvironment(value: string | null | undefined): AsaasEnvironment {
-  if (typeof value === 'string' && value.trim().toLowerCase() === 'producao') {
-    return 'producao';
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+
+    if (normalized) {
+      const withoutDiacritics = normalized.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+
+      if (PRODUCAO_ALIASES.has(withoutDiacritics)) {
+        return 'producao';
+      }
+    }
   }
+
   return 'homologacao';
 }
 

--- a/backend/tests/asaasIntegrationResolver.test.ts
+++ b/backend/tests/asaasIntegrationResolver.test.ts
@@ -53,6 +53,33 @@ test('resolveAsaasIntegration returns sandbox base URL when environment is homol
   assert.deepEqual(pool.calls[0].params, ['asaas', EMPRESA_ID]);
 });
 
+test('resolveAsaasIntegration normalizes produção aliases to default base URL', async () => {
+  const aliases = ['produção', 'production', 'prod', 'live'];
+
+  for (const alias of aliases) {
+    const pool = new FakePool([
+      {
+        rowCount: 1,
+        rows: [
+          {
+            id: 99,
+            provider: 'asaas',
+            url_api: null,
+            key_value: 'alias-token',
+            environment: alias,
+            active: true,
+          },
+        ],
+      },
+    ]);
+
+    const integration = await resolveAsaasIntegration(EMPRESA_ID, pool as any);
+
+    assert.equal(integration.environment, 'producao');
+    assert.equal(integration.baseUrl, ASAAS_DEFAULT_BASE_URLS.producao);
+  }
+});
+
 test('resolveAsaasIntegration prioritizes custom API URL for production', async () => {
   const pool = new FakePool([
     {


### PR DESCRIPTION
## Summary
- strip diacritics and recognize common aliases for the Asaas produção environment
- cover the new aliases in the Asaas integration resolver tests
- document supported ASAAS_ENVIRONMENT values for operators

## Testing
- npm test *(fails: existing backend test suite contains unrelated failures with legacy mocks and database dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e878aaac8326abd67d767ae70046