### PR TITLE
Fix timeline scroll reset and emphasize load more CTA

### DIFF
--- a/frontend/src/pages/operator/VisualizarProcesso.tsx
+++ b/frontend/src/pages/operator/VisualizarProcesso.tsx
@@ -1486,8 +1486,20 @@ export const TimelineMes = memo(function TimelineMes({
   const [intervalo, setIntervalo] = useState({ inicio: 0, fim: movimentacoesVisiveis });
 
   useEffect(() => {
-    setIntervalo({ inicio: 0, fim: movimentacoesVisiveis });
-  }, [movimentacoesVisiveis, grupo.chave]);
+    if (!virtualizado) {
+      setIntervalo({ inicio: 0, fim: movimentacoesVisiveis });
+      return;
+    }
+
+    setIntervalo((atual) => {
+      if (movimentacoesVisiveis <= atual.fim) {
+        return atual;
+      }
+
+      const fim = Math.min(grupo.itens.length, movimentacoesVisiveis);
+      return { inicio: atual.inicio, fim };
+    });
+  }, [movimentacoesVisiveis, grupo.chave, virtualizado, grupo.itens.length]);
 
   useEffect(() => {
     if (!aberto || !virtualizado) {
@@ -2569,9 +2581,9 @@ export default function VisualizarProcesso() {
                 {totalGruposFiltrados > gruposVisiveis.length ? (
                   <div className="text-center">
                     <Button
-                      variant="outline"
                       onClick={handleCarregarMaisMeses}
                       aria-expanded={gruposVisiveis.length < totalGruposFiltrados}
+                      className="font-semibold"
                     >
                       Carregar mais meses
                     </Button>


### PR DESCRIPTION
## Summary
- avoid resetting the virtualized timeline scroll position when showing more movements
- make the "Carregar mais meses" action more prominent to ease discovery

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc9768e47c8326ac3f69a570d572dc