### PR TITLE
Atualiza título dos anexos na VisualizarProcesso

### DIFF
--- a/frontend/src/pages/operator/VisualizarProcesso.tsx
+++ b/frontend/src/pages/operator/VisualizarProcesso.tsx
@@ -1636,7 +1636,7 @@ export const TimelineMes = memo(function TimelineMes({
                         {item.anexos.length ? (
                           <div className="space-y-2 rounded-xl border border-primary/20 bg-primary/5 p-3">
                             <p className="text-xs font-semibold uppercase tracking-wide text-primary">
-                              Anexos do dia
+                              Anexos
                             </p>
                             <ul className="space-y-3">
                               {item.anexos.map((anexo) => (


### PR DESCRIPTION
## Summary
- renomeia a seção de anexos na linha do tempo do processo para exibir apenas "Anexos"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc929685608326859ae71ada65916f