### PR TITLE
Atualiza carregamento dinâmico de tipos de processo

### DIFF
--- a/frontend/src/pages/operator/NovaOportunidade.tsx
+++ b/frontend/src/pages/operator/NovaOportunidade.tsx
@@ -286,6 +286,8 @@ export default function NovaOportunidade() {
       : [];
   };
 
+  const areaAtuacaoWatch = form.watch("area_atuacao");
+
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -317,14 +319,6 @@ export default function NovaOportunidade() {
           })
         );
 
-        const tiposData = await fetchJson(`${apiUrl}/api/tipo-processos`);
-        setTipos(
-          tiposData.map((t) => {
-            const item = t as any;
-            return { id: String(item.id), name: item.nome } as Option;
-          })
-        );
-
         const areasData = await fetchJson(`${apiUrl}/api/areas`);
         setAreas(
           areasData.map((a) => {
@@ -351,6 +345,92 @@ export default function NovaOportunidade() {
     };
     fetchData();
   }, [apiUrl]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchTipos = async () => {
+      const normalizedAreaId = areaAtuacaoWatch?.trim() || "";
+      const query = normalizedAreaId ? `?area_atuacao_id=${normalizedAreaId}` : "";
+
+      try {
+        const res = await fetch(`${apiUrl}/api/tipo-processos${query}`, {
+          headers: { Accept: "application/json" },
+        });
+
+        let json: unknown = null;
+        try {
+          json = await res.json();
+        } catch (error) {
+          console.error(
+            "Não foi possível interpretar a resposta de tipos de processo",
+            error,
+          );
+        }
+
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+
+        const records = Array.isArray(json)
+          ? json
+          : Array.isArray((json as { rows?: unknown[] })?.rows)
+          ? ((json as { rows: unknown[] }).rows)
+          : Array.isArray((json as { data?: { rows?: unknown[] } })?.data?.rows)
+          ? ((json as { data: { rows: unknown[] } }).data.rows)
+          : Array.isArray((json as { data?: unknown[] })?.data)
+          ? ((json as { data: unknown[] }).data)
+          : [];
+
+        const options = records
+          .map((record) => {
+            const item = record as any;
+            const id = item?.id;
+            const nome = typeof item?.nome === "string" ? item.nome.trim() : "";
+            if (!id || !nome) {
+              return null;
+            }
+            return { id: String(id), name: nome } as Option;
+          })
+          .filter((option): option is Option => option !== null)
+          .sort((a, b) => a.name.localeCompare(b.name, "pt-BR"));
+
+        if (cancelled) {
+          return;
+        }
+
+        setTipos(options);
+
+        const currentValue = form.getValues("tipo_processo")?.trim() || "";
+        if (currentValue && !options.some((option) => option.id === currentValue)) {
+          form.setValue("tipo_processo", "", {
+            shouldDirty: true,
+            shouldTouch: true,
+          });
+        }
+      } catch (error) {
+        console.error(error);
+        if (cancelled) {
+          return;
+        }
+
+        setTipos([]);
+        const currentValue = form.getValues("tipo_processo")?.trim() || "";
+        if (currentValue) {
+          form.setValue("tipo_processo", "", {
+            shouldDirty: true,
+            shouldTouch: true,
+          });
+        }
+      }
+    };
+
+    fetchTipos();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiUrl, areaAtuacaoWatch, form]);
 
   const faseValue = form.watch("fase");
   const formaPagamento = form.watch("forma_pagamento");

--- a/frontend/src/pages/operator/Processos.tsx
+++ b/frontend/src/pages/operator/Processos.tsx
@@ -922,8 +922,13 @@ export default function Processos() {
             setTipoProcessoLoading(true);
             setTipoProcessoError(null);
 
+            const areaId = parseOptionalInteger(processForm.areaAtuacaoId);
+            const path = areaId
+                ? `tipo-processos?area_atuacao_id=${areaId}`
+                : "tipo-processos";
+
             try {
-                const res = await fetch(getApiUrl("tipo-processos"), {
+                const res = await fetch(getApiUrl(path), {
                     headers: { Accept: "application/json" },
                 });
 
@@ -962,6 +967,21 @@ export default function Processos() {
 
                 if (!cancelled) {
                     setTipoProcessoOptions(options);
+                    setProcessForm((prev) => {
+                        if (!prev.tipoProcessoId) {
+                            return prev;
+                        }
+
+                        const exists = options.some(
+                            (option) => option.id === prev.tipoProcessoId,
+                        );
+
+                        if (exists) {
+                            return prev;
+                        }
+
+                        return { ...prev, tipoProcessoId: "" };
+                    });
                 }
             } catch (error) {
                 console.error(error);
@@ -972,6 +992,12 @@ export default function Processos() {
                             ? error.message
                             : "Erro ao carregar tipos de processo",
                     );
+                    setProcessForm((prev) => {
+                        if (!prev.tipoProcessoId) {
+                            return prev;
+                        }
+                        return { ...prev, tipoProcessoId: "" };
+                    });
                 }
             } finally {
                 if (!cancelled) {
@@ -985,7 +1011,7 @@ export default function Processos() {
         return () => {
             cancelled = true;
         };
-    }, []);
+    }, [processForm.areaAtuacaoId]);
 
     useEffect(() => {
         let cancelled = false;


### PR DESCRIPTION
## Summary
- recarrega os tipos de processo conforme a área selecionada nos formulários de processos e oportunidades, garantindo que opções obsoletas sejam limpas
- ajusta a edição de oportunidades para buscar tipos a partir da área já salva antes de restaurar o valor selecionado

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68df0e7d3f548326aadc4b0172321e9d