### PR TITLE
Add select support to parameter pages

### DIFF
--- a/frontend/src/pages/operator/configuracoes/parametros/TipoProcesso.tsx
+++ b/frontend/src/pages/operator/configuracoes/parametros/TipoProcesso.tsx
@@ -8,6 +8,7 @@ export default function TipoProcesso() {
       placeholder="Novo tipo de processo"
       emptyMessage="Nenhum tipo cadastrado"
       endpoint="/api/tipo-processos"
+      selectField={{ key: "area_atuacao_id", label: "Área", optionsEndpoint: "/api/areas" }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- extend ParameterPage to optionally load and render select-based fields alongside existing inputs
- include the selected option in create/update payloads and show the resolved label in the listing
- configure TipoProcesso to use the Área select sourced from /api/areas

## Testing
- npm --prefix frontend run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68df0d44c9bc8326990719a796bf47c8