### PR TITLE
Improve appointment dialog responsiveness

### DIFF
--- a/frontend/src/components/agenda/AppointmentCreationDialog.tsx
+++ b/frontend/src/components/agenda/AppointmentCreationDialog.tsx
@@ -257,7 +257,7 @@ export default function AppointmentCreationDialog({
         }
       }}
     >
-      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="w-[min(100vw-2rem,64rem)] max-w-4xl max-h-[90vh] overflow-y-auto sm:w-[min(100vw-4rem,64rem)]">
         <DialogHeader>
           <DialogTitle>Novo Agendamento</DialogTitle>
         </DialogHeader>

--- a/frontend/src/components/agenda/AppointmentForm.tsx
+++ b/frontend/src/components/agenda/AppointmentForm.tsx
@@ -439,8 +439,8 @@ export function AppointmentForm({
             />
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-            <div className="space-y-2 md:col-span-2">
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+            <div className="space-y-2 sm:col-span-2 xl:col-span-2">
               <Label>Data *</Label>
               <Popover>
                 <PopoverTrigger asChild>
@@ -485,7 +485,13 @@ export function AppointmentForm({
               </div>
             </div>
 
-            <div className="flex items-center gap-3 rounded-lg border border-dashed border-muted-foreground/30 px-4 py-3 md:self-end">
+            <div
+              className={cn(
+                'flex flex-col items-start gap-2 rounded-lg border border-dashed border-muted-foreground/30 px-4 py-3',
+                'sm:flex-row sm:items-center sm:gap-3 sm:col-span-2',
+                'xl:col-span-1 xl:self-end',
+              )}
+            >
               <Switch
                 id="allDay"
                 checked={isAllDay}


### PR DESCRIPTION
## Summary
- adjust the appointment creation dialog width so it fits smaller viewports without overflowing
- reorganize the scheduling form grid so the "Dia todo" toggle has adequate space on smaller breakpoints

## Testing
- npm run lint *(fails: missing dependency `@eslint/js` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dad32c7bd48326b9144e9e1e3c80be