### PR TITLE
Format blog publication timestamps consistently

### DIFF
--- a/frontend/src/lib/date.ts
+++ b/frontend/src/lib/date.ts
@@ -1,6 +1,23 @@
 const pad = (value: number) => value.toString().padStart(2, "0");
 
-export const formatPostDateTime = (value: string): string => {
+const createFormatter = () =>
+  new Intl.DateTimeFormat("pt-BR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+
+let blogPublicationFormatter: Intl.DateTimeFormat | undefined;
+
+const getBlogPublicationFormatter = () => {
+  if (!blogPublicationFormatter) {
+    blogPublicationFormatter = createFormatter();
+  }
+
+  return blogPublicationFormatter;
+};
+
+export const formatBlogPublicationDate = (value: string): string => {
   if (!value) {
     return "";
   }
@@ -12,15 +29,11 @@ export const formatPostDateTime = (value: string): string => {
   }
 
   try {
-    return new Intl.DateTimeFormat("pt-BR", {
-      day: "2-digit",
-      month: "2-digit",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    }).format(parsedDate);
+    return getBlogPublicationFormatter().format(parsedDate);
   } catch (error) {
-    return `${pad(parsedDate.getDate())}/${pad(parsedDate.getMonth() + 1)}/${parsedDate.getFullYear()} ${pad(parsedDate.getHours())}:${pad(parsedDate.getMinutes())}`;
+    return `${pad(parsedDate.getDate())}/${pad(parsedDate.getMonth() + 1)}/${parsedDate.getFullYear()}`;
   }
 };
+
+export const formatPostDateTime = (value: string): string =>
+  formatBlogPublicationDate(value);

--- a/frontend/src/pages/administrator/BlogPosts.tsx
+++ b/frontend/src/pages/administrator/BlogPosts.tsx
@@ -56,6 +56,7 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { adminApi, blogPostKeys, type BlogPost, type BlogPostInput } from "@/lib/adminApi";
 import { useBlogPosts, useBlogCategories } from "@/hooks/useBlogPosts";
+import { formatBlogPublicationDate } from "@/lib/date";
 import { useAuth } from "@/features/auth/AuthProvider";
 
 interface BlogPostFormState {
@@ -127,19 +128,6 @@ const buildInputPayload = (state: BlogPostFormState): BlogPostInput => {
     content: content.length > 0 ? content : undefined,
     tags: normalizeTags(state.tags),
   };
-};
-
-const formatDisplayDate = (value: string): string => {
-  const parsed = new Date(value);
-  if (!Number.isNaN(parsed.getTime())) {
-    return parsed.toLocaleDateString("pt-BR", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-    });
-  }
-
-  return value;
 };
 
 const BlogPosts = () => {
@@ -426,7 +414,7 @@ const BlogPosts = () => {
                       <TableCell className="whitespace-nowrap">{post.category}</TableCell>
                       <TableCell className="whitespace-nowrap">{post.author}</TableCell>
                       <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
-                        {formatDisplayDate(post.date)}
+                        {formatBlogPublicationDate(post.date)}
                       </TableCell>
                       <TableCell className="text-right">
                         <div className="flex items-center justify-end gap-2">


### PR DESCRIPTION
## Summary
- centralize blog publication date formatting in a shared helper
- update admin blog post listing to use the shared formatter for consistency

## Testing
- `npm --prefix frontend test` *(fails: vitest not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dabd97d8888326ac77de885fa09f83