### PR TITLE
fix: remover rolagem interna das movimentacoes

### DIFF
--- a/frontend/src/pages/operator/VisualizarProcesso.tsx
+++ b/frontend/src/pages/operator/VisualizarProcesso.tsx
@@ -2301,7 +2301,7 @@ export default function VisualizarProcesso() {
   );
 
   const totalMovimentacoes = movimentacoesFiltradas.length;
-  const usarVirtualizacao = totalMovimentacoes > 120;
+  const usarVirtualizacao = false;
 
   const gruposVisiveis = useMemo(
     () => gruposFiltrados.slice(0, mesesVisiveis),


### PR DESCRIPTION
## Summary
- desativa a virtualização na timeline de movimentações para evitar que o acordeon mensal crie uma rolagem interna indesejada na tela de visualizar processo

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc991bf8d483268b9d0184b93d09b5