### PR TITLE
Enforce SMTP credential configuration and sanitize docs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -25,8 +25,12 @@ Estrutura inicial do backend usando Express e TypeScript.
    utilize:
 
    ```bash
-   export DATABASE_URL="postgres://postgres:C@104rm0nd1994@easypanel02.quantumtecnologia.com.br:5438/quantumtecnologia?sslmode=disable"
+   export DATABASE_URL="postgres://usuario:senha@host:porta/nomedb?sslmode=disable"
    ```
+
+   Recomenda-se armazenar essas credenciais em um arquivo `.env` (não versionado)
+   ou no gerenciador de segredos da sua infraestrutura, carregando-as antes de
+   iniciar a aplicação.
 
    Caso prefira outra instância local, substitua a string acima pela conexão
    desejada.

--- a/backend/dist/services/emailService.js
+++ b/backend/dist/services/emailService.js
@@ -19,14 +19,27 @@ const parseBoolean = (value, defaultValue) => {
     }
     return defaultValue;
 };
+const smtpUser = process.env.SMTP_USER;
+const smtpPass = process.env.SMTP_PASSWORD ?? process.env.SMTP_PASS;
+if (!smtpUser || !smtpPass) {
+    const missingParts = [];
+    if (!smtpUser) {
+        missingParts.push('SMTP_USER');
+    }
+    if (!smtpPass) {
+        missingParts.push('SMTP_PASSWORD (ou SMTP_PASS)');
+    }
+    const missingDescription = missingParts.join(' e ');
+    throw new Error(`Configuração SMTP inválida. Defina ${missingDescription} como variáveis de ambiente antes de iniciar o servidor.`);
+}
 const DEFAULT_SMTP_CONFIG = {
     host: process.env.SMTP_HOST || 'smtp.hostinger.com',
     port: Number.parseInt(process.env.SMTP_PORT || '465', 10),
     secure: parseBoolean(process.env.SMTP_SECURE, true),
     rejectUnauthorized: parseBoolean(process.env.SMTP_REJECT_UNAUTHORIZED, true),
     auth: {
-        user: process.env.SMTP_USER || 'contato@quantumtecnologia.com.br',
-        pass: process.env.SMTP_PASSWORD || process.env.SMTP_PASS || 'C@104rm0nd1994',
+        user: smtpUser,
+        pass: smtpPass,
     },
 };
 const systemName = process.env.SYSTEM_NAME || 'Quantum JUD';

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -31,14 +31,32 @@ const parseBoolean = (value: string | undefined, defaultValue: boolean): boolean
   return defaultValue;
 };
 
+const smtpUser = process.env.SMTP_USER;
+const smtpPass = process.env.SMTP_PASSWORD ?? process.env.SMTP_PASS;
+
+if (!smtpUser || !smtpPass) {
+  const missingParts: string[] = [];
+  if (!smtpUser) {
+    missingParts.push('SMTP_USER');
+  }
+  if (!smtpPass) {
+    missingParts.push('SMTP_PASSWORD (ou SMTP_PASS)');
+  }
+
+  const missingDescription = missingParts.join(' e ');
+  throw new Error(
+    `Configuração SMTP inválida. Defina ${missingDescription} como variáveis de ambiente antes de iniciar o servidor.`
+  );
+}
+
 const DEFAULT_SMTP_CONFIG: SmtpConfig = {
   host: process.env.SMTP_HOST || 'smtp.hostinger.com',
   port: Number.parseInt(process.env.SMTP_PORT || '465', 10),
   secure: parseBoolean(process.env.SMTP_SECURE, true),
   rejectUnauthorized: parseBoolean(process.env.SMTP_REJECT_UNAUTHORIZED, true),
   auth: {
-    user: process.env.SMTP_USER || 'contato@quantumtecnologia.com.br',
-    pass: process.env.SMTP_PASSWORD || process.env.SMTP_PASS || 'C@104rm0nd1994',
+    user: smtpUser,
+    pass: smtpPass,
   },
 };
 


### PR DESCRIPTION
## Summary
- require SMTP_USER and SMTP_PASSWORD/SMTP_PASS to come from the environment and emit a clear startup error when they are missing
- update the compiled email service bundle to mirror the new credential guard
- replace the exposed database connection string in the backend README with a neutral placeholder and guidance to store secrets in env files or a secret manager

## Testing
- SMTP_USER=fake@example.com SMTP_PASSWORD=placeholder npm test *(fails: AsaasChargeService.createCharge maps refunded responses to estornado status due to "Cannot read properties of undefined (reading 'createCharge')")*

------
https://chatgpt.com/codex/tasks/task_e_68daeaa885408326bbb91eaea59cddec