### PR TITLE
Prevent horizontal scroll in AI summary modal

### DIFF
--- a/frontend/src/components/ui/safe-markdown.tsx
+++ b/frontend/src/components/ui/safe-markdown.tsx
@@ -92,7 +92,7 @@ export function SafeMarkdown({ content, className }: SafeMarkdownProps) {
   return (
     <div
       className={cn(
-        "prose prose-sm max-w-none text-muted-foreground dark:prose-invert",
+        "prose prose-sm max-w-none break-words text-muted-foreground dark:prose-invert",
         className,
       )}
       dangerouslySetInnerHTML={{ __html: html }}

--- a/frontend/src/pages/operator/VisualizarProcesso.tsx
+++ b/frontend/src/pages/operator/VisualizarProcesso.tsx
@@ -2711,7 +2711,7 @@ export default function VisualizarProcesso() {
       </section>
 
       <Dialog open={modalAberto} onOpenChange={handleAlterarModalConteudo}>
-        <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+        <DialogContent className="max-h-[85vh] overflow-y-auto overflow-x-hidden sm:max-w-2xl">
           <DialogHeader className="gap-3 sm:flex-row sm:items-start sm:justify-between sm:space-y-0">
             <DialogTitle>
               {movimentacaoSelecionada?.stepType || "Movimentação selecionada"}


### PR DESCRIPTION
## Summary
- prevent the Visualizar Processo modal from showing horizontal scrolling by hiding x-overflow
- allow SafeMarkdown content to wrap long tokens to avoid sideways scrolling when rendering AI summaries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df380292888326821b2294847c304f