### PR TITLE
Add AI summary button to timeline events

### DIFF
--- a/frontend/src/components/ui/modern-timeline.tsx
+++ b/frontend/src/components/ui/modern-timeline.tsx
@@ -13,6 +13,7 @@ interface TimelineEvent {
   description?: string | null;
   type?: string;
   isPrivate?: boolean;
+  onGenerateSummary?: () => void;
 }
 
 interface TimelineGroup {
@@ -81,10 +82,10 @@ function TimelineGroupComponent({
   );
 }
 
-function TimelineEventComponent({ 
-  event, 
-  isLast 
-}: { 
+function TimelineEventComponent({
+  event,
+  isLast
+}: {
   event: TimelineEvent;
   isLast: boolean;
 }) {
@@ -94,7 +95,7 @@ function TimelineEventComponent({
   return (
     <Card className="relative ml-6 group hover:shadow-md transition-all duration-200">
       <div className="absolute -left-9 top-6 w-4 h-4 rounded-full bg-primary border-4 border-background shadow-sm" />
-      
+
       <CardContent className="pt-4">
         <div className="flex items-start justify-between gap-4 mb-3">
           <div className="flex-1 space-y-1">
@@ -149,6 +150,13 @@ function TimelineEventComponent({
             )}
           </div>
         )}
+        {event.onGenerateSummary ? (
+          <div className="mt-4">
+            <Button type="button" onClick={event.onGenerateSummary} className="gap-2">
+              Resumir com IA
+            </Button>
+          </div>
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/frontend/src/pages/operator/VisualizarProcesso.tsx
+++ b/frontend/src/pages/operator/VisualizarProcesso.tsx
@@ -1928,6 +1928,7 @@ export default function VisualizarProcesso() {
   const [modalAberto, setModalAberto] = useState(false);
   const [carregandoResumo, setCarregandoResumo] = useState(false);
   const [erroResumo, setErroResumo] = useState<string | null>(null);
+  const [gerarResumoAoAbrir, setGerarResumoAoAbrir] = useState(false);
 
   const aplicarModelo = useCallback(
     (modelo: ProcessoViewModel) => {
@@ -2250,6 +2251,14 @@ export default function VisualizarProcesso() {
     setModalAberto(true);
   }, []);
 
+  const handleMostrarResumoIa = useCallback(
+    (movimentacao: MovimentacaoProcesso) => {
+      setGerarResumoAoAbrir(true);
+      handleMostrarConteudo(movimentacao);
+    },
+    [handleMostrarConteudo],
+  );
+
   const handleAlterarModalConteudo = useCallback((aberto: boolean) => {
     setModalAberto(aberto);
     if (!aberto) {
@@ -2257,6 +2266,7 @@ export default function VisualizarProcesso() {
       setResumoIa(null);
       setErroResumo(null);
       setCarregandoResumo(false);
+      setGerarResumoAoAbrir(false);
     }
   }, []);
 
@@ -2318,6 +2328,13 @@ export default function VisualizarProcesso() {
       setCarregandoResumo(false);
     }
   }, [movimentacaoSelecionada, toast]);
+
+  useEffect(() => {
+    if (gerarResumoAoAbrir && movimentacaoSelecionada && modalAberto) {
+      setGerarResumoAoAbrir(false);
+      void handleGerarResumoIa();
+    }
+  }, [gerarResumoAoAbrir, movimentacaoSelecionada, modalAberto, handleGerarResumoIa]);
 
   const conteudoMovimentacoes = useMemo(() => {
     if (!viewModel) {
@@ -2428,6 +2445,7 @@ export default function VisualizarProcesso() {
                       description: item.conteudo,
                       type: item.stepType,
                       isPrivate: item.privado,
+                      onGenerateSummary: () => handleMostrarResumoIa(item),
                     })),
                   }))}
                 />
@@ -2464,6 +2482,7 @@ export default function VisualizarProcesso() {
     handleVerMaisMovimentos,
     handleCarregarMaisMeses,
     handleMostrarConteudo,
+    handleMostrarResumoIa,
     filtroTipo,
     filtroInicio,
     filtroFim,


### PR DESCRIPTION
## Summary
- add a summary action to each movimentação in the timeline so operators can trigger the AI resume directly from the event
- automatically open the movimentação modal and request the AI summary when the new action is used, resetting the trigger afterwards

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68df18c85e208326a2fa229e15f7d8fd