### PR TITLE
Expose process participants details

### DIFF
--- a/backend/src/models/processo.ts
+++ b/backend/src/models/processo.ts
@@ -10,6 +10,32 @@ export interface ProcessoAdvogado {
   nome: string | null;
 }
 
+export interface ProcessoParticipantLawyer {
+  name: string | null;
+  document: string | null;
+}
+
+export interface ProcessoParticipantRepresentative {
+  name: string | null;
+  document: string | null;
+}
+
+export interface ProcessoParticipant {
+  id?: number | string | null;
+  name: string | null;
+  document: string | null;
+  document_type?: string | null;
+  side: 'ativo' | 'passivo' | null;
+  type: string | null;
+  person_type: string | null;
+  role: string | null;
+  party_role: string | null;
+  lawyers?: ProcessoParticipantLawyer[] | null;
+  representatives?: ProcessoParticipantRepresentative[] | null;
+  registered_at?: string | null;
+  source?: string | null;
+}
+
 export interface ProcessoMovimentacao {
   id: string;
   data: string | null;
@@ -137,4 +163,5 @@ export interface Processo {
   oportunidade?: ProcessoOportunidadeResumo | null;
   advogados: ProcessoAdvogado[];
   movimentacoes?: ProcessoMovimentacao[];
+  participants?: ProcessoParticipant[] | null;
 }


### PR DESCRIPTION
## Summary
- normalize and merge participant data from crawler and opportunity tables when loading a processo
- expose the merged participants list on the processo response and extend the Processo model types

## Testing
- npm run build --prefix backend

------
https://chatgpt.com/codex/tasks/task_e_68df0a7104c08326b1478863d3c78a19