### PR TITLE
feat: implement local file storage for uploads

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -71,6 +71,30 @@ API hospedada pela Quantum em `https://quantumtecnologia.com.br`.
 Em produção recomenda-se executar `npm run build` seguido de `npm start`, ou
 utilizar a imagem Docker disponibilizada na raiz do monorepo.
 
+# Uploads de arquivos
+
+O endpoint `POST /uploads` aceita um formulário `multipart/form-data` com o
+campo `file` e persiste o conteúdo no filesystem local por padrão. Os arquivos
+ficam disponíveis em `backend/uploads/` e também podem ser servidos
+automaticamente pela API quando `FILE_STORAGE_PUBLIC_BASE_URL` aponta para um
+path relativo (ex.: `/uploads/`).
+
+Variáveis de ambiente relacionadas:
+
+- `FILE_STORAGE_DRIVER`: driver utilizado para salvar arquivos. Atualmente há o
+  driver `local` (padrão) e o modo `disabled`, que retorna HTTP 501
+  imediatamente.
+- `FILE_STORAGE_LOCAL_ROOT`: caminho onde os arquivos serão salvos quando o
+  driver local estiver ativo. Por padrão utiliza `<repo>/backend/uploads`.
+- `FILE_STORAGE_PUBLIC_BASE_URL`: base usada para montar a URL pública retornada
+  após o upload. Aceita caminhos relativos (`/uploads/`) ou URLs completas
+  (`https://cdn.example.com/uploads/`).
+- `UPLOAD_MAX_SIZE_MB`: tamanho máximo de arquivo aceito pela API (padrão 10
+  MB).
+- `UPLOAD_ALLOWED_MIME_TYPES`: lista separada por vírgula com os tipos MIME
+  permitidos. Quando não definida, a API aceita `image/jpeg`, `image/png`,
+  `image/webp`, `application/pdf` e `text/plain`.
+
 # Rodando testes
 
 Os testes automatizados ficam em `backend/tests/` e utilizam o runner nativo do

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -1,6 +1,29 @@
-import { Request, Response } from 'express';
+import type { Request, Response } from 'express';
+import {
+  saveUploadedFile,
+  StorageUnavailableError,
+} from '../services/fileStorageService';
 
