### PR TITLE
Add cliente autocomplete to processo modal

### DIFF
--- a/frontend/src/pages/operator/Processos.tsx
+++ b/frontend/src/pages/operator/Processos.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/select";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Switch } from "@/components/ui/switch";
 import {
   Popover,
   PopoverContent,
@@ -189,6 +190,11 @@ interface AdvogadoOption {
   descricao?: string;
 }
 
+interface SimpleOption {
+  id: string;
+  nome: string;
+}
+
 interface ApiOportunidade {
   id?: number | string | null;
   sequencial_empresa?: number | string | null;
@@ -215,6 +221,10 @@ interface ProcessFormState {
   dataDistribuicao: string;
   instancia: string;
   instanciaOutro: string;
+  areaAtuacaoId: string;
+  tipoProcessoId: string;
+  sistemaCnjId: string;
+  monitorarProcesso: boolean;
 }
 
 export interface ManualSyncFlags {
@@ -372,6 +382,45 @@ const parseOptionalInteger = (value: unknown): number | null => {
   return null;
 };
 
+const extractOptionItems = (
+  payload: unknown,
+): Record<string, unknown>[] => {
+  if (Array.isArray(payload)) {
+    return payload.filter(
+      (item): item is Record<string, unknown> =>
+        item !== null && typeof item === "object",
+    );
+  }
+
+  if (payload && typeof payload === "object") {
+    const directData = (payload as { data?: unknown }).data;
+    if (Array.isArray(directData)) {
+      return directData.filter(
+        (item): item is Record<string, unknown> =>
+          item !== null && typeof item === "object",
+      );
+    }
+
+    const directRows = (payload as { rows?: unknown }).rows;
+    if (Array.isArray(directRows)) {
+      return directRows.filter(
+        (item): item is Record<string, unknown> =>
+          item !== null && typeof item === "object",
+      );
+    }
+
+    const nestedRows = (payload as { data?: { rows?: unknown } }).data?.rows;
+    if (Array.isArray(nestedRows)) {
+      return nestedRows.filter(
+        (item): item is Record<string, unknown> =>
+          item !== null && typeof item === "object",
+      );
+    }
+  }
+
+  return [];
+};
+
 const normalizeClienteTipo = (value: string | null | undefined): string => {
   if (!value) {
     return "";
@@ -462,6 +511,10 @@ const createEmptyProcessForm = (): ProcessFormState => ({
   dataDistribuicao: "",
   instancia: "",
   instanciaOutro: "",
+  areaAtuacaoId: "",
+  tipoProcessoId: "",
+  sistemaCnjId: "",
+  monitorarProcesso: false,
 });
 
 const mapApiProcessoToProcesso = (processo: ApiProcesso): Processo => {
@@ -640,11 +693,24 @@ export default function Processos() {
   const [propostasLoading, setPropostasLoading] = useState(false);
   const [propostasError, setPropostasError] = useState<string | null>(null);
   const [propostasPopoverOpen, setPropostasPopoverOpen] = useState(false);
+  const [areaOptions, setAreaOptions] = useState<SimpleOption[]>([]);
+  const [areaLoading, setAreaLoading] = useState(false);
+  const [areaError, setAreaError] = useState<string | null>(null);
+  const [areaPopoverOpen, setAreaPopoverOpen] = useState(false);
+  const [tipoProcessoOptions, setTipoProcessoOptions] = useState<SimpleOption[]>([]);
+  const [tipoProcessoLoading, setTipoProcessoLoading] = useState(false);
+  const [tipoProcessoError, setTipoProcessoError] = useState<string | null>(null);
+  const [tipoProcessoPopoverOpen, setTipoProcessoPopoverOpen] = useState(false);
+  const [sistemaOptions, setSistemaOptions] = useState<SimpleOption[]>([]);
+  const [sistemaLoading, setSistemaLoading] = useState(false);
+  const [sistemaError, setSistemaError] = useState<string | null>(null);
+  const [sistemaPopoverOpen, setSistemaPopoverOpen] = useState(false);
   const [ufs, setUfs] = useState<Uf[]>([]);
   const [municipios, setMunicipios] = useState<Municipio[]>([]);
   const [municipiosLoading, setMunicipiosLoading] = useState(false);
   const [clientes, setClientes] = useState<ClienteResumo[]>([]);
   const [clientesLoading, setClientesLoading] = useState(false);
+  const [clientePopoverOpen, setClientePopoverOpen] = useState(false);
   const [processosLoading, setProcessosLoading] = useState(false);
   const [processosError, setProcessosError] = useState<string | null>(null);
   const [createError, setCreateError] = useState<string | null>(null);
@@ -850,6 +916,222 @@ export default function Processos() {
   useEffect(() => {
     let cancelled = false;
 
+    const fetchTipoProcessos = async () => {
+      setTipoProcessoLoading(true);
+      setTipoProcessoError(null);
+
+      try {
+        const res = await fetch(getApiUrl("tipo-processos"), {
+          headers: { Accept: "application/json" },
+        });
+
+        let json: unknown = null;
+        try {
+          json = await res.json();
+        } catch (error) {
+          console.error(
+            "Não foi possível interpretar a resposta de tipos de processo",
+            error,
+          );
+        }
+
+        if (!res.ok) {
+          throw new Error(
+            json && typeof json === "object" && "error" in json &&
+              typeof (json as { error?: unknown }).error === "string"
+              ? String((json as { error: string }).error)
+              : `Não foi possível carregar os tipos de processo (HTTP ${res.status})`,
+          );
+        }
+
+        const items = extractOptionItems(json);
+        const options = items
+          .map((item) => {
+            const id = parseOptionalInteger(item.id);
+            const nome =
+              typeof item.nome === "string" ? item.nome.trim() : "";
+            if (!id || id <= 0 || !nome) {
+              return null;
+            }
+            return { id: String(id), nome };
+          })
+          .filter((option): option is SimpleOption => option !== null)
+          .sort((a, b) => a.nome.localeCompare(b.nome, "pt-BR"));
+
+        if (!cancelled) {
+          setTipoProcessoOptions(options);
+        }
+      } catch (error) {
+        console.error(error);
+        if (!cancelled) {
+          setTipoProcessoOptions([]);
+          setTipoProcessoError(
+            error instanceof Error
+              ? error.message
+              : "Erro ao carregar tipos de processo",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setTipoProcessoLoading(false);
+        }
+      }
+    };
+
+    fetchTipoProcessos();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchAreas = async () => {
+      setAreaLoading(true);
+      setAreaError(null);
+
+      try {
+        const res = await fetch(getApiUrl("areas"), {
+          headers: { Accept: "application/json" },
+        });
+
+        let json: unknown = null;
+        try {
+          json = await res.json();
+        } catch (error) {
+          console.error(
+            "Não foi possível interpretar a resposta de áreas",
+            error,
+          );
+        }
+
+        if (!res.ok) {
+          throw new Error(
+            json && typeof json === "object" && "error" in json &&
+              typeof (json as { error?: unknown }).error === "string"
+              ? String((json as { error: string }).error)
+              : `Não foi possível carregar as áreas de atuação (HTTP ${res.status})`,
+          );
+        }
+
+        const items = extractOptionItems(json);
+        const options = items
+          .map((item) => {
+            const id = parseOptionalInteger(item.id);
+            const nome =
+              typeof item.nome === "string" ? item.nome.trim() : "";
+            if (!id || id <= 0 || !nome) {
+              return null;
+            }
+            return { id: String(id), nome };
+          })
+          .filter((option): option is SimpleOption => option !== null)
+          .sort((a, b) => a.nome.localeCompare(b.nome, "pt-BR"));
+
+        if (!cancelled) {
+          setAreaOptions(options);
+        }
+      } catch (error) {
+        console.error(error);
+        if (!cancelled) {
+          setAreaOptions([]);
+          setAreaError(
+            error instanceof Error
+              ? error.message
+              : "Erro ao carregar áreas de atuação",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setAreaLoading(false);
+        }
+      }
+    };
+
+    fetchAreas();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchSistemas = async () => {
+      setSistemaLoading(true);
+      setSistemaError(null);
+
+      try {
+        const res = await fetch(getApiUrl("sistemas-cnj"), {
+          headers: { Accept: "application/json" },
+        });
+
+        let json: unknown = null;
+        try {
+          json = await res.json();
+        } catch (error) {
+          console.error(
+            "Não foi possível interpretar a resposta de sistemas CNJ",
+            error,
+          );
+        }
+
+        if (!res.ok) {
+          throw new Error(
+            json && typeof json === "object" && "error" in json &&
+              typeof (json as { error?: unknown }).error === "string"
+              ? String((json as { error: string }).error)
+              : `Não foi possível carregar os sistemas judiciais (HTTP ${res.status})`,
+          );
+        }
+
+        const items = extractOptionItems(json);
+        const options = items
+          .map((item) => {
+            const id = parseOptionalInteger(item.id);
+            const nome =
+              typeof item.nome === "string" ? item.nome.trim() : "";
+            if (!id || id <= 0 || !nome) {
+              return null;
+            }
+            return { id: String(id), nome };
+          })
+          .filter((option): option is SimpleOption => option !== null)
+          .sort((a, b) => a.nome.localeCompare(b.nome, "pt-BR"));
+
+        if (!cancelled) {
+          setSistemaOptions(options);
+        }
+      } catch (error) {
+        console.error(error);
+        if (!cancelled) {
+          setSistemaOptions([]);
+          setSistemaError(
+            error instanceof Error
+              ? error.message
+              : "Erro ao carregar sistemas judiciais",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setSistemaLoading(false);
+        }
+      }
+    };
+
+    fetchSistemas();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
     const fetchPropostas = async () => {
       setPropostasLoading(true);
       setPropostasError(null);
@@ -1000,10 +1282,44 @@ export default function Processos() {
     [processForm.advogados, advogadosOptions],
   );
 
+  const selectedCliente = useMemo(
+    () =>
+      clientes.find((cliente) => String(cliente.id) === processForm.clienteId) ?? null,
+    [processForm.clienteId, clientes],
+  );
+
   const selectedProposta = useMemo(
     () => propostas.find((option) => option.id === processForm.propostaId) ?? null,
     [processForm.propostaId, propostas],
   );
+
+  const selectedArea = useMemo(
+    () =>
+      areaOptions.find((option) => option.id === processForm.areaAtuacaoId) ?? null,
+    [processForm.areaAtuacaoId, areaOptions],
+  );
+
+  const selectedTipoProcesso = useMemo(
+    () =>
+      tipoProcessoOptions.find(
+        (option) => option.id === processForm.tipoProcessoId,
+      ) ?? null,
+    [processForm.tipoProcessoId, tipoProcessoOptions],
+  );
+
+  const selectedSistema = useMemo(
+    () =>
+      sistemaOptions.find((option) => option.id === processForm.sistemaCnjId) ?? null,
+    [processForm.sistemaCnjId, sistemaOptions],
+  );
+
+  const clienteButtonLabel = clientesLoading && clientes.length === 0
+    ? "Carregando clientes..."
+    : selectedCliente
+      ? `${selectedCliente.nome}${selectedCliente.documento ? ` (${selectedCliente.documento})` : ""}`
+      : clientes.length === 0
+        ? "Nenhum cliente disponível"
+        : "Selecione o cliente";
 
   const propostaButtonLabel = selectedProposta
     ? selectedProposta.label
@@ -1014,6 +1330,33 @@ export default function Processos() {
         : propostas.length === 0
           ? "Nenhuma proposta disponível"
           : "Selecione a proposta";
+
+  const tipoProcessoButtonLabel =
+    tipoProcessoLoading && tipoProcessoOptions.length === 0
+      ? "Carregando tipos..."
+      : selectedTipoProcesso
+        ? selectedTipoProcesso.nome
+        : tipoProcessoOptions.length === 0
+          ? tipoProcessoError ?? "Nenhum tipo disponível"
+          : "Selecione o tipo de processo";
+
+  const areaButtonLabel =
+    areaLoading && areaOptions.length === 0
+      ? "Carregando áreas..."
+      : selectedArea
+        ? selectedArea.nome
+        : areaOptions.length === 0
+          ? areaError ?? "Nenhuma área disponível"
+          : "Selecione a área de atuação";
+
+  const sistemaButtonLabel =
+    sistemaLoading && sistemaOptions.length === 0
+      ? "Carregando sistemas..."
+      : selectedSistema
+        ? selectedSistema.nome
+        : sistemaOptions.length === 0
+          ? sistemaError ?? "Nenhum sistema disponível"
+          : "Selecione o sistema judicial";
 
   const toggleAdvogadoSelection = useCallback((id: string) => {
     setProcessForm((prev) => {
@@ -1254,6 +1597,9 @@ export default function Processos() {
     if (!open) {
       setAdvogadosPopoverOpen(false);
       setPropostasPopoverOpen(false);
+      setAreaPopoverOpen(false);
+      setTipoProcessoPopoverOpen(false);
+      setSistemaPopoverOpen(false);
       setProcessForm(createEmptyProcessForm());
       setCreateError(null);
     }
@@ -1304,7 +1650,7 @@ export default function Processos() {
           ? processForm.instanciaOutro.trim()
           : processForm.instancia.trim();
       if (instanciaPayload) {
-        payload.orgao_julgador = instanciaPayload;
+        payload.instancia = instanciaPayload;
       }
 
       const dataDistribuicaoPayload = processForm.dataDistribuicao.trim();
@@ -1316,6 +1662,23 @@ export default function Processos() {
       if (propostaId && propostaId > 0) {
         payload.oportunidade_id = propostaId;
       }
+
+      const tipoProcessoId = parseOptionalInteger(processForm.tipoProcessoId);
+      if (tipoProcessoId && tipoProcessoId > 0) {
+        payload.tipo_processo_id = tipoProcessoId;
+      }
+
+      const areaAtuacaoId = parseOptionalInteger(processForm.areaAtuacaoId);
+      if (areaAtuacaoId && areaAtuacaoId > 0) {
+        payload.area_atuacao_id = areaAtuacaoId;
+      }
+
+      const sistemaCnjId = parseOptionalInteger(processForm.sistemaCnjId);
+      if (sistemaCnjId && sistemaCnjId > 0) {
+        payload.sistema_cnj_id = sistemaCnjId;
+      }
+
+      payload.monitorar_processo = processForm.monitorarProcesso;
 
       const res = await fetch(getApiUrl("processos"), {
         method: "POST",
@@ -1841,7 +2204,7 @@ export default function Processos() {
       </Dialog>
 
       <Dialog open={isDialogOpen} onOpenChange={handleDialogOpenChange}>
-        <DialogContent className="sm:max-w-lg">
+        <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Cadastrar processo</DialogTitle>
             <DialogDescription>
@@ -1849,42 +2212,72 @@ export default function Processos() {
             </DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 sm:grid-cols-2">
-            <div className="space-y-2 sm:col-span-2">
+            <div className="space-y-2 sm:col-span-1">
               <Label htmlFor="process-client">Cliente</Label>
-              <Select
-                value={processForm.clienteId}
-                onValueChange={(value) =>
-                  setProcessForm((prev) => ({
-                    ...prev,
-                    clienteId: value,
-                  }))
-                }
-              >
-                <SelectTrigger
-                  id="process-client"
-                  disabled={clientesLoading || clientes.length === 0}
+              <Popover open={clientePopoverOpen} onOpenChange={setClientePopoverOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    id="process-client"
+                    type="button"
+                    variant="outline"
+                    role="combobox"
+                    aria-expanded={clientePopoverOpen}
+                    className="w-full justify-between"
+                    disabled={clientesLoading && clientes.length === 0}
+                  >
+                    <span className="truncate">{clienteButtonLabel}</span>
+                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent
+                  className="w-[var(--radix-popover-trigger-width)] p-0"
+                  align="start"
                 >
-                  <SelectValue
-                    placeholder={
-                      clientesLoading
-                        ? "Carregando clientes..."
-                        : clientes.length > 0
-                          ? "Selecione o cliente"
-                          : "Nenhum cliente encontrado"
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {clientes.map((cliente) => (
-                    <SelectItem key={cliente.id} value={String(cliente.id)}>
-                      {cliente.nome}
-                      {cliente.documento ? ` (${cliente.documento})` : ""}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                  <Command>
+                    <CommandInput placeholder="Pesquisar cliente..." />
+                    <CommandList>
+                      <CommandEmpty>
+                        {clientesLoading
+                          ? "Carregando clientes..."
+                          : "Nenhum cliente encontrado"}
+                      </CommandEmpty>
+                      <CommandGroup>
+                        {clientes.map((cliente) => (
+                          <CommandItem
+                            key={cliente.id}
+                            value={`${cliente.nome} ${cliente.documento ?? ""}`.trim()}
+                            onSelect={() => {
+                              setProcessForm((prev) => ({
+                                ...prev,
+                                clienteId: String(cliente.id),
+                              }));
+                              setClientePopoverOpen(false);
+                            }}
+                          >
+                            <Check
+                              className={`mr-2 h-4 w-4 ${
+                                processForm.clienteId === String(cliente.id)
+                                  ? "opacity-100"
+                                  : "opacity-0"
+                              }`}
+                            />
+                            <div className="flex flex-col">
+                              <span>{cliente.nome}</span>
+                              {cliente.documento ? (
+                                <span className="text-xs text-muted-foreground">
+                                  {cliente.documento}
+                                </span>
+                              ) : null}
+                            </div>
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
             </div>
-            <div className="space-y-2 sm:col-span-2">
+            <div className="space-y-2 sm:col-span-1">
               <Label htmlFor="process-proposta">Proposta vinculada</Label>
               <Popover
                 open={propostasPopoverOpen}
@@ -2128,65 +2521,173 @@ export default function Processos() {
                 </p>
               )}
             </div>
-            <div className="space-y-4 sm:col-span-2 md:col-span-1">
-              <div className="space-y-2">
-                <Label htmlFor="process-number">Número do processo</Label>
-                <Input
-                  id="process-number"
-                  placeholder="0000000-00.0000.0.00.0000"
-                  value={processForm.numero}
-                  onChange={(event) =>
-                    setProcessForm((prev) => ({
-                      ...prev,
-                      numero: formatProcessNumber(event.target.value),
-                    }))
-                  }
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="process-instancia">Instância do processo</Label>
-                <Select
-                  value={processForm.instancia}
-                  onValueChange={(value) =>
-                    setProcessForm((prev) => ({
-                      ...prev,
-                      instancia: value,
-                      instanciaOutro:
-                        value === INSTANCIA_OUTRO_VALUE ? prev.instanciaOutro : "",
-                    }))
-                  }
+            <div className="space-y-2 sm:col-span-1">
+              <Label htmlFor="process-area-atuacao">Área de atuação</Label>
+              <Popover open={areaPopoverOpen} onOpenChange={setAreaPopoverOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    role="combobox"
+                    aria-expanded={areaPopoverOpen}
+                    className="w-full justify-between"
+                    id="process-area-atuacao"
+                    disabled={areaLoading && areaOptions.length === 0}
+                  >
+                    <span className="truncate">{areaButtonLabel}</span>
+                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent
+                  className="w-[var(--radix-popover-trigger-width)] p-0"
+                  align="start"
                 >
-                  <SelectTrigger id="process-instancia">
-                    <SelectValue placeholder="Selecione a instância" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {INSTANCIA_OPTIONS.map((option) => (
-                      <SelectItem key={option} value={option}>
-                        {option}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              {isInstanciaOutroSelected ? (
-                <div className="space-y-2">
-                  <Label htmlFor="process-instancia-outro">Especificar instância</Label>
-                  <Input
-                    id="process-instancia-outro"
-                    placeholder="Descreva a instância"
-                    value={processForm.instanciaOutro}
-                    onChange={(event) =>
-                      setProcessForm((prev) => ({
-                        ...prev,
-                        instanciaOutro: event.target.value,
-                      }))
-                    }
-                  />
-                </div>
+                  <Command>
+                    <CommandInput placeholder="Pesquisar área..." />
+                    <CommandList>
+                      <CommandEmpty>
+                        {areaLoading
+                          ? "Carregando áreas..."
+                          : areaError ?? "Nenhuma área encontrada"}
+                      </CommandEmpty>
+                      <CommandGroup>
+                        {areaOptions.map((option) => (
+                          <CommandItem
+                            key={option.id}
+                            value={`${option.nome} ${option.id}`}
+                            onSelect={() => {
+                              setProcessForm((prev) => ({
+                                ...prev,
+                                areaAtuacaoId:
+                                  prev.areaAtuacaoId === option.id ? "" : option.id,
+                              }));
+                              setAreaPopoverOpen(false);
+                            }}
+                          >
+                            <Check
+                              className={`mr-2 h-4 w-4 ${
+                                processForm.areaAtuacaoId === option.id
+                                  ? "opacity-100"
+                                  : "opacity-0"
+                              }`}
+                            />
+                            {option.nome}
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+              {areaError ? (
+                <p className="text-xs text-destructive">{areaError}</p>
               ) : null}
-
+            </div>
+            <div className="space-y-2 sm:col-span-1">
+              <Label htmlFor="process-tipo-processo">Tipo de processo</Label>
+              <Popover
+                open={tipoProcessoPopoverOpen}
+                onOpenChange={setTipoProcessoPopoverOpen}
+              >
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    role="combobox"
+                    aria-expanded={tipoProcessoPopoverOpen}
+                    className="w-full justify-between"
+                    id="process-tipo-processo"
+                    disabled={tipoProcessoLoading && tipoProcessoOptions.length === 0}
+                  >
+                    <span className="truncate">{tipoProcessoButtonLabel}</span>
+                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent
+                  className="w-[var(--radix-popover-trigger-width)] p-0"
+                  align="start"
+                >
+                  <Command>
+                    <CommandInput placeholder="Pesquisar tipo..." />
+                    <CommandList>
+                      <CommandEmpty>
+                        {tipoProcessoLoading
+                          ? "Carregando tipos..."
+                          : tipoProcessoError ?? "Nenhum tipo encontrado"}
+                      </CommandEmpty>
+                      <CommandGroup>
+                        {tipoProcessoOptions.map((option) => (
+                          <CommandItem
+                            key={option.id}
+                            value={`${option.nome} ${option.id}`}
+                            onSelect={() => {
+                              setProcessForm((prev) => ({
+                                ...prev,
+                                tipoProcessoId:
+                                  prev.tipoProcessoId === option.id ? "" : option.id,
+                              }));
+                              setTipoProcessoPopoverOpen(false);
+                            }}
+                          >
+                            <Check
+                              className={`mr-2 h-4 w-4 ${
+                                processForm.tipoProcessoId === option.id
+                                  ? "opacity-100"
+                                  : "opacity-0"
+                              }`}
+                            />
+                            {option.nome}
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+              {tipoProcessoError ? (
+                <p className="text-xs text-destructive">{tipoProcessoError}</p>
+              ) : null}
             </div>
             <div className="space-y-2 sm:col-span-2 md:col-span-1">
+              <Label htmlFor="process-number">Número do processo</Label>
+              <Input
+                id="process-number"
+                placeholder="0000000-00.0000.0.00.0000"
+                value={processForm.numero}
+                onChange={(event) =>
+                  setProcessForm((prev) => ({
+                    ...prev,
+                    numero: formatProcessNumber(event.target.value),
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-2 sm:col-span-1">
+              <Label htmlFor="process-instancia">Instância do processo</Label>
+              <Select
+                value={processForm.instancia}
+                onValueChange={(value) =>
+                  setProcessForm((prev) => ({
+                    ...prev,
+                    instancia: value,
+                    instanciaOutro:
+                      value === INSTANCIA_OUTRO_VALUE ? prev.instanciaOutro : "",
+                  }))
+                }
+              >
+                <SelectTrigger id="process-instancia">
+                  <SelectValue placeholder="Selecione a instância" />
+                </SelectTrigger>
+                <SelectContent>
+                  {INSTANCIA_OPTIONS.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      {option}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2 sm:col-span-1">
               <Label htmlFor="process-distribution-date">Data da distribuição</Label>
               <Input
                 id="process-distribution-date"
@@ -2199,6 +2700,106 @@ export default function Processos() {
                   }))
                 }
               />
+            </div>
+            {isInstanciaOutroSelected ? (
+              <div className="space-y-2 sm:col-span-2">
+                <Label htmlFor="process-instancia-outro">Especificar instância</Label>
+                <Input
+                  id="process-instancia-outro"
+                  placeholder="Descreva a instância"
+                  value={processForm.instanciaOutro}
+                  onChange={(event) =>
+                    setProcessForm((prev) => ({
+                      ...prev,
+                      instanciaOutro: event.target.value,
+                    }))
+                  }
+                />
+              </div>
+            ) : null}
+            <div className="space-y-2 sm:col-span-2 md:col-span-1">
+              <Label htmlFor="process-sistema-cnj">Sistema judicial</Label>
+              <Popover open={sistemaPopoverOpen} onOpenChange={setSistemaPopoverOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    role="combobox"
+                    aria-expanded={sistemaPopoverOpen}
+                    className="w-full justify-between"
+                    id="process-sistema-cnj"
+                    disabled={sistemaLoading && sistemaOptions.length === 0}
+                  >
+                    <span className="truncate">{sistemaButtonLabel}</span>
+                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent
+                  className="w-[var(--radix-popover-trigger-width)] p-0"
+                  align="start"
+                >
+                  <Command>
+                    <CommandInput placeholder="Pesquisar sistema..." />
+                    <CommandList>
+                      <CommandEmpty>
+                        {sistemaLoading
+                          ? "Carregando sistemas..."
+                          : sistemaError ?? "Nenhum sistema encontrado"}
+                      </CommandEmpty>
+                      <CommandGroup>
+                        {sistemaOptions.map((option) => (
+                          <CommandItem
+                            key={option.id}
+                            value={`${option.nome} ${option.id}`}
+                            onSelect={() => {
+                              setProcessForm((prev) => ({
+                                ...prev,
+                                sistemaCnjId:
+                                  prev.sistemaCnjId === option.id ? "" : option.id,
+                              }));
+                              setSistemaPopoverOpen(false);
+                            }}
+                          >
+                            <Check
+                              className={`mr-2 h-4 w-4 ${
+                                processForm.sistemaCnjId === option.id
+                                  ? "opacity-100"
+                                  : "opacity-0"
+                              }`}
+                            />
+                            {option.nome}
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+              {sistemaError ? (
+                <p className="text-xs text-destructive">{sistemaError}</p>
+              ) : null}
+            </div>
+            <div className="sm:col-span-2">
+              <div className="flex items-center justify-between rounded-md border border-border/60 px-3 py-2">
+                <div className="space-y-1">
+                  <Label htmlFor="process-monitorar" className="text-sm font-medium">
+                    Monitorar processo
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Ative para acompanhar automaticamente atualizações deste processo.
+                  </p>
+                </div>
+                <Switch
+                  id="process-monitorar"
+                  checked={processForm.monitorarProcesso}
+                  onCheckedChange={(checked) =>
+                    setProcessForm((prev) => ({
+                      ...prev,
+                      monitorarProcesso: checked,
+                    }))
+                  }
+                />
+              </div>
             </div>
           </div>
           {createError ? (


### PR DESCRIPTION
## Summary
- replace the cliente select in the processo creation modal with an autocomplete popover
- derive the selected cliente label so the chosen nome/documento is displayed consistently

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68def9b2593483268ece810ee8904d89