### PR TITLE
Atualiza listagem de processos com dados de movimentação

### DIFF
--- a/backend/src/models/processo.ts
+++ b/backend/src/models/processo.ts
@@ -108,6 +108,7 @@ export interface Processo {
   criado_em: string;
   atualizado_em: string;
   ultima_sincronizacao: string | null;
+  ultima_movimentacao?: string | null;
   consultas_api_count: number;
   movimentacoes_count: number;
   cliente?: ProcessoClienteResumo | null;

--- a/frontend/src/pages/operator/Processos.tsx
+++ b/frontend/src/pages/operator/Processos.tsx
@@ -167,6 +167,7 @@ interface ApiProcesso {
   oportunidade?: ApiProcessoOportunidade | null;
   advogados?: ApiProcessoAdvogado[] | null;
   ultima_sincronizacao?: string | null;
+  ultima_movimentacao?: string | null;
   consultas_api_count?: number | string | null;
   movimentacoes_count?: number | string | null;
 }


### PR DESCRIPTION
## Summary
- ajusta a consulta base da listagem de processos para considerar dados das tabelas de gatilhos e evitar contagens duplicadas
- expõe o campo de última movimentação no modelo do processo e na tipagem do frontend

## Testing
- npm test *(falha: suíte apresenta inconsistências pré-existentes em múltiplos testes)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc990c1448326bf5fdfac3f355163