### PR TITLE
Allow proposal details to expand fully

### DIFF
--- a/frontend/src/pages/operator/VisualizarOportunidade.tsx
+++ b/frontend/src/pages/operator/VisualizarOportunidade.tsx
@@ -2980,7 +2980,7 @@ export default function VisualizarOportunidade() {
         </CardHeader>
 
         <CardContent>
-          <ScrollArea className="max-h-none md:max-h-[75vh] lg:max-h-[80vh]">
+          <ScrollArea className="max-h-none">
             <div className="space-y-6">
               {/* percorre as seções definidas e exibe apenas campos que existam */}
               {renderDataSection("fluxo")}


### PR DESCRIPTION
## Summary
- remove viewport-based max-height constraints from the proposal detail ScrollArea so full content is visible

## Testing
- not run (npm install blocked by registry permissions)


------
https://chatgpt.com/codex/tasks/task_e_68dad2e50ebc8326929166801da00bbb