### PR TITLE
Limit AI integration dropdown to supported providers

### DIFF
--- a/frontend/src/pages/operator/EditorPage.tsx
+++ b/frontend/src/pages/operator/EditorPage.tsx
@@ -258,8 +258,14 @@ export default function EditorPage() {
   }, [integrationQuery.data, companyId]);
 
   const activeAiIntegrations = useMemo(() => {
+    const allowedProviders = ['gemini', 'openai'];
     return [...accessibleIntegrationKeys]
-      .filter(integration => integration.active)
+      .filter(integration => {
+        const provider = typeof integration.provider === 'string'
+          ? integration.provider.trim().toLowerCase()
+          : '';
+        return integration.active && allowedProviders.includes(provider);
+      })
       .sort((a, b) => {
         if (a.environment === b.environment) {
           const labelA = getApiKeyProviderLabel(a.provider) || a.provider;


### PR DESCRIPTION
## Summary
- filter the Editor AI integration dropdown to only include active Gemini and OpenAI keys

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68dc617b346483268ad555544e03f961