### PR TITLE
Ensure IA resumo uses cleaned output

### DIFF
--- a/frontend/src/pages/operator/VisualizarProcesso.tsx
+++ b/frontend/src/pages/operator/VisualizarProcesso.tsx
@@ -193,7 +193,7 @@ function prepararResumoIa(conteudo?: string | null): string | null {
 
   const resumoLimpo = resumoConciso.replace(/\*\*/g, "");
 
-  return resumoConciso;
+  return resumoLimpo || resumoConciso;
 }
 
 interface ApiProcessoCounty {


### PR DESCRIPTION
## Summary
- adjust prepararResumoIa to return the cleaned resumoLimpo value with fallback to the original resumoConciso

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df3361258c8326bf93eebef5270ef1