### PR TITLE
Prefill document title when creating from template

### DIFF
--- a/frontend/src/pages/operator/VisualizarOportunidade.tsx
+++ b/frontend/src/pages/operator/VisualizarOportunidade.tsx
@@ -552,6 +552,7 @@ export default function VisualizarOportunidade() {
     null,
   );
   const [documentSubmitting, setDocumentSubmitting] = useState(false);
+  const lastTemplateLabelRef = useRef<string>("");
   const [documents, setDocuments] = useState<OpportunityDocument[]>([]);
   const [documentsLoading, setDocumentsLoading] = useState(false);
   const [documentsError, setDocumentsError] = useState<string | null>(null);
@@ -1083,6 +1084,39 @@ export default function VisualizarOportunidade() {
       cancelled = true;
     };
   }, [apiUrl, documentDialogOpen, documentType]);
+
+  useEffect(() => {
+    if (!documentDialogOpen || documentType !== "modelo") {
+      lastTemplateLabelRef.current = "";
+      return;
+    }
+
+    const template = documentTemplates.find(
+      (option) => option.value === selectedTemplate,
+    );
+
+    if (!template) {
+      lastTemplateLabelRef.current = "";
+      return;
+    }
+
+    setDocumentTitle((current) => {
+      const trimmedCurrent = current.trim();
+      const previousLabel = lastTemplateLabelRef.current;
+      lastTemplateLabelRef.current = template.label;
+
+      if (trimmedCurrent.length === 0 || trimmedCurrent === previousLabel) {
+        return template.label;
+      }
+
+      return current;
+    });
+  }, [
+    documentDialogOpen,
+    documentType,
+    documentTemplates,
+    selectedTemplate,
+  ]);
 
   useEffect(() => {
     if (!opportunity || (opportunity as { _namesLoaded?: boolean })._namesLoaded)


### PR DESCRIPTION
## Summary
- prefill the document title input with the selected template name when generating a document from a standard template
- avoid overriding a manually edited title by only applying the template name when the field is empty or unchanged

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc7aedd25883268b5aa1ac6a2d28e3