-export const upload = async (_req: Request, res: Response) => {
-  // Stub implementation for uploads. In a real scenario, this would upload to S3/MinIO.
-  res.json({ key: 'stub', url: 'https://example.com/stub', name: 'file', size: 0 });
+export const upload = async (req: Request, res: Response) => {
+  const file = req.file;
+
+  if (!file) {
+    return res
+      .status(400)
+      .json({ error: 'Nenhum arquivo foi enviado ou o campo "file" está ausente.' });
+  }
+
+  try {
+    const metadata = await saveUploadedFile(file);
+    return res.status(201).json(metadata);
+  } catch (error) {
+    if (error instanceof StorageUnavailableError) {
+      return res.status(501).json({ error: error.message });
+    }
+
+    console.error('Falha ao realizar upload de arquivo', error);
+    return res
+      .status(500)
+      .json({ error: 'Não foi possível processar o upload do arquivo.' });
+  }
 };

--- a/backend/src/middlewares/uploadMiddleware.ts
+++ b/backend/src/middlewares/uploadMiddleware.ts
@@ -1,0 +1,258 @@
+import type { Express, NextFunction, Request, Response } from 'express';
+import { Readable } from 'node:stream';
+
+const CRLF = Buffer.from('\r\n');
+const HEADER_SEPARATOR = Buffer.from('\r\n\r\n');
+
+const parseBoundary = (contentType: string): string | null => {
+  const match = /boundary=([^;]+)/i.exec(contentType);
+  if (!match) {
+    return null;
+  }
+
+  return match[1].trim().replace(/^"|"$/g, '');
+};
+
+type ParsedPart = {
+  fieldname: string;
+  filename?: string;
+  contentType?: string;
+  contentTransferEncoding?: string;
+  content: Buffer;
+};
+
+const parseHeaders = (buffer: Buffer): Record<string, string> => {
+  const lines = buffer.toString('utf8').split('\r\n').filter(Boolean);
+  const headers: Record<string, string> = {};
+
+  for (const line of lines) {
+    const [rawName, ...rest] = line.split(':');
+    const name = rawName?.trim().toLowerCase();
+    if (!name) {
+      continue;
+    }
+    headers[name] = rest.join(':').trim();
+  }
+
+  return headers;
+};
+
+const parseContentDisposition = (value: string | undefined) => {
+  if (!value) {
+    return { fieldname: undefined, filename: undefined };
+  }
+
+  const segments = value.split(';').map((segment) => segment.trim());
+  const params: Record<string, string> = {};
+
+  for (const segment of segments) {
+    const [key, rawValue] = segment.split('=');
+    if (!rawValue) {
+      continue;
+    }
+    params[key.toLowerCase()] = rawValue.replace(/^"|"$/g, '');
+  }
+
+  return {
+    fieldname: params.name,
+    filename: params.filename,
+  };
+};
+
+const extractParts = (body: Buffer, boundary: string): ParsedPart[] => {
+  const boundaryBuffer = Buffer.from(`--${boundary}`);
+  const parts: ParsedPart[] = [];
+  let searchIndex = 0;
+
+  while (searchIndex < body.length) {
+    const boundaryIndex = body.indexOf(boundaryBuffer, searchIndex);
+    if (boundaryIndex === -1) {
+      break;
+    }
+
+    let partStart = boundaryIndex + boundaryBuffer.length;
+
+    if (body[partStart] === 45 && body[partStart + 1] === 45) {
+      // Encontramos o boundary final "--boundary--"
+      break;
+    }
+
+    if (body[partStart] === CRLF[0] && body[partStart + 1] === CRLF[1]) {
+      partStart += CRLF.length;
+    } else if (body[partStart] === CRLF[1]) {
+      partStart += 1;
+    }
+
+    const headerEndIndex = body.indexOf(HEADER_SEPARATOR, partStart);
+    if (headerEndIndex === -1) {
+      break;
+    }
+
+    const headersBuffer = body.slice(partStart, headerEndIndex);
+    const headers = parseHeaders(headersBuffer);
+    const { fieldname, filename } = parseContentDisposition(
+      headers['content-disposition']
+    );
+
+    const contentStart = headerEndIndex + HEADER_SEPARATOR.length;
+    let nextBoundaryIndex = body.indexOf(boundaryBuffer, contentStart);
+
+    if (nextBoundaryIndex === -1) {
+      nextBoundaryIndex = body.length;
+    }
+
+    let contentEnd = nextBoundaryIndex;
+
+    if (
+      body[nextBoundaryIndex - 2] === CRLF[0] &&
+      body[nextBoundaryIndex - 1] === CRLF[1]
+    ) {
+      contentEnd -= CRLF.length;
+    } else if (body[nextBoundaryIndex - 1] === CRLF[1]) {
+      contentEnd -= 1;
+    }
+
+    const content = body.slice(contentStart, contentEnd);
+
+    parts.push({
+      fieldname: fieldname ?? '',
+      filename: filename ?? undefined,
+      contentType: headers['content-type'],
+      contentTransferEncoding: headers['content-transfer-encoding'],
+      content,
+    });
+
+    searchIndex = nextBoundaryIndex;
+  }
+
+  return parts;
+};
+
+const toReadableStream = (buffer: Buffer) => {
+  return Readable.from(buffer);
+};
+
+const parseAllowedMimeTypes = (): Set<string> => {
+  const raw = process.env.UPLOAD_ALLOWED_MIME_TYPES;
+  if (!raw) {
+    return new Set([
+      'image/jpeg',
+      'image/png',
+      'image/webp',
+      'application/pdf',
+      'text/plain',
+    ]);
+  }
+
+  return new Set(
+    raw
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean)
+  );
+};
+
+const resolveMaxFileSize = (): number => {
+  const configured = Number.parseInt(process.env.UPLOAD_MAX_SIZE_MB ?? '10', 10);
+  const sizeInMb = Number.isNaN(configured) || configured <= 0 ? 10 : configured;
+  return sizeInMb * 1024 * 1024;
+};
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    file?: Express.Multer.File;
+  }
+}
+
+export const singleFileUpload = (req: Request, res: Response, next: NextFunction) => {
+  const contentType = req.headers['content-type'];
+  if (!contentType || !contentType.includes('multipart/form-data')) {
+    return res
+      .status(400)
+      .json({ error: 'Envie o arquivo usando multipart/form-data.' });
+  }
+
+  const boundary = parseBoundary(contentType);
+
+  if (!boundary) {
+    return res
+      .status(400)
+      .json({ error: 'Não foi possível identificar o boundary do upload.' });
+  }
+
+  const maxFileSize = resolveMaxFileSize();
+  const allowedMimeTypes = parseAllowedMimeTypes();
+  const chunks: Buffer[] = [];
+  let totalSize = 0;
+  let limitExceeded = false;
+
+  req.on('data', (chunk: Buffer) => {
+    if (limitExceeded) {
+      return;
+    }
+
+    totalSize += chunk.length;
+
+    if (totalSize > maxFileSize) {
+      limitExceeded = true;
+      return;
+    }
+
+    chunks.push(chunk);
+  });
+
+  req.on('end', () => {
+    if (limitExceeded) {
+      return res.status(413).json({
+        error: `Arquivo maior que o limite permitido de ${Math.round(
+          maxFileSize / 1024 / 1024
+        )}MB.`,
+      });
+    }
+
+    try {
+      const body = Buffer.concat(chunks);
+      const parts = extractParts(body, boundary);
+      const filePart = parts.find((part) => part.fieldname === 'file');
+
+      if (!filePart || !filePart.filename) {
+        return res
+          .status(400)
+          .json({ error: 'Campo de arquivo "file" não encontrado.' });
+      }
+
+      const mimeType = filePart.contentType ?? 'application/octet-stream';
+
+      if (allowedMimeTypes.size > 0 && !allowedMimeTypes.has(mimeType)) {
+        return res.status(400).json({
+          error: `Tipo de arquivo não suportado. Permitidos: ${Array.from(
+            allowedMimeTypes
+          ).join(', ')}`,
+        });
+      }
+
+      const buffer = filePart.content;
+
+      req.file = {
+        fieldname: 'file',
+        originalname: filePart.filename,
+        encoding: filePart.contentTransferEncoding ?? '7bit',
+        mimetype: mimeType,
+        size: buffer.length,
+        buffer,
+        destination: '',
+        filename: filePart.filename,
+        path: '',
+        stream: toReadableStream(buffer),
+      } satisfies Express.Multer.File;
+
+      next();
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  req.on('error', (error) => {
+    next(error);
+  });
+};

--- a/backend/src/routes/uploadRoutes.ts
+++ b/backend/src/routes/uploadRoutes.ts
@@ -1,8 +1,56 @@
 import { Router } from 'express';
 import { upload } from '../controllers/uploadController';
+import { singleFileUpload } from '../middlewares/uploadMiddleware';
 
 const router = Router();
 
-router.post('/uploads', upload);
+/**
+ * @openapi
+ * /uploads:
+ *   post:
+ *     summary: Faz upload de um arquivo.
+ *     tags:
+ *       - Uploads
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - file
+ *             properties:
+ *               file:
+ *                 type: string
+ *                 format: binary
+ *     responses:
+ *       201:
+ *         description: Upload concluído.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 key:
+ *                   type: string
+ *                 url:
+ *                   type: string
+ *                   format: uri
+ *                 name:
+ *                   type: string
+ *                 size:
+ *                   type: integer
+ *                 mimeType:
+ *                   type: string
+ *       400:
+ *         description: Erro de validação no upload.
+ *       413:
+ *         description: Arquivo excede o limite configurado.
+ *       501:
+ *         description: Armazenamento de arquivos indisponível.
+ *       500:
+ *         description: Erro inesperado ao processar o upload.
+ */
+router.post('/uploads', singleFileUpload, upload);
 
 export default router;

--- a/backend/tests/fileStorageService.test.ts
+++ b/backend/tests/fileStorageService.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import type { Express } from 'express';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import test from 'node:test';
+
+const createFakeFile = (name: string, content: Buffer): Express.Multer.File => ({
+  fieldname: 'file',
+  originalname: name,
+  encoding: '7bit',
+  mimetype: 'text/plain',
+  size: content.length,
+  buffer: content,
+  destination: '',
+  filename: name,
+  path: '',
+  stream: Readable.from(content),
+});
+
+test('saveUploadedFile persiste o arquivo no diretório local configurado', async () => {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'uploads-'));
+  const content = Buffer.from('conteúdo de teste', 'utf8');
+
+  process.env.FILE_STORAGE_DRIVER = 'local';
+  process.env.FILE_STORAGE_LOCAL_ROOT = tmpDir;
+  process.env.FILE_STORAGE_PUBLIC_BASE_URL = 'https://cdn.example.com/uploads/';
+
+  const service = await import('../src/services/fileStorageService');
+  const metadata = await service.saveUploadedFile(createFakeFile('exemplo.txt', content));
+
+  assert.equal(path.extname(metadata.key), '.txt');
+  assert.equal(metadata.name, 'exemplo.txt');
+  assert.equal(metadata.mimeType, 'text/plain');
+  assert.equal(metadata.size, content.length);
+  assert.equal(metadata.url, `https://cdn.example.com/uploads/${metadata.key}`);
+
+  const stored = await readFile(path.join(tmpDir, metadata.key));
+  assert.deepEqual(stored, content);
+
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+test('saveUploadedFile lança erro quando o armazenamento está desabilitado', async () => {
+  process.env.FILE_STORAGE_DRIVER = 'disabled';
+  delete process.env.FILE_STORAGE_LOCAL_ROOT;
+
+  const service = await import('../src/services/fileStorageService');
+
+  await assert.rejects(
+    () =>
+      service.saveUploadedFile(
+        createFakeFile('arquivo.txt', Buffer.from('dados', 'utf8'))
+      ),
+    (error: unknown) => {
+      assert(error instanceof service.StorageUnavailableError);
+      assert.match(
+        error.message,
+        /armazenamento de arquivos não está habilitado/i
+      );
+      return true;
+    }
+  );
+});

--- a/backend/tests/uploadController.test.ts
+++ b/backend/tests/uploadController.test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import type { Express, Request, Response } from 'express';
+import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import test from 'node:test';
+
+type UploadResponse = {
+  key: string;
+  url: string;
+  name: string;
+  size: number;
+  mimeType: string;
+};
+
+const createMockResponse = () => {
+  const response: Partial<Response> & { statusCode: number; body: unknown } = {
+    statusCode: 200,
+    body: undefined,
+    status(code: number) {
+      this.statusCode = code;
+      return this as Response;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this as Response;
+    },
+  };
+
+  return response as Response & { statusCode: number; body: unknown };
+};
+
+const createFakeFile = (name: string, content: Buffer): Express.Multer.File => ({
+  fieldname: 'file',
+  originalname: name,
+  encoding: '7bit',
+  mimetype: 'text/plain',
+  size: content.length,
+  buffer: content,
+  destination: '',
+  filename: name,
+  path: '',
+  stream: Readable.from(content),
+});
+
+test('upload retorna 400 quando nenhum arquivo é enviado', async () => {
+  const { upload } = await import('../src/controllers/uploadController');
+  const req = { file: undefined } as unknown as Request;
+  const res = createMockResponse();
+
+  await upload(req, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, {
+    error: 'Nenhum arquivo foi enviado ou o campo "file" está ausente.',
+  });
+});
+
+test('upload persiste o arquivo e retorna metadados reais', async () => {
+  process.env.FILE_STORAGE_DRIVER = 'local';
+  process.env.FILE_STORAGE_PUBLIC_BASE_URL = '/arquivos/';
+  const uploadsDir = await mkdtemp(path.join(tmpdir(), 'upload-controller-'));
+  process.env.FILE_STORAGE_LOCAL_ROOT = uploadsDir;
+
+  const { upload } = await import('../src/controllers/uploadController');
+  const res = createMockResponse();
+  const payload = Buffer.from('conteúdo gerado em teste', 'utf8');
+  const req = { file: createFakeFile('documento.txt', payload) } as unknown as Request;
+
+  try {
+    await upload(req, res);
+
+    assert.equal(res.statusCode, 201);
+    const body = res.body as UploadResponse;
+    assert.equal(body.name, 'documento.txt');
+    assert.equal(body.size, payload.length);
+    assert.equal(body.mimeType, 'text/plain');
+    assert.ok(body.key.endsWith('.txt'));
+    assert.ok(body.url.startsWith('/arquivos/'));
+
+    await stat(path.join(uploadsDir, body.key));
+  } finally {
+    await rm(uploadsDir, { recursive: true, force: true });
+  }
+});
+
+test('upload responde 501 quando o armazenamento está desabilitado', async () => {
+  process.env.FILE_STORAGE_DRIVER = 'disabled';
+
+  const { upload } = await import('../src/controllers/uploadController');
+  const req = { file: createFakeFile('arquivo.txt', Buffer.from('dados')) } as unknown as Request;
+  const res = createMockResponse();
+
+  await upload(req, res);
+
+  assert.equal(res.statusCode, 501);
+  assert.deepEqual(res.body, {
+    error: 'O armazenamento de arquivos não está habilitado. Entre em contato com o administrador.',
+  });
+});
+
+test('upload responde 500 quando o serviço falha inesperadamente', async () => {
+  process.env.FILE_STORAGE_DRIVER = 'local';
+  process.env.FILE_STORAGE_LOCAL_ROOT = '/proc/1/mem';
+
+  const { upload } = await import('../src/controllers/uploadController');
+  const req = { file: createFakeFile('falha.txt', Buffer.from('erro')) } as unknown as Request;
+  const res = createMockResponse();
+
+  await upload(req, res);
+
+  assert.equal(res.statusCode, 500);
+  assert.deepEqual(res.body, {
+    error: 'Não foi possível processar o upload do arquivo.',
+  });
+});

--- a/backend/uploads/.gitignore
+++ b/backend/uploads/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- implement a filesystem-backed storage service with real keys/URLs and configuration guards for unavailable drivers
- add a multipart upload middleware with size/type validation, expose the route via Swagger, and serve stored files when using the local driver
- replace the upload controller stub, document the new environment variables, and cover the service/controller behavior with dedicated tests

## Testing
- node --import tsx --test tests/fileStorageService.test.ts tests/uploadController.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68daeaa868408326b70764abaf0a1aa5