### PR TITLE
Adjust AI summary sentence filtering

### DIFF
--- a/frontend/src/pages/operator/VisualizarProcesso.tsx
+++ b/frontend/src/pages/operator/VisualizarProcesso.tsx
@@ -177,7 +177,19 @@ function prepararResumoIa(conteudo?: string | null): string | null {
   const frases = paragrafoUnico
     .split(/(?<=[.!?])\s+/)
     .filter((frase) => frase.trim().length > 0);
-  const resumoConciso = frases.slice(0, 3).join(" ") || paragrafoUnico;
+  let frasesParaResumo = frases;
+
+  if (frases.length > 0) {
+    const primeiraFraseNormalizada = frases[0].trim().toLowerCase();
+    const prefixosRemoviveis = ["resumo", "síntese", "este documento"];
+
+    if (prefixosRemoviveis.some((prefixo) => primeiraFraseNormalizada.startsWith(prefixo))) {
+      const restantes = frases.slice(1);
+      frasesParaResumo = restantes.length > 0 ? restantes : frases;
+    }
+  }
+
+  const resumoConciso = frasesParaResumo.slice(0, 3).join(" ") || paragrafoUnico;
 
   const resumoLimpo = resumoConciso.replace(/\*\*/g, "");
 


### PR DESCRIPTION
## Summary
- ignore introductory AI summary sentences that start with common headings
- retain the original phrases when all sentences would otherwise be removed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df32f096548326ad6accf302101e1b