### PR TITLE
Add AI summary modal for process movements

### DIFF
--- a/backend/src/routes/integrationApiKeyRoutes.ts
+++ b/backend/src/routes/integrationApiKeyRoutes.ts
@@ -202,6 +202,10 @@ router.post('/integrations/providers/asaas/validate', validateAsaasIntegration);
  *                 type: string
  *               prompt:
  *                 type: string
+ *               mode:
+ *                 type: string
+ *                 enum: [default, summary]
+ *                 description: Define o comportamento da IA; usar "summary" para respostas resumidas.
  *     responses:
  *       200:
  *         description: Texto gerado com sucesso

--- a/frontend/src/lib/integrationApiKeys.ts
+++ b/frontend/src/lib/integrationApiKeys.ts
@@ -80,10 +80,16 @@ export interface UpdateIntegrationApiKeyPayload {
   global?: boolean;
 }
 
+export type GenerateAiTextMode = 'default' | 'summary';
+
 export interface GenerateAiTextPayload {
   integrationId: number;
   documentType: string;
   prompt: string;
+  /**
+   * Define o modo de geração. Utilize 'summary' para solicitar respostas enxutas (ex.: resumos em tópicos).
+   */
+  mode?: GenerateAiTextMode;
 }
 
 export interface GenerateAiTextResponse {


### PR DESCRIPTION
## Summary
- add a modal to VisualizarProcesso so operators can open movements, view attachments and request AI summaries
- reuse integration utilities on the frontend to locate an active Gemini/OpenAI key and call the backend in summary mode
- update the AI generation controller and routes to support the new summary mode with a tailored prompt and fallback response

## Testing
- pnpm --filter frontend lint *(fails: No projects matched the filters in "/workspace/jus-connect")*
- pnpm lint *(fails: No package.json was found in "/workspace/jus-connect")*

------
https://chatgpt.com/codex/tasks/task_e_68dc8db49ebc83269be22776907bcb48