### PR TITLE
fix: ensure upload request typing

### DIFF
--- a/backend/src/controllers/processoController.ts
+++ b/backend/src/controllers/processoController.ts
@@ -981,7 +981,7 @@ export const createProcessoMovimentacaoManual = async (
       throw new Error('Falha ao criar movimentação');
     }
 
-    const movimentacoes = parseMovimentacoes([insertedRow]);
+    const movimentacoes = parseMovimentacoes([insertedRow]) ?? [];
 
     if (movimentacoes.length === 0) {
       throw new Error('Falha ao processar movimentação criada');

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -1,11 +1,14 @@
 import type { Request, Response } from 'express';
+import type { UploadedFile } from '../middlewares/uploadMiddleware';
 import {
   saveUploadedFile,
   StorageUnavailableError,
 } from '../services/fileStorageService';
 import { buildErrorResponse } from '../utils/errorResponse';
 
-export const upload = async (req: Request, res: Response) => {
+type UploadRequest = Request & { file?: UploadedFile };
+
+export const upload = async (req: UploadRequest, res: Response) => {
   const file = req.file;
 
   if (!file) {

--- a/backend/src/middlewares/uploadMiddleware.ts
+++ b/backend/src/middlewares/uploadMiddleware.ts
@@ -174,7 +174,13 @@ declare module 'express-serve-static-core' {
   }
 }
 
-export const singleFileUpload = (req: Request, res: Response, next: NextFunction) => {
+type SingleFileUploadRequest = Request & { file?: UploadedFile };
+
+export const singleFileUpload = (
+  req: SingleFileUploadRequest,
+  res: Response,
+  next: NextFunction,
+) => {
   const contentType = req.headers['content-type'];
   if (!contentType || !contentType.includes('multipart/form-data')) {
     return res


### PR DESCRIPTION
## Summary
- ensure manual movimentação creation handles parse results safely
- align upload controller and middleware request typing to expose the file property

## Testing
- npm --prefix backend run build

------
https://chatgpt.com/codex/tasks/task_e_68dd7f43f0248326aa41ccd318c5190e