### PR TITLE
Normalize agenda location type before persisting

### DIFF
--- a/backend/dist/controllers/agendaController.js
+++ b/backend/dist/controllers/agendaController.js
@@ -57,6 +57,22 @@ const normalizeAgendaStatus = (value) => {
     }
     return 1;
 };
+const normalizeAgendaLocationType = (value) => {
+    if (typeof value !== 'string') {
+        return null;
+    }
+    const normalized = value.trim().toLowerCase();
+    if (normalized === '') {
+        return null;
+    }
+    if (normalized === 'interno' || normalized === 'interna' || normalized === 'presencial') {
+        return 'Interno';
+    }
+    if (normalized === 'externo' || normalized === 'externa' || normalized === 'online' || normalized === 'virtual') {
+        return 'Externo';
+    }
+    return null;
+};
 const buildAgendaSelect = (cteName) => `
   SELECT
     ${cteName}.id,
@@ -259,6 +275,7 @@ exports.getTotalCompromissosHoje = getTotalCompromissosHoje;
 const createAgenda = async (req, res) => {
     const { titulo, tipo, descricao, data, hora_inicio, hora_fim, cliente, tipo_local, local, lembrete, status, } = req.body;
     const normalizedStatus = normalizeAgendaStatus(status);
+    const normalizedLocationType = normalizeAgendaLocationType(tipo_local);
     try {
         if (!req.auth) {
             return res.status(401).json({ error: 'Token inválido.' });
@@ -305,7 +322,7 @@ const createAgenda = async (req, res) => {
             hora_inicio,
             hora_fim,
             cliente,
-            tipo_local,
+            normalizedLocationType,
             local,
             lembrete,
             normalizedStatus,
@@ -348,6 +365,7 @@ const updateAgenda = async (req, res) => {
     const { id } = req.params;
     const { titulo, tipo, descricao, data, hora_inicio, hora_fim, cliente, tipo_local, local, lembrete, status, } = req.body;
     const normalizedStatus = normalizeAgendaStatus(status);
+    const normalizedLocationType = normalizeAgendaLocationType(tipo_local);
     try {
         if (!req.auth) {
             return res.status(401).json({ error: 'Token inválido.' });
@@ -389,7 +407,7 @@ const updateAgenda = async (req, res) => {
             hora_inicio,
             hora_fim,
             cliente,
-            tipo_local,
+            normalizedLocationType,
             local,
             lembrete,
             normalizedStatus,

--- a/backend/src/controllers/agendaController.ts
+++ b/backend/src/controllers/agendaController.ts
@@ -65,6 +65,33 @@ const normalizeAgendaStatus = (value: unknown): number => {
   return 1;
 };
 
+const normalizeAgendaLocationType = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+
+  if (normalized === '') {
+    return null;
+  }
+
+  if (normalized === 'interno' || normalized === 'interna' || normalized === 'presencial') {
+    return 'Interno';
+  }
+
+  if (
+    normalized === 'externo' ||
+    normalized === 'externa' ||
+    normalized === 'online' ||
+    normalized === 'virtual'
+  ) {
+    return 'Externo';
+  }
+
+  return null;
+};
+
 const buildAgendaSelect = (cteName: string): string => `
   SELECT
     ${cteName}.id,
@@ -314,6 +341,7 @@ export const createAgenda = async (req: Request, res: Response) => {
   } = req.body;
 
   const normalizedStatus = normalizeAgendaStatus(status);
+  const normalizedLocationType = normalizeAgendaLocationType(tipo_local);
 
   try {
     if (!req.auth) {
@@ -368,7 +396,7 @@ export const createAgenda = async (req: Request, res: Response) => {
         hora_inicio,
         hora_fim,
         cliente,
-        tipo_local,
+        normalizedLocationType,
         local,
         lembrete,
         normalizedStatus,
@@ -426,6 +454,7 @@ export const updateAgenda = async (req: Request, res: Response) => {
   } = req.body;
 
   const normalizedStatus = normalizeAgendaStatus(status);
+  const normalizedLocationType = normalizeAgendaLocationType(tipo_local);
 
   try {
     if (!req.auth) {
@@ -475,7 +504,7 @@ export const updateAgenda = async (req: Request, res: Response) => {
         hora_inicio,
         hora_fim,
         cliente,
-        tipo_local,
+        normalizedLocationType,
         local,
         lembrete,
         normalizedStatus,


### PR DESCRIPTION
## Summary
- normalize incoming agenda location types so they match the values accepted by the database
- reuse the normalized location type for agenda insert and update operations to avoid constraint violations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc7b12db5c8326b9577312840aec46