### PR TITLE
Atualiza consulta de movimentações de processo

### DIFF
--- a/backend/src/models/processo.ts
+++ b/backend/src/models/processo.ts
@@ -21,6 +21,11 @@ export interface ProcessoMovimentacao {
   fonte: Record<string, unknown> | null;
   criado_em?: string | null;
   atualizado_em?: string | null;
+  numero_cnj?: string | null;
+  instancia_processo?: string | null;
+  sigiloso?: boolean | null;
+  crawl_id?: string | null;
+  data_cadastro?: string | null;
 }
 
 export interface ProcessoSyncIntegrationInfo {


### PR DESCRIPTION
## Summary
- ajusta a busca de movimentações para usar o número CNJ e retornar os campos completos da trigger
- atualiza o parser de movimentações para expor os novos atributos convertendo datas para ISO quando disponível
- estende a interface ProcessoMovimentacao e garante que criações manuais retornem as informações adicionais

## Testing
- npm run build --prefix backend *(falha: erros TS18047 preexistentes em processoController.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68df0897315c83268a82b10a9d207d47