### PR TITLE
Integrate processo attachments with frontend access

### DIFF
--- a/backend/src/models/processo.ts
+++ b/backend/src/models/processo.ts
@@ -55,6 +55,17 @@ export interface ProcessoMovimentacao {
   data_cadastro?: string | null;
 }
 
+export interface ProcessoAttachment {
+  id: string;
+  id_andamento: string | null;
+  id_anexo: string | null;
+  nome: string | null;
+  tipo: string | null;
+  data_cadastro: string | null;
+  instancia_processo: string | null;
+  crawl_id: string | null;
+}
+
 export interface ProcessoSyncIntegrationInfo {
   id: number;
   provider: string;
@@ -177,5 +188,6 @@ export interface Processo {
   oportunidade?: ProcessoOportunidadeResumo | null;
   advogados: ProcessoAdvogado[];
   movimentacoes?: ProcessoMovimentacao[];
+  attachments?: ProcessoAttachment[];
   participants?: ProcessoParticipant[] | null;
 }

--- a/frontend/src/pages/operator/VisualizarProcesso.test.ts
+++ b/frontend/src/pages/operator/VisualizarProcesso.test.ts
@@ -282,6 +282,7 @@ describe("filtrarMovimentacoes", () => {
         conteudo: "Decisão publicada",
         privado: false,
         tags: null,
+        anexos: [],
       },
       {
         id: "2",
@@ -292,6 +293,7 @@ describe("filtrarMovimentacoes", () => {
         conteudo: "Publicação no diário",
         privado: false,
         tags: { formatted: "md" },
+        anexos: [],
       },
       {
         id: "3",
@@ -302,6 +304,7 @@ describe("filtrarMovimentacoes", () => {
         conteudo: "Sem data disponível",
         privado: false,
         tags: null,
+        anexos: [],
       },
     ];
 


### PR DESCRIPTION
## Summary
- parse processo attachments on the backend, fetch them by numero_cnj and expose them via getProcessoById
- map attachments to their movimentações on the frontend and surface the new metadata across the UI
- add a secure download handler for attachments and adjust existing tests for the expanded view model

## Testing
- pnpm test -- --runTestsByPath src/pages/operator/VisualizarProcesso.test.ts *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68df364a37f483269ef0c4b5b819e